### PR TITLE
Harden chat-safe MCP surface and eval guidance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,16 +14,19 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup .NET SDK
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           global-json-file: global.json
-          cache: true
+          cache: false
 
       - name: Restore local tools
         run: dotnet tool restore
+
+      - name: Restore packages
+        run: dotnet restore
 
       - name: Build Release
         run: dotnet build -c Release --no-restore

--- a/src/DotnetAgents.CalDav.Core/Configuration/CalDavOptions.cs
+++ b/src/DotnetAgents.CalDav.Core/Configuration/CalDavOptions.cs
@@ -28,9 +28,6 @@ public sealed class CalDavOptions
     /// <summary>Optional timeout for HTTP requests. Defaults to 30 seconds.</summary>
     public TimeSpan RequestTimeout { get; set; } = TimeSpan.FromSeconds(30);
 
-    /// <summary>When true, advanced (href-based) MCP tools are exposed alongside chat-oriented tools. Defaults to false.</summary>
-    public bool ExposeAdvancedTools { get; set; }
-
     public override string ToString() =>
         $"CalDavOptions {{ BaseUrl = {BaseUrl}, Username = {Username}, Password = *** }}";
 }

--- a/src/DotnetAgents.CalDav.Core/Configuration/CalDavOptions.cs
+++ b/src/DotnetAgents.CalDav.Core/Configuration/CalDavOptions.cs
@@ -28,6 +28,9 @@ public sealed class CalDavOptions
     /// <summary>Optional timeout for HTTP requests. Defaults to 30 seconds.</summary>
     public TimeSpan RequestTimeout { get; set; } = TimeSpan.FromSeconds(30);
 
+    /// <summary>When true, advanced (href-based) MCP tools are exposed alongside chat-oriented tools. Defaults to false.</summary>
+    public bool ExposeAdvancedTools { get; set; }
+
     public override string ToString() =>
         $"CalDavOptions {{ BaseUrl = {BaseUrl}, Username = {Username}, Password = *** }}";
 }

--- a/src/DotnetAgents.CalDav.Core/Services/TaskListResolver.cs
+++ b/src/DotnetAgents.CalDav.Core/Services/TaskListResolver.cs
@@ -8,15 +8,6 @@ namespace DotnetAgents.CalDav.Core.Services;
 /// <inheritdoc/>
 internal sealed class TaskListResolver : ITaskListResolver
 {
-    private static readonly IReadOnlyDictionary<string, string> KnownAliases =
-        new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
-        {
-            { "task list", "Tasks" },
-            { "tasks", "Tasks" },
-            { "shopping list", "Shopping" },
-            { "shopping", "Shopping" },
-        };
-
     private readonly IOptions<CalDavOptions> _options;
 
     public TaskListResolver(IOptions<CalDavOptions> options)
@@ -63,11 +54,11 @@ internal sealed class TaskListResolver : ITaskListResolver
                     $"Ambiguous task list name '{userInput}' matched {exactMatches.Count} lists.");
             }
 
-            // Rule 2: Known alias match
-            var aliasResolved = TryResolveAlias(taskLists, userInput.Trim());
-            if (aliasResolved is not null)
+            // Rule 2: Dynamic alias match
+            var aliasMap = BuildAliasMap(taskLists);
+            if (aliasMap.TryGetValue(userInput.Trim(), out var aliasMatch))
             {
-                return Task.FromResult(WithDefaultFlag(aliasResolved, defaultName));
+                return Task.FromResult(WithDefaultFlag(aliasMatch, defaultName));
             }
         }
 
@@ -91,28 +82,47 @@ internal sealed class TaskListResolver : ITaskListResolver
             message);
     }
 
-    private static TaskList? TryResolveAlias(IReadOnlyList<TaskList> taskLists, string input)
+    private static IReadOnlyDictionary<string, TaskList> BuildAliasMap(IReadOnlyList<TaskList> taskLists)
     {
-        if (KnownAliases.TryGetValue(input, out var canonicalPhrase))
-        {
-            var matches = taskLists
-                .Where(t =>
-                    t.DisplayName.Contains(canonicalPhrase, StringComparison.OrdinalIgnoreCase) ||
-                    t.DisplayName.Contains(input, StringComparison.OrdinalIgnoreCase))
-                .ToList();
+        var suffixes = new[] { " list", " tasks", " task list" };
+        var aliases = new Dictionary<string, List<TaskList>>(StringComparer.OrdinalIgnoreCase);
 
-            return matches.Count switch
+        foreach (var list in taskLists)
+        {
+            var name = list.DisplayName.Trim();
+
+            foreach (var suffix in suffixes)
             {
-                1 => matches[0],
-                > 1 => throw new TaskListResolutionException(
-                    input,
-                    taskLists.Select(t => t.DisplayName).ToList(),
-                    $"Task list alias '{input}' is ambiguous. Matching lists: {string.Join(", ", matches.Select(t => t.DisplayName))}."),
-                _ => null
-            };
+                if (name.EndsWith(suffix, StringComparison.OrdinalIgnoreCase) && name.Length > suffix.Length)
+                {
+                    var stripped = name[..^suffix.Length].Trim();
+                    if (!string.IsNullOrWhiteSpace(stripped))
+                    {
+                        if (!aliases.TryGetValue(stripped, out var existing))
+                        {
+                            existing = [];
+                            aliases[stripped] = existing;
+                        }
+                        existing.Add(list);
+                    }
+                }
+            }
+
+            if (name.Length > 1 && name.EndsWith('s'))
+            {
+                var singular = name[..^1];
+                if (!aliases.TryGetValue(singular, out var existing))
+                {
+                    existing = [];
+                    aliases[singular] = existing;
+                }
+                existing.Add(list);
+            }
         }
 
-        return null;
+        return aliases
+            .Where(kvp => kvp.Value.Count == 1)
+            .ToDictionary(kvp => kvp.Key, kvp => kvp.Value[0], StringComparer.OrdinalIgnoreCase);
     }
 
     private static TaskList? ResolveDefaultList(IReadOnlyList<TaskList> taskLists, string? defaultName)

--- a/src/DotnetAgents.CalDav.Mcp/.mcp/server.json
+++ b/src/DotnetAgents.CalDav.Mcp/.mcp/server.json
@@ -25,6 +25,10 @@
     "CALDAV_DEFAULT_TASK_LIST": {
       "description": "Display name of the default task list to use when chat requests omit an explicit list name (optional)",
       "required": false
+    },
+    "CALDAV_EXPOSE_ADVANCED_TOOLS": {
+      "description": "Set to true to expose advanced href-based tools alongside the chat-safe surface (optional)",
+      "required": false
     }
   }
 }

--- a/src/DotnetAgents.CalDav.Mcp/Hosting/CalDavEnvironmentMapper.cs
+++ b/src/DotnetAgents.CalDav.Mcp/Hosting/CalDavEnvironmentMapper.cs
@@ -11,7 +11,8 @@ public static class CalDavEnvironmentMapper
 {
     /// <summary>
     /// Creates a configure action that reads CALDAV_URL, CALDAV_USERNAME,
-    /// CALDAV_PASSWORD, and optional CALDAV_TASK_LISTS from environment variables.
+    /// CALDAV_PASSWORD, CALDAV_TASK_LISTS, CALDAV_DEFAULT_TASK_LIST, and CALDAV_EXPOSE_ADVANCED_TOOLS
+    /// from environment variables.
     /// </summary>
     /// <param name="envProvider">
     /// Override for environment variable access. Defaults to <see cref="Environment.GetEnvironmentVariable"/>.
@@ -27,6 +28,7 @@ public static class CalDavEnvironmentMapper
             options.Password = getEnv("CALDAV_PASSWORD") ?? string.Empty;
             options.TaskLists = getEnv("CALDAV_TASK_LISTS");
             options.DefaultTaskList = getEnv("CALDAV_DEFAULT_TASK_LIST");
+            options.ExposeAdvancedTools = bool.TryParse(getEnv("CALDAV_EXPOSE_ADVANCED_TOOLS"), out var exposeAdvanced) && exposeAdvanced;
         };
     }
 }

--- a/src/DotnetAgents.CalDav.Mcp/Hosting/CalDavEnvironmentMapper.cs
+++ b/src/DotnetAgents.CalDav.Mcp/Hosting/CalDavEnvironmentMapper.cs
@@ -11,7 +11,7 @@ public static class CalDavEnvironmentMapper
 {
     /// <summary>
     /// Creates a configure action that reads CALDAV_URL, CALDAV_USERNAME,
-    /// CALDAV_PASSWORD, CALDAV_TASK_LISTS, CALDAV_DEFAULT_TASK_LIST, and CALDAV_EXPOSE_ADVANCED_TOOLS
+    /// CALDAV_PASSWORD, CALDAV_TASK_LISTS, and CALDAV_DEFAULT_TASK_LIST
     /// from environment variables.
     /// </summary>
     /// <param name="envProvider">
@@ -28,7 +28,6 @@ public static class CalDavEnvironmentMapper
             options.Password = getEnv("CALDAV_PASSWORD") ?? string.Empty;
             options.TaskLists = getEnv("CALDAV_TASK_LISTS");
             options.DefaultTaskList = getEnv("CALDAV_DEFAULT_TASK_LIST");
-            options.ExposeAdvancedTools = bool.TryParse(getEnv("CALDAV_EXPOSE_ADVANCED_TOOLS"), out var exposeAdvanced) && exposeAdvanced;
         };
     }
 }

--- a/src/DotnetAgents.CalDav.Mcp/Hosting/CalDavHostBuilder.cs
+++ b/src/DotnetAgents.CalDav.Mcp/Hosting/CalDavHostBuilder.cs
@@ -1,5 +1,6 @@
 using DotnetAgents.CalDav.Core.Configuration;
 using DotnetAgents.CalDav.Core.DependencyInjection;
+using DotnetAgents.CalDav.Mcp.Tools;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
@@ -16,13 +17,26 @@ public sealed class CalDavHostBuilder
     /// The caller must configure <see cref="CalDavOptions"/> via <see cref="ConfigureCalDav"/>
     /// before calling <see cref="HostApplicationBuilder.Build"/>.
     /// </summary>
-    public static HostApplicationBuilder CreateBuilder()
+    /// <param name="exposeAdvancedTools">
+    /// When <c>true</c>, registers all tool classes including <see cref="TaskQueryTools"/> and
+    /// <see cref="TaskMutationTools"/> (href-based, advanced tools). When <c>false</c> (default),
+    /// registers only chat-safe tools: <see cref="TaskListTools"/> and <see cref="ChatTaskTools"/>.
+    /// </param>
+    public static HostApplicationBuilder CreateBuilder(bool exposeAdvancedTools = false)
     {
         var builder = Host.CreateApplicationBuilder();
 
-        builder.Services.AddMcpServer()
+        var mcpBuilder = builder.Services.AddMcpServer()
             .WithStdioServerTransport()
-            .WithToolsFromAssembly(typeof(CalDavHostBuilder).Assembly);
+            .WithTools<TaskListTools>()
+            .WithTools<ChatTaskTools>();
+
+        if (exposeAdvancedTools)
+        {
+            mcpBuilder
+                .WithTools<TaskQueryTools>()
+                .WithTools<TaskMutationTools>();
+        }
 
         // TimeProvider abstraction — registered at the host layer so the MCP
         // program explicitly owns the dependency rather than relying on a

--- a/src/DotnetAgents.CalDav.Mcp/Hosting/CalDavMcpRunner.cs
+++ b/src/DotnetAgents.CalDav.Mcp/Hosting/CalDavMcpRunner.cs
@@ -55,7 +55,8 @@ public sealed class CalDavMcpRunner
     {
         try
         {
-            var builder = CalDavHostBuilder.CreateBuilder();
+            var exposeAdvancedTools = Environment.GetEnvironmentVariable("CALDAV_EXPOSE_ADVANCED_TOOLS") == "true";
+            var builder = CalDavHostBuilder.CreateBuilder(exposeAdvancedTools);
             builder.Services.ConfigureCalDav(configure);
             using var host = builder.Build();
             await host.RunAsync(cancellationToken).ConfigureAwait(false);

--- a/src/DotnetAgents.CalDav.Mcp/Hosting/CalDavMcpRunner.cs
+++ b/src/DotnetAgents.CalDav.Mcp/Hosting/CalDavMcpRunner.cs
@@ -50,12 +50,18 @@ public sealed class CalDavMcpRunner
         }
     }
 
+    internal static bool ShouldExposeAdvancedTools(Func<string, string?>? envProvider = null)
+    {
+        var getEnv = envProvider ?? Environment.GetEnvironmentVariable;
+        return string.Equals(getEnv("CALDAV_EXPOSE_ADVANCED_TOOLS"), "true", StringComparison.OrdinalIgnoreCase);
+    }
+
     [ExcludeFromCodeCoverage]
     private static async Task<int> RunHostAsync(Action<CalDavOptions> configure, CancellationToken cancellationToken)
     {
         try
         {
-            var exposeAdvancedTools = Environment.GetEnvironmentVariable("CALDAV_EXPOSE_ADVANCED_TOOLS") == "true";
+            var exposeAdvancedTools = ShouldExposeAdvancedTools();
             var builder = CalDavHostBuilder.CreateBuilder(exposeAdvancedTools);
             builder.Services.ConfigureCalDav(configure);
             using var host = builder.Build();

--- a/src/DotnetAgents.CalDav.Mcp/Tools/ChatTaskTools.cs
+++ b/src/DotnetAgents.CalDav.Mcp/Tools/ChatTaskTools.cs
@@ -71,7 +71,7 @@ public sealed class ChatTaskTools
         return JsonSerializer.Serialize(created);
     }
 
-    [McpServerTool(Name = "find_tasks"), Description("Find tasks by summary text. If the user named a list, pass listName and search only that list. If they did not name a list, this tool searches all visible lists and returns all matches. Use this for read-only lookup; for mutations, use complete_task_by_summary or delete_task_by_summary which enforce single-target safety.")]
+    [McpServerTool(Name = "find_tasks"), Description("Find tasks by summary text. If the user named a list, pass listName and search only that list. If they did not name a list, this tool searches all visible lists and returns all matches. Use this for read-only lookup only. Do not use this as the first step of a destructive flow; for mutations, call complete_task_by_summary or delete_task_by_summary directly because they enforce single-target safety.")]
     public async Task<string> FindTaskInListAsync(
         [Description("User-facing task list name such as 'Shopping', 'Work', or 'task list'. Omit or pass null to search all visible lists.")] string? taskListName,
         [Description("Exact task summary to match. If multiple tasks share this summary, all matches are returned.")] string summary,
@@ -81,7 +81,7 @@ public sealed class ChatTaskTools
         return JsonSerializer.Serialize(matches);
     }
 
-    [McpServerTool(Name = "complete_task_by_summary"), Description("Mark a task as completed by summary. If the user named a list, only that list is searched. If they did not name a list, all visible lists are searched. If zero tasks match, returns not_found. If multiple tasks match, returns ambiguous with candidates instead of guessing. Never complete multiple tasks in one call.")]
+    [McpServerTool(Name = "complete_task_by_summary"), Description("Mark a task as completed by summary. If the user named a list, only that list is searched. If they did not name a list, all visible lists are searched. If zero tasks match, returns not_found. If multiple tasks match, returns ambiguous with candidates instead of guessing. This is a single-target tool: never complete multiple tasks in one call or by repeating this tool for a bulk request without explicit per-target confirmation.")]
     public async Task<string> CompleteTaskInListAsync(
         [Description("User-facing task list name such as 'Shopping', 'Work', or 'task list'. Omit or pass null to search all visible lists.")] string? taskListName,
         [Description("Exact task summary to match. If multiple tasks share this summary, the tool fails with candidates.")] string summary,
@@ -112,7 +112,7 @@ public sealed class ChatTaskTools
         return JsonSerializer.Serialize(completed);
     }
 
-    [McpServerTool(Name = "delete_task_by_summary"), Description("Delete a task by summary. If the user named a list, only that list is searched. If they did not name a list, all visible lists are searched. If zero tasks match, returns not_found. If multiple tasks match, returns ambiguous with candidates instead of guessing. Never delete multiple tasks in one call.")]
+    [McpServerTool(Name = "delete_task_by_summary"), Description("Delete a task by summary. If the user named a list, only that list is searched. If they did not name a list, all visible lists are searched. If zero tasks match, returns not_found. If multiple tasks match, returns ambiguous with candidates instead of guessing. This is a single-target tool: never delete multiple tasks in one call or by repeating this tool for a bulk request without explicit per-target confirmation.")]
     public async Task<string> DeleteTaskInListAsync(
         [Description("User-facing task list name such as 'Shopping', 'Work', or 'task list'. Omit or pass null to search all visible lists.")] string? taskListName,
         [Description("Exact task summary to match. If multiple tasks share this summary, the tool fails with candidates.")] string summary,
@@ -245,7 +245,10 @@ public sealed class ChatTaskTools
         public static readonly NotFoundResult Instance = new();
     }
 
-    private sealed record CandidateMatch(string Summary, string TaskListName, string Href);
+    private sealed record CandidateMatch(
+        [property: JsonPropertyName("summary")] string Summary,
+        [property: JsonPropertyName("taskListName")] string TaskListName,
+        [property: JsonPropertyName("href")] string Href);
 
     private sealed record AmbiguousResponse(
         [property: JsonPropertyName("status")] string Status,

--- a/src/DotnetAgents.CalDav.Mcp/Tools/ChatTaskTools.cs
+++ b/src/DotnetAgents.CalDav.Mcp/Tools/ChatTaskTools.cs
@@ -5,6 +5,7 @@ using DotnetAgents.CalDav.Core;
 using ModelContextProtocol.Server;
 using System.ComponentModel;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace DotnetAgents.CalDav.Mcp.Tools;
 
@@ -46,7 +47,7 @@ public sealed class ChatTaskTools
         return JsonSerializer.Serialize(tasks);
     }
 
-    [McpServerTool(Name = "add_task"), Description("Create a task in a user-facing task list name. If the user says 'add a task ...' and does not name a list, omit listName so the configured default task list is used. Explicit list names always win over task content.")]
+    [McpServerTool(Name = "add_task"), Description("Create a task in a user-facing task list name. If the user says 'add a task ...' and does not name a list, omit listName so the configured default task list is used. Explicit list names always win over task content. Never choose a list based on what the task sounds like.")]
     public async Task<string> AddTaskToListAsync(
         [Description("User-facing task list name such as 'Shopping', 'Work', or 'task list'. Omit or pass null to use the configured default list.")] string? taskListName,
         [Description("Brief summary / title of the task (exact summary to store)")] string summary,
@@ -70,7 +71,7 @@ public sealed class ChatTaskTools
         return JsonSerializer.Serialize(created);
     }
 
-    [McpServerTool(Name = "find_tasks"), Description("Find tasks by summary text. If the user named a list, pass listName and search only that list. If they did not name a list, this tool searches all visible lists and returns matches without guessing.")]
+    [McpServerTool(Name = "find_tasks"), Description("Find tasks by summary text. If the user named a list, pass listName and search only that list. If they did not name a list, this tool searches all visible lists and returns all matches. Use this for read-only lookup; for mutations, use complete_task_by_summary or delete_task_by_summary which enforce single-target safety.")]
     public async Task<string> FindTaskInListAsync(
         [Description("User-facing task list name such as 'Shopping', 'Work', or 'task list'. Omit or pass null to search all visible lists.")] string? taskListName,
         [Description("Exact task summary to match. If multiple tasks share this summary, all matches are returned.")] string summary,
@@ -80,37 +81,59 @@ public sealed class ChatTaskTools
         return JsonSerializer.Serialize(matches);
     }
 
-    [McpServerTool(Name = "complete_task_by_summary"), Description("Mark a task as completed by summary. If the user named a list, only that list is searched. If they did not name a list, all visible lists are searched and the tool only completes when exactly one match exists.")]
+    [McpServerTool(Name = "complete_task_by_summary"), Description("Mark a task as completed by summary. If the user named a list, only that list is searched. If they did not name a list, all visible lists are searched. If zero tasks match, returns not_found. If multiple tasks match, returns ambiguous with candidates instead of guessing. Never complete multiple tasks in one call.")]
     public async Task<string> CompleteTaskInListAsync(
         [Description("User-facing task list name such as 'Shopping', 'Work', or 'task list'. Omit or pass null to search all visible lists.")] string? taskListName,
         [Description("Exact task summary to match. If multiple tasks share this summary, the tool fails with candidates.")] string summary,
         [Description("ETag for optimistic concurrency control (null to preserve the fetched ETag)")] string? etag = null,
         CancellationToken cancellationToken = default)
     {
-        var existing = await ResolveUniqueMatchAsync(taskListName, summary, cancellationToken);
+        var (result, availableLists) = await TryResolveUniqueMatchAsync(taskListName, summary, cancellationToken);
 
-        var task = existing.Task with
+        return result switch
+        {
+            ResolvedMatch match => await CompleteTask(match.Task, etag, cancellationToken),
+            AmbiguousResult a => ReturnAmbiguous(summary, a.Matches),
+            NotFoundResult => ReturnNotFound(summary, taskListName, availableLists),
+            _ => throw new InvalidOperationException($"Unexpected resolve result: {result.GetType().Name}")
+        };
+    }
+
+    private async Task<string> CompleteTask(TaskItem task, string? etag, CancellationToken cancellationToken)
+    {
+        var updated = task with
         {
             Status = CalDavTaskStatus.Completed,
             Completed = _timeProvider.GetUtcNow(),
-            ETag = etag ?? existing.Task.ETag
+            ETag = etag ?? task.ETag
         };
 
-        var completed = await _taskService.UpdateTaskAsync(task, cancellationToken);
+        var completed = await _taskService.UpdateTaskAsync(updated, cancellationToken);
         return JsonSerializer.Serialize(completed);
     }
 
-    [McpServerTool(Name = "delete_task_by_summary"), Description("Delete a task by summary. If the user named a list, only that list is searched. If they did not name a list, all visible lists are searched and the tool only deletes when exactly one match exists.")]
+    [McpServerTool(Name = "delete_task_by_summary"), Description("Delete a task by summary. If the user named a list, only that list is searched. If they did not name a list, all visible lists are searched. If zero tasks match, returns not_found. If multiple tasks match, returns ambiguous with candidates instead of guessing. Never delete multiple tasks in one call.")]
     public async Task<string> DeleteTaskInListAsync(
         [Description("User-facing task list name such as 'Shopping', 'Work', or 'task list'. Omit or pass null to search all visible lists.")] string? taskListName,
         [Description("Exact task summary to match. If multiple tasks share this summary, the tool fails with candidates.")] string summary,
         [Description("ETag for optimistic concurrency control (null to skip concurrency check)")] string? etag = null,
         CancellationToken cancellationToken = default)
     {
-        var existing = await ResolveUniqueMatchAsync(taskListName, summary, cancellationToken);
+        var (result, availableLists) = await TryResolveUniqueMatchAsync(taskListName, summary, cancellationToken);
 
-        await _taskService.DeleteTaskAsync(existing.Task.Href, etag ?? existing.Task.ETag, cancellationToken);
-        return JsonSerializer.Serialize(new { Href = existing.Task.Href, Deleted = true, TaskList = existing.TaskList.DisplayName });
+        return result switch
+        {
+            ResolvedMatch match => await DeleteTask(match.Task, etag, cancellationToken),
+            AmbiguousResult a => ReturnAmbiguous(summary, a.Matches),
+            NotFoundResult => ReturnNotFound(summary, taskListName, availableLists),
+            _ => throw new InvalidOperationException($"Unexpected resolve result: {result.GetType().Name}")
+        };
+    }
+
+    private async Task<string> DeleteTask(TaskItem task, string? etag, CancellationToken cancellationToken)
+    {
+        await _taskService.DeleteTaskAsync(task.Href, etag ?? task.ETag, cancellationToken);
+        return JsonSerializer.Serialize(new { Href = task.Href, Summary = task.Summary, Deleted = true });
     }
 
     private async Task<TaskList> ResolveTaskListAsync(string? taskListName, CancellationToken cancellationToken)
@@ -153,22 +176,53 @@ public sealed class ChatTaskTools
         return matches;
     }
 
-    private async Task<TaskMatch> ResolveUniqueMatchAsync(
+    private async Task<(ResolveResult Result, IReadOnlyList<TaskList> AllLists)> TryResolveUniqueMatchAsync(
         string? taskListName,
         string summary,
         CancellationToken cancellationToken)
     {
-        var matches = await FindMatchesAsync(taskListName, summary, cancellationToken);
+        var allLists = await _taskService.GetTaskListsAsync(cancellationToken);
+        var listsToSearch = string.IsNullOrWhiteSpace(taskListName)
+            ? allLists
+            : [await _taskListResolver.ResolveAsync(allLists, taskListName, cancellationToken)];
 
-        return matches.Count switch
+        var matches = new List<TaskMatch>();
+        foreach (var taskList in listsToSearch)
         {
-            1 => matches[0],
-            0 => throw new InvalidOperationException(string.IsNullOrWhiteSpace(taskListName)
-                ? $"Task '{summary.Trim()}' was not found in any visible task list."
-                : $"Task '{summary.Trim()}' was not found in list '{taskListName.Trim()}'."),
-            _ => throw new InvalidOperationException(
-                $"Task summary '{summary.Trim()}' is ambiguous. Matching tasks: {string.Join(", ", matches.Select(match => $"{match.Task.Summary} in {match.TaskList.DisplayName} ({match.Task.Href})"))}.")
+            var tasks = await FindTasksBySummaryAsync(taskList, summary, cancellationToken);
+            matches.AddRange(tasks.Select(task => new TaskMatch(taskList, task)));
+        }
+
+        ResolveResult result = matches.Count switch
+        {
+            1 => new ResolvedMatch(matches[0].TaskList, matches[0].Task),
+            0 => NotFoundResult.Instance,
+            _ => new AmbiguousResult(matches.Select(m => new CandidateMatch(m.Task.Summary ?? string.Empty, m.TaskList.DisplayName, m.Task.Href)).ToArray())
         };
+
+        return (result, allLists);
+    }
+
+    private static string ReturnAmbiguous(string summary, CandidateMatch[] candidates)
+    {
+        return JsonSerializer.Serialize(new AmbiguousResponse(
+            "ambiguous",
+            summary,
+            $"Multiple tasks match '{summary}'. Specify the task list name to disambiguate.",
+            candidates));
+    }
+
+    private static string ReturnNotFound(string summary, string? taskListName, IReadOnlyList<TaskList> availableLists)
+    {
+        var message = string.IsNullOrWhiteSpace(taskListName)
+            ? $"Task '{summary.Trim()}' was not found in any visible task list."
+            : $"Task '{summary.Trim()}' was not found in list '{taskListName.Trim()}'.";
+
+        return JsonSerializer.Serialize(new NotFoundResponse(
+            "not_found",
+            summary,
+            message,
+            availableLists.Select(tl => tl.DisplayName).ToArray()));
     }
 
     private async Task<IReadOnlyList<TaskList>> GetListsToSearchAsync(string? taskListName, CancellationToken cancellationToken)
@@ -182,4 +236,26 @@ public sealed class ChatTaskTools
     }
 
     private sealed record TaskMatch(TaskList TaskList, TaskItem Task);
+
+    private abstract record ResolveResult;
+    private sealed record ResolvedMatch(TaskList TaskList, TaskItem Task) : ResolveResult;
+    private sealed record AmbiguousResult(CandidateMatch[] Matches) : ResolveResult;
+    private sealed record NotFoundResult : ResolveResult
+    {
+        public static readonly NotFoundResult Instance = new();
+    }
+
+    private sealed record CandidateMatch(string Summary, string TaskListName, string Href);
+
+    private sealed record AmbiguousResponse(
+        [property: JsonPropertyName("status")] string Status,
+        [property: JsonPropertyName("summary")] string Summary,
+        [property: JsonPropertyName("message")] string Message,
+        [property: JsonPropertyName("candidates")] CandidateMatch[] Candidates);
+
+    private sealed record NotFoundResponse(
+        [property: JsonPropertyName("status")] string Status,
+        [property: JsonPropertyName("summary")] string Summary,
+        [property: JsonPropertyName("message")] string Message,
+        [property: JsonPropertyName("availableLists")] string[] AvailableLists);
 }

--- a/src/DotnetAgents.CalDav.Mcp/Tools/TaskMutationTools.cs
+++ b/src/DotnetAgents.CalDav.Mcp/Tools/TaskMutationTools.cs
@@ -22,9 +22,9 @@ public sealed class TaskMutationTools
         _timeProvider = timeProvider;
     }
 
-    [McpServerTool(Name = "create_task"), Description("Create a new task in a CalDAV task list by absolute href. Use the chat-oriented add-to-list tool unless you already know the exact href.")]
+    [McpServerTool(Name = "create_task"), Description("Create a new task in a CalDAV task list by absolute href. Only use this when the user explicitly provides or confirms the exact href. Prefer the chat-oriented add-to-list tool for normal agent workflows.")]
     public async Task<string> CreateTaskAsync(
-        [Description("The absolute href of the task list to create the task in. Use the chat-oriented add-to-list tool unless you already know the exact href.")] string taskListHref,
+        [Description("The absolute href of the task list to create the task in. Only use this when the user explicitly provides or confirms the exact href. Prefer the chat-oriented add-to-list tool otherwise.")] string taskListHref,
         [Description("Brief summary / title of the task")] string summary,
         [Description("Detailed description of the task")] string? description = null,
         [Description("Task status: NeedsAction, InProcess, Completed, or Cancelled")] string? status = null,
@@ -45,9 +45,9 @@ public sealed class TaskMutationTools
         return JsonSerializer.Serialize(created);
     }
 
-    [McpServerTool(Name = "update_task"), Description("Partial update of an existing CalDAV task by absolute href. Omitted or null fields preserve the current value (fetch-and-merge semantics). Use chat-oriented list-name tools unless you already know the exact href.")]
+    [McpServerTool(Name = "update_task"), Description("Partial update of an existing CalDAV task by absolute href. Omitted or null fields preserve the current value (fetch-and-merge semantics). Only use this when the user explicitly provides or confirms the exact href. Prefer chat-oriented list-name tools otherwise.")]
     public async Task<string> UpdateTaskAsync(
-        [Description("The absolute href of the task to update. Use chat-oriented list-name tools unless you already know the exact href.")] string href,
+        [Description("The absolute href of the task to update. Only use this when the user explicitly provides or confirms the exact href. Prefer chat-oriented list-name tools otherwise.")] string href,
         [Description("Updated summary / title of the task (null to preserve existing)")] string? summary = null,
         [Description("Updated description of the task (null to preserve existing)")] string? description = null,
         [Description("Updated status: NeedsAction, InProcess, Completed, or Cancelled (null to preserve existing)")] string? status = null,
@@ -73,9 +73,9 @@ public sealed class TaskMutationTools
         return JsonSerializer.Serialize(updated);
     }
 
-    [McpServerTool(Name = "complete_task"), Description("Mark a CalDAV task as completed with a deterministic timestamp by absolute href. Use the chat-oriented complete-in-list tool unless you already know the exact href.")]
+    [McpServerTool(Name = "complete_task"), Description("Mark a CalDAV task as completed with a deterministic timestamp by absolute href. Only use this when the user explicitly provides or confirms the exact href. Prefer the chat-oriented complete-in-list tool for normal agent workflows.")]
     public async Task<string> CompleteTaskAsync(
-        [Description("The absolute href of the task to complete. Use the chat-oriented complete-in-list tool unless you already know the exact href.")] string href,
+        [Description("The absolute href of the task to complete. Only use this when the user explicitly provides or confirms the exact href. Prefer the chat-oriented complete-in-list tool otherwise.")] string href,
         [Description("ETag for optimistic concurrency control")] string? etag = null,
         CancellationToken cancellationToken = default)
     {
@@ -93,9 +93,9 @@ public sealed class TaskMutationTools
         return JsonSerializer.Serialize(completed);
     }
 
-    [McpServerTool(Name = "delete_task"), Description("Delete a CalDAV task by its absolute href. Use the chat-oriented delete-in-list tool unless you already know the exact href.")]
+    [McpServerTool(Name = "delete_task"), Description("Delete a CalDAV task by its absolute href. Only use this when the user explicitly provides or confirms the exact href. Do not use this for search-then-delete flows or bulk deletion. Prefer the chat-oriented delete-in-list tool for normal agent workflows.")]
     public async Task<string> DeleteTaskAsync(
-        [Description("The absolute href of the task to delete. Use the chat-oriented delete-in-list tool unless you already know the exact href.")] string href,
+        [Description("The absolute href of the task to delete. Only use this when the user explicitly provides or confirms the exact href. Do not use this for search-then-delete flows or bulk deletion. Prefer the chat-oriented delete-in-list tool otherwise.")] string href,
         [Description("ETag for optimistic concurrency control")] string? etag = null,
         CancellationToken cancellationToken = default)
     {

--- a/src/DotnetAgents.CalDav.Mcp/Tools/TaskQueryTools.cs
+++ b/src/DotnetAgents.CalDav.Mcp/Tools/TaskQueryTools.cs
@@ -20,9 +20,9 @@ public sealed class TaskQueryTools
         _taskService = taskService;
     }
 
-    [McpServerTool(Name = "list_tasks"), Description("List tasks in a CalDAV task list by absolute href with optional filters. Use the chat-oriented list-name tools unless you already know the exact href.")]
+    [McpServerTool(Name = "list_tasks"), Description("List tasks in a CalDAV task list by absolute href with optional filters. Only use this when the user explicitly provides or confirms the exact href. Prefer the chat-oriented list-name tools for normal agent workflows.")]
     public async Task<string> ListTasksAsync(
-        [Description("The absolute href of the task list to query. Use chat-oriented list-name tools unless you already know the exact href.")] string taskListHref,
+        [Description("The absolute href of the task list to query. Only use this when the user explicitly provides or confirms the exact href. Prefer chat-oriented list-name tools otherwise.")] string taskListHref,
         [Description("Filter by status: NeedsAction, InProcess, Completed, or Cancelled")] string? status = null,
         [Description("Filter for tasks due after this date/time")] DateTimeOffset? dueAfter = null,
         [Description("Filter for tasks due before this date/time")] DateTimeOffset? dueBefore = null,
@@ -43,9 +43,9 @@ public sealed class TaskQueryTools
         return System.Text.Json.JsonSerializer.Serialize(tasks);
     }
 
-    [McpServerTool(Name = "get_task"), Description("Get a single CalDAV task by its absolute href. Use chat-oriented list-name tools unless you already know the exact href.")]
+    [McpServerTool(Name = "get_task"), Description("Get a single CalDAV task by its absolute href. Only use this when the user explicitly provides or confirms the exact href. Prefer chat-oriented list-name tools otherwise.")]
     public async Task<string> GetTaskAsync(
-        [Description("The absolute href of the task to retrieve. Use chat-oriented list-name tools unless you already know the exact href.")] string href,
+        [Description("The absolute href of the task to retrieve. Only use this when the user explicitly provides or confirms the exact href. Prefer chat-oriented list-name tools otherwise.")] string href,
         CancellationToken cancellationToken)
     {
         var task = await _taskService.GetTaskAsync(href, cancellationToken);

--- a/tests/DotnetAgents.CalDav.Core.Tests.Unit/Services/TaskListResolverTests.cs
+++ b/tests/DotnetAgents.CalDav.Core.Tests.Unit/Services/TaskListResolverTests.cs
@@ -92,22 +92,22 @@ public class TaskListResolverTests
     public async Task ResolveAsync_AliasTasks_ResolvesToSingleTasksList()
     {
         var resolver = CreateResolver();
-        var lists = new List<TaskList> { T("My Tasks"), T("Shopping List") };
+        var lists = new List<TaskList> { T("Tasks"), T("Shopping List") };
 
-        var result = await resolver.ResolveAsync(lists, "tasks", TestContext.Current.CancellationToken);
+        var result = await resolver.ResolveAsync(lists, "task", TestContext.Current.CancellationToken);
 
-        result.DisplayName.ShouldBe("My Tasks");
+        result.DisplayName.ShouldBe("Tasks");
     }
 
     [Fact]
     public async Task ResolveAsync_AliasTaskList_ResolvesToSingleTasksList()
     {
         var resolver = CreateResolver();
-        var lists = new List<TaskList> { T("My Tasks"), T("Shopping List") };
+        var lists = new List<TaskList> { T("Tasks"), T("Shopping List") };
 
-        var result = await resolver.ResolveAsync(lists, "task list", TestContext.Current.CancellationToken);
+        var result = await resolver.ResolveAsync(lists, "tasks", TestContext.Current.CancellationToken);
 
-        result.DisplayName.ShouldBe("My Tasks");
+        result.DisplayName.ShouldBe("Tasks");
     }
 
     [Fact]
@@ -136,15 +136,13 @@ public class TaskListResolverTests
     public async Task ResolveAsync_AliasAmbiguous_ThrowsWithCandidates()
     {
         var resolver = CreateResolver();
-        // Two lists that both contain "Tasks"
         var lists = new List<TaskList> { T("Work Tasks"), T("Personal Tasks") };
 
         var ex = await Should.ThrowAsync<TaskListResolutionException>(
             () => resolver.ResolveAsync(lists, "tasks", TestContext.Current.CancellationToken));
 
-        ex.Message.ShouldContain("ambiguous", Case.Insensitive);
-        ex.Message.ShouldContain("Work Tasks");
-        ex.Message.ShouldContain("Personal Tasks");
+        ex.Message.ShouldContain("not found", Case.Insensitive);
+        ex.AvailableLists.ShouldBe(["Work Tasks", "Personal Tasks"]);
     }
 
     [Fact]
@@ -237,6 +235,69 @@ public class TaskListResolverTests
         var result = await resolver.ResolveAsync(lists, "tasks", TestContext.Current.CancellationToken);
 
         result.DisplayName.ShouldBe("tasks");
+    }
+
+    // ─── Phase 2: Dynamic alias generation ─────────────────────────────────
+
+    [Fact]
+    public async Task ResolveAsync_DynamicAlias_SuffixStripping_ResolvesShoppingList()
+    {
+        var resolver = CreateResolver();
+        var lists = new List<TaskList> { T("My Tasks"), T("Shopping List") };
+
+        var result = await resolver.ResolveAsync(lists, "shopping", TestContext.Current.CancellationToken);
+
+        result.DisplayName.ShouldBe("Shopping List");
+    }
+
+    [Fact]
+    public async Task ResolveAsync_DynamicAlias_SingularForm_ResolvesTasksList()
+    {
+        var resolver = CreateResolver();
+        var lists = new List<TaskList> { T("Tasks"), T("Shopping List") };
+
+        var result = await resolver.ResolveAsync(lists, "task", TestContext.Current.CancellationToken);
+
+        result.DisplayName.ShouldBe("Tasks");
+    }
+
+    [Fact]
+    public async Task ResolveAsync_DynamicAlias_AmbiguousAlias_DroppedAndThrowsNotFound()
+    {
+        var resolver = CreateResolver();
+        // Both "Personal Tasks" (strips " tasks") and "Personal List" (strips " list") generate "personal"
+        var lists = new List<TaskList> { T("Personal Tasks"), T("Personal List") };
+
+        var ex = await Should.ThrowAsync<TaskListResolutionException>(
+            () => resolver.ResolveAsync(lists, "personal", TestContext.Current.CancellationToken));
+
+        ex.Message.ShouldContain("not found", Case.Insensitive);
+        ex.AvailableLists.ShouldBe(["Personal Tasks", "Personal List"]);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_DynamicAlias_NoCollisionWithExactName()
+    {
+        var resolver = CreateResolver();
+        var lists = new List<TaskList> { T("Work"), T("Work Tasks") };
+
+        // "work" should resolve to "Work" via exact match, not be confused with "Work Tasks"
+        var result = await resolver.ResolveAsync(lists, "work", TestContext.Current.CancellationToken);
+
+        result.DisplayName.ShouldBe("Work");
+    }
+
+    [Fact]
+    public async Task ResolveAsync_DynamicAlias_AvailableListsReportedOnFailure()
+    {
+        var resolver = CreateResolver();
+        var lists = new List<TaskList> { T("Shopping List"), T("Work Tasks") };
+
+        var ex = await Should.ThrowAsync<TaskListResolutionException>(
+            () => resolver.ResolveAsync(lists, "nonexistent", TestContext.Current.CancellationToken));
+
+        ex.AvailableLists.ShouldContain("Shopping List");
+        ex.AvailableLists.ShouldContain("Work Tasks");
     }
 
     // ─── Cancellation ──────────────────────────────────────────────────────

--- a/tests/DotnetAgents.CalDav.IntegrationTests/McpToolsIntegrationTests.cs
+++ b/tests/DotnetAgents.CalDav.IntegrationTests/McpToolsIntegrationTests.cs
@@ -237,10 +237,21 @@ public sealed class McpToolsIntegrationTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task GetTask_ThrowsWhenNotFound()
+    public async Task ChatDeleteTaskBySummary_ReturnsAmbiguousJsonWhenMultipleTasksMatchInSameList()
     {
-        await Should.ThrowAsync<InvalidOperationException>(
-            () => _taskQueryTools.GetTaskAsync("/nonexistent/path.ics", TestContext.Current.CancellationToken));
+        var summary = UniqueValue("duplicate-delete");
+        await CreateTrackedTaskAsync(new TaskItem { Summary = summary });
+        await CreateTrackedTaskAsync(new TaskItem { Summary = summary });
+
+        var json = await _chatTaskTools.DeleteTaskInListAsync(
+            "Tasks",
+            summary,
+            cancellationToken: TestContext.Current.CancellationToken);
+        using var doc = JsonDocument.Parse(json);
+
+        doc.RootElement.GetProperty("status").GetString().ShouldBe("ambiguous");
+        doc.RootElement.GetProperty("summary").GetString().ShouldBe(summary);
+        doc.RootElement.GetProperty("candidates").GetArrayLength().ShouldBe(2);
     }
 
     [Fact]
@@ -450,23 +461,6 @@ public sealed class McpToolsIntegrationTests : IAsyncLifetime
 
         tasks.ShouldContain(task => task.Summary == taskSummary);
         tasks.ShouldNotContain(task => task.Summary == shoppingSummary);
-    }
-
-    [Fact]
-    public async Task ChatDeleteTaskBySummary_ThrowsWhenMultipleTasksMatchInSameList()
-    {
-        var summary = UniqueValue("duplicate-delete");
-        await CreateTrackedTaskAsync(new TaskItem { Summary = summary });
-        await CreateTrackedTaskAsync(new TaskItem { Summary = summary });
-
-        var ex = await Should.ThrowAsync<InvalidOperationException>(
-            () => _chatTaskTools.DeleteTaskInListAsync(
-                "Tasks",
-                summary,
-                cancellationToken: TestContext.Current.CancellationToken));
-
-        ex.Message.ShouldContain("ambiguous", Case.Insensitive);
-        ex.Message.ShouldContain(".ics");
     }
 
     private async Task<TaskItem> CreateTrackedTaskAsync(TaskItem task)

--- a/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/CalDavEnvironmentMapperTests.cs
+++ b/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/CalDavEnvironmentMapperTests.cs
@@ -108,38 +108,4 @@ public class CalDavEnvironmentMapperTests
         options.DefaultTaskList.ShouldBeNull();
     }
 
-    [Fact]
-    public void MapFromEnvironment_MapsExposeAdvancedTools_WhenEnvVarIsTrue()
-    {
-        var envVars = new Dictionary<string, string?>
-        {
-            ["CALDAV_URL"] = "https://caldav.example.com",
-            ["CALDAV_USERNAME"] = "user",
-            ["CALDAV_PASSWORD"] = "pass",
-            ["CALDAV_EXPOSE_ADVANCED_TOOLS"] = "true",
-        };
-
-        var configure = CalDavEnvironmentMapper.MapFromEnvironment(key => envVars.GetValueOrDefault(key));
-        var options = new CalDavOptions();
-        configure(options);
-
-        options.ExposeAdvancedTools.ShouldBeTrue();
-    }
-
-    [Fact]
-    public void MapFromEnvironment_MissingExposeAdvancedTools_DefaultsToFalse()
-    {
-        var envVars = new Dictionary<string, string?>
-        {
-            ["CALDAV_URL"] = "https://caldav.example.com",
-            ["CALDAV_USERNAME"] = "user",
-            ["CALDAV_PASSWORD"] = "pass",
-        };
-
-        var configure = CalDavEnvironmentMapper.MapFromEnvironment(key => envVars.GetValueOrDefault(key));
-        var options = new CalDavOptions();
-        configure(options);
-
-        options.ExposeAdvancedTools.ShouldBeFalse();
-    }
 }

--- a/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/CalDavEnvironmentMapperTests.cs
+++ b/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/CalDavEnvironmentMapperTests.cs
@@ -107,4 +107,39 @@ public class CalDavEnvironmentMapperTests
 
         options.DefaultTaskList.ShouldBeNull();
     }
+
+    [Fact]
+    public void MapFromEnvironment_MapsExposeAdvancedTools_WhenEnvVarIsTrue()
+    {
+        var envVars = new Dictionary<string, string?>
+        {
+            ["CALDAV_URL"] = "https://caldav.example.com",
+            ["CALDAV_USERNAME"] = "user",
+            ["CALDAV_PASSWORD"] = "pass",
+            ["CALDAV_EXPOSE_ADVANCED_TOOLS"] = "true",
+        };
+
+        var configure = CalDavEnvironmentMapper.MapFromEnvironment(key => envVars.GetValueOrDefault(key));
+        var options = new CalDavOptions();
+        configure(options);
+
+        options.ExposeAdvancedTools.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void MapFromEnvironment_MissingExposeAdvancedTools_DefaultsToFalse()
+    {
+        var envVars = new Dictionary<string, string?>
+        {
+            ["CALDAV_URL"] = "https://caldav.example.com",
+            ["CALDAV_USERNAME"] = "user",
+            ["CALDAV_PASSWORD"] = "pass",
+        };
+
+        var configure = CalDavEnvironmentMapper.MapFromEnvironment(key => envVars.GetValueOrDefault(key));
+        var options = new CalDavOptions();
+        configure(options);
+
+        options.ExposeAdvancedTools.ShouldBeFalse();
+    }
 }

--- a/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/CalDavHostBuilderTests.cs
+++ b/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/CalDavHostBuilderTests.cs
@@ -137,4 +137,57 @@ public class CalDavHostBuilderTests
             toolMethods.ShouldNotBeEmpty($"{toolType.Name} is marked [McpServerToolType] but has no [McpServerTool] methods");
         }
     }
+
+    [Fact]
+    public void CreateBuilder_DefaultMode_RegistersOnlyChatSafeTools()
+    {
+        // Arrange & Act
+        var builder = CalDavHostBuilder.CreateBuilder();
+
+        // Assert — only TaskListTools and ChatTaskTools should be registered as tool types
+        var registeredToolTypes = GetRegisteredMcpToolTypes(builder.Services);
+
+        registeredToolTypes.ShouldContain(typeof(DotnetAgents.CalDav.Mcp.Tools.TaskListTools));
+        registeredToolTypes.ShouldContain(typeof(DotnetAgents.CalDav.Mcp.Tools.ChatTaskTools));
+        registeredToolTypes.ShouldNotContain(typeof(DotnetAgents.CalDav.Mcp.Tools.TaskQueryTools),
+            "TaskQueryTools should not be registered in default (chat-safe) mode");
+        registeredToolTypes.ShouldNotContain(typeof(DotnetAgents.CalDav.Mcp.Tools.TaskMutationTools),
+            "TaskMutationTools should not be registered in default (chat-safe) mode");
+    }
+
+    [Fact]
+    public void CreateBuilder_AdvancedMode_RegistersAllToolTypes()
+    {
+        // Arrange & Act
+        var builder = CalDavHostBuilder.CreateBuilder(exposeAdvancedTools: true);
+
+        // Assert — all 4 tool classes should be registered
+        var registeredToolTypes = GetRegisteredMcpToolTypes(builder.Services);
+
+        registeredToolTypes.ShouldContain(typeof(DotnetAgents.CalDav.Mcp.Tools.TaskListTools));
+        registeredToolTypes.ShouldContain(typeof(DotnetAgents.CalDav.Mcp.Tools.ChatTaskTools));
+        registeredToolTypes.ShouldContain(typeof(DotnetAgents.CalDav.Mcp.Tools.TaskQueryTools));
+        registeredToolTypes.ShouldContain(typeof(DotnetAgents.CalDav.Mcp.Tools.TaskMutationTools));
+    }
+
+    private static IReadOnlyList<Type> GetRegisteredMcpToolTypes(IServiceCollection services)
+    {
+        // The MCP SDK registers each [McpServerTool] method as an McpServerTool service.
+        // The ImplementationFactory's declaring type is a generic closure class that
+        // captures the tool type as its first generic argument.
+        var mcpAssembly = typeof(DotnetAgents.CalDav.Mcp.Hosting.CalDavHostBuilder).Assembly;
+        var knownToolTypes = mcpAssembly.GetTypes()
+            .Where(t => t.GetCustomAttribute<ModelContextProtocol.Server.McpServerToolTypeAttribute>() is not null)
+            .ToHashSet();
+
+        return services
+            .Where(sd => sd.ServiceType == typeof(ModelContextProtocol.Server.McpServerTool)
+                         && sd.ImplementationFactory is not null)
+            .Select(sd => sd.ImplementationFactory!.Method.DeclaringType)
+            .Where(declaringType => declaringType is not null && declaringType.IsGenericType)
+            .Select(declaringType => declaringType!.GetGenericArguments()[0])
+            .Where(toolType => knownToolTypes.Contains(toolType))
+            .Distinct()
+            .ToArray();
+    }
 }

--- a/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/CalDavMcpRunnerTests.cs
+++ b/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/CalDavMcpRunnerTests.cs
@@ -8,6 +8,17 @@ namespace DotnetAgents.CalDav.Mcp.Tests.Unit;
 
 public class CalDavMcpRunnerTests
 {
+    [Theory]
+    [InlineData("true")]
+    [InlineData("True")]
+    [InlineData("TRUE")]
+    public void ShouldExposeAdvancedTools_ReturnsTrue_ForCaseInsensitiveTrue(string envValue)
+    {
+        var result = CalDavMcpRunner.ShouldExposeAdvancedTools(_ => envValue);
+
+        result.ShouldBeTrue();
+    }
+
     [Fact]
     public async Task RunAsync_WithAllConfigMissing_ReturnsExitCode1()
     {

--- a/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/ChatTaskToolsTests.cs
+++ b/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/ChatTaskToolsTests.cs
@@ -148,6 +148,9 @@ public class ChatTaskToolsTests
         doc.RootElement.GetProperty("message").GetString()!.ShouldContain("Multiple tasks match");
         var candidates = doc.RootElement.GetProperty("candidates");
         candidates.GetArrayLength().ShouldBe(2);
+        candidates[0].GetProperty("summary").GetString().ShouldBe("Review");
+        candidates[0].GetProperty("taskListName").GetString().ShouldBe("Work");
+        candidates[0].GetProperty("href").GetString().ShouldBe("/work/1.ics");
     }
 
     [Fact]
@@ -227,6 +230,9 @@ public class ChatTaskToolsTests
         doc.RootElement.GetProperty("summary").GetString().ShouldBe("Strawberry");
         var candidates = doc.RootElement.GetProperty("candidates");
         candidates.GetArrayLength().ShouldBe(2);
+        candidates[0].GetProperty("summary").GetString().ShouldBe("Strawberry");
+        candidates[0].GetProperty("taskListName").GetString().ShouldBe("Tasks");
+        candidates[0].GetProperty("href").GetString().ShouldBe("/tasks/1.ics");
     }
 
     [Fact]
@@ -236,13 +242,13 @@ public class ChatTaskToolsTests
             "Create a task in a user-facing task list name. If the user says 'add a task ...' and does not name a list, omit listName so the configured default task list is used. Explicit list names always win over task content. Never choose a list based on what the task sounds like.");
 
         GetDescription(nameof(ChatTaskTools.CompleteTaskInListAsync)).ShouldBe(
-            "Mark a task as completed by summary. If the user named a list, only that list is searched. If they did not name a list, all visible lists are searched. If zero tasks match, returns not_found. If multiple tasks match, returns ambiguous with candidates instead of guessing. Never complete multiple tasks in one call.");
+            "Mark a task as completed by summary. If the user named a list, only that list is searched. If they did not name a list, all visible lists are searched. If zero tasks match, returns not_found. If multiple tasks match, returns ambiguous with candidates instead of guessing. This is a single-target tool: never complete multiple tasks in one call or by repeating this tool for a bulk request without explicit per-target confirmation.");
 
         GetDescription(nameof(ChatTaskTools.DeleteTaskInListAsync)).ShouldBe(
-            "Delete a task by summary. If the user named a list, only that list is searched. If they did not name a list, all visible lists are searched. If zero tasks match, returns not_found. If multiple tasks match, returns ambiguous with candidates instead of guessing. Never delete multiple tasks in one call.");
+            "Delete a task by summary. If the user named a list, only that list is searched. If they did not name a list, all visible lists are searched. If zero tasks match, returns not_found. If multiple tasks match, returns ambiguous with candidates instead of guessing. This is a single-target tool: never delete multiple tasks in one call or by repeating this tool for a bulk request without explicit per-target confirmation.");
 
         GetDescription(nameof(ChatTaskTools.FindTaskInListAsync)).ShouldBe(
-            "Find tasks by summary text. If the user named a list, pass listName and search only that list. If they did not name a list, this tool searches all visible lists and returns all matches. Use this for read-only lookup; for mutations, use complete_task_by_summary or delete_task_by_summary which enforce single-target safety.");
+            "Find tasks by summary text. If the user named a list, pass listName and search only that list. If they did not name a list, this tool searches all visible lists and returns all matches. Use this for read-only lookup only. Do not use this as the first step of a destructive flow; for mutations, call complete_task_by_summary or delete_task_by_summary directly because they enforce single-target safety.");
     }
 
     private static string GetDescription(string methodName)
@@ -335,6 +341,9 @@ public class ChatTaskToolsTests
         doc.RootElement.GetProperty("message").GetString()!.ShouldContain("Multiple tasks match");
         var candidates = doc.RootElement.GetProperty("candidates");
         candidates.GetArrayLength().ShouldBe(2);
+        candidates[0].GetProperty("summary").GetString().ShouldBe("buy milk");
+        candidates[0].GetProperty("taskListName").GetString().ShouldBe("Shopping");
+        candidates[0].GetProperty("href").GetString().ShouldBe("/shopping/1.ics");
     }
 
     [Fact]

--- a/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/ChatTaskToolsTests.cs
+++ b/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/ChatTaskToolsTests.cs
@@ -127,7 +127,7 @@ public class ChatTaskToolsTests
     }
 
     [Fact]
-    public async Task CompleteTaskInListAsync_ThrowsWhenSummaryAmbiguous()
+    public async Task CompleteTaskInListAsync_AmbiguousInSameList_ReturnsStructuredJson()
     {
         _taskService.GetTaskListsAsync(Arg.Any<CancellationToken>())
             .Returns(new[] { new TaskList { Href = "/work/", DisplayName = "Work" } });
@@ -140,12 +140,14 @@ public class ChatTaskToolsTests
                 new TaskItem { Href = "/work/2.ics", Summary = "Review", ETag = "\"2\"" }
             });
 
-        var ex = await Should.ThrowAsync<InvalidOperationException>(
-            () => _sut.CompleteTaskInListAsync("Work", "Review", cancellationToken: CancellationToken.None));
+        var json = await _sut.CompleteTaskInListAsync("Work", "Review", cancellationToken: CancellationToken.None);
+        using var doc = JsonDocument.Parse(json);
 
-        ex.Message.ShouldContain("ambiguous");
-        ex.Message.ShouldContain("/work/1.ics");
-        ex.Message.ShouldContain("/work/2.ics");
+        doc.RootElement.GetProperty("status").GetString().ShouldBe("ambiguous");
+        doc.RootElement.GetProperty("summary").GetString().ShouldBe("Review");
+        doc.RootElement.GetProperty("message").GetString()!.ShouldContain("Multiple tasks match");
+        var candidates = doc.RootElement.GetProperty("candidates");
+        candidates.GetArrayLength().ShouldBe(2);
     }
 
     [Fact]
@@ -206,7 +208,7 @@ public class ChatTaskToolsTests
     }
 
     [Fact]
-    public async Task CompleteTaskInListAsync_WithoutListName_ThrowsWhenMatchesExistAcrossLists()
+    public async Task CompleteTaskInListAsync_AmbiguousAcrossLists_ReturnsStructuredJson()
     {
         _taskService.GetTaskListsAsync(Arg.Any<CancellationToken>())
             .Returns([
@@ -218,24 +220,39 @@ public class ChatTaskToolsTests
         _taskService.GetTasksAsync("/shopping/", Arg.Any<TaskQuery>(), Arg.Any<CancellationToken>())
             .Returns([new TaskItem { Href = "/shopping/1.ics", Summary = "Strawberry", ETag = "\"2\"" }]);
 
-        var ex = await Should.ThrowAsync<InvalidOperationException>(
-            () => _sut.CompleteTaskInListAsync(null, "Strawberry", cancellationToken: CancellationToken.None));
+        var json = await _sut.CompleteTaskInListAsync(null, "Strawberry", cancellationToken: CancellationToken.None);
+        using var doc = JsonDocument.Parse(json);
 
-        ex.Message.ShouldContain("ambiguous", Case.Insensitive);
-        ex.Message.ShouldContain("Shopping");
-        ex.Message.ShouldContain("Tasks");
+        doc.RootElement.GetProperty("status").GetString().ShouldBe("ambiguous");
+        doc.RootElement.GetProperty("summary").GetString().ShouldBe("Strawberry");
+        var candidates = doc.RootElement.GetProperty("candidates");
+        candidates.GetArrayLength().ShouldBe(2);
     }
 
     [Fact]
     public void ChatTools_DescriptionsSteerTowardListNames()
     {
-        var method = typeof(ChatTaskTools).GetMethod(nameof(ChatTaskTools.AddTaskToListAsync));
+        GetDescription(nameof(ChatTaskTools.AddTaskToListAsync)).ShouldBe(
+            "Create a task in a user-facing task list name. If the user says 'add a task ...' and does not name a list, omit listName so the configured default task list is used. Explicit list names always win over task content. Never choose a list based on what the task sounds like.");
+
+        GetDescription(nameof(ChatTaskTools.CompleteTaskInListAsync)).ShouldBe(
+            "Mark a task as completed by summary. If the user named a list, only that list is searched. If they did not name a list, all visible lists are searched. If zero tasks match, returns not_found. If multiple tasks match, returns ambiguous with candidates instead of guessing. Never complete multiple tasks in one call.");
+
+        GetDescription(nameof(ChatTaskTools.DeleteTaskInListAsync)).ShouldBe(
+            "Delete a task by summary. If the user named a list, only that list is searched. If they did not name a list, all visible lists are searched. If zero tasks match, returns not_found. If multiple tasks match, returns ambiguous with candidates instead of guessing. Never delete multiple tasks in one call.");
+
+        GetDescription(nameof(ChatTaskTools.FindTaskInListAsync)).ShouldBe(
+            "Find tasks by summary text. If the user named a list, pass listName and search only that list. If they did not name a list, this tool searches all visible lists and returns all matches. Use this for read-only lookup; for mutations, use complete_task_by_summary or delete_task_by_summary which enforce single-target safety.");
+    }
+
+    private static string GetDescription(string methodName)
+    {
+        var method = typeof(ChatTaskTools).GetMethod(methodName);
         method.ShouldNotBeNull();
 
-        var attr = method.GetCustomAttribute<System.ComponentModel.DescriptionAttribute>();
+        var attr = method!.GetCustomAttribute<System.ComponentModel.DescriptionAttribute>();
         attr.ShouldNotBeNull();
-        attr!.Description.ShouldContain("default", Case.Insensitive);
-        attr.Description.ShouldContain("Explicit list names always win", Case.Insensitive);
+        return attr!.Description;
     }
 
     [Fact]
@@ -275,7 +292,7 @@ public class ChatTaskToolsTests
     }
 
     [Fact]
-    public async Task DeleteTaskInListAsync_ThrowsNotFound_WithoutListName()
+    public async Task DeleteTaskInListAsync_NotFound_ReturnsStructuredJsonWithAvailableLists()
     {
         _taskService.GetTaskListsAsync(Arg.Any<CancellationToken>())
             .Returns([
@@ -287,15 +304,41 @@ public class ChatTaskToolsTests
         _taskService.GetTasksAsync("/shopping/", Arg.Any<TaskQuery>(), Arg.Any<CancellationToken>())
             .Returns(Array.Empty<TaskItem>());
 
-        var ex = await Should.ThrowAsync<InvalidOperationException>(
-            () => _sut.DeleteTaskInListAsync(null, "Nonexistent", cancellationToken: CancellationToken.None));
+        var json = await _sut.DeleteTaskInListAsync(null, "Nonexistent", cancellationToken: CancellationToken.None);
+        using var doc = JsonDocument.Parse(json);
 
-        ex.Message.ShouldContain("not found");
-        ex.Message.ShouldContain("any visible task list");
+        doc.RootElement.GetProperty("status").GetString().ShouldBe("not_found");
+        doc.RootElement.GetProperty("summary").GetString().ShouldBe("Nonexistent");
+        doc.RootElement.GetProperty("message").GetString()!.ShouldContain("not found");
+        var availableLists = doc.RootElement.GetProperty("availableLists");
+        availableLists.GetArrayLength().ShouldBe(2);
     }
 
     [Fact]
-    public async Task CompleteTaskInListAsync_ThrowsNotFound_WithExplicitListName()
+    public async Task DeleteTaskInListAsync_AmbiguousMatch_ReturnsStructuredJson()
+    {
+        _taskService.GetTaskListsAsync(Arg.Any<CancellationToken>())
+            .Returns([
+                new TaskList { Href = "/shopping/", DisplayName = "Shopping" },
+                new TaskList { Href = "/tasks/", DisplayName = "Tasks" }
+            ]);
+        _taskService.GetTasksAsync("/shopping/", Arg.Any<TaskQuery>(), Arg.Any<CancellationToken>())
+            .Returns([new TaskItem { Href = "/shopping/1.ics", Summary = "buy milk", ETag = "\"1\"" }]);
+        _taskService.GetTasksAsync("/tasks/", Arg.Any<TaskQuery>(), Arg.Any<CancellationToken>())
+            .Returns([new TaskItem { Href = "/tasks/2.ics", Summary = "buy milk", ETag = "\"2\"" }]);
+
+        var json = await _sut.DeleteTaskInListAsync(null, "buy milk", cancellationToken: CancellationToken.None);
+        using var doc = JsonDocument.Parse(json);
+
+        doc.RootElement.GetProperty("status").GetString().ShouldBe("ambiguous");
+        doc.RootElement.GetProperty("summary").GetString().ShouldBe("buy milk");
+        doc.RootElement.GetProperty("message").GetString()!.ShouldContain("Multiple tasks match");
+        var candidates = doc.RootElement.GetProperty("candidates");
+        candidates.GetArrayLength().ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task CompleteTaskInListAsync_NotFound_WithExplicitListName_ReturnsStructuredJson()
     {
         _taskService.GetTaskListsAsync(Arg.Any<CancellationToken>())
             .Returns([new TaskList { Href = "/work/", DisplayName = "Work" }]);
@@ -304,11 +347,15 @@ public class ChatTaskToolsTests
         _taskService.GetTasksAsync("/work/", Arg.Any<TaskQuery>(), Arg.Any<CancellationToken>())
             .Returns(Array.Empty<TaskItem>());
 
-        var ex = await Should.ThrowAsync<InvalidOperationException>(
-            () => _sut.CompleteTaskInListAsync("Work", "Missing task", cancellationToken: CancellationToken.None));
+        var json = await _sut.CompleteTaskInListAsync("Work", "Missing task", cancellationToken: CancellationToken.None);
+        using var doc = JsonDocument.Parse(json);
 
-        ex.Message.ShouldContain("not found");
-        ex.Message.ShouldContain("Work");
+        doc.RootElement.GetProperty("status").GetString().ShouldBe("not_found");
+        doc.RootElement.GetProperty("summary").GetString().ShouldBe("Missing task");
+        doc.RootElement.GetProperty("message").GetString()!.ShouldContain("not found");
+        doc.RootElement.GetProperty("message").GetString()!.ShouldContain("Work");
+        var availableLists = doc.RootElement.GetProperty("availableLists");
+        availableLists.GetArrayLength().ShouldBe(1);
     }
 
     [Fact]

--- a/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/TaskMutationToolsTests.cs
+++ b/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/TaskMutationToolsTests.cs
@@ -643,6 +643,7 @@ public class TaskMutationToolsTests
         descAttr.ShouldNotBeNull("update_task must have a [Description] attribute");
         descAttr.Description.ShouldContain("partial update", Case.Insensitive,
             "update_task description must document partial-update semantics so MCP clients understand null = preserve");
+        descAttr.Description.ShouldContain("explicitly provides or confirms the exact href", Case.Insensitive);
     }
 
     [Fact]
@@ -663,6 +664,38 @@ public class TaskMutationToolsTests
             descAttr.Description.ShouldContain("null", Case.Insensitive,
                 $"Parameter '{param.Name}' description must mention null behavior for partial-update clarity");
         }
+    }
+
+    [Fact]
+    public void RawHrefMutationToolDescriptions_RequireExplicitHrefAndDiscourageBulkUse()
+    {
+        GetDescription(nameof(TaskMutationTools.CreateTaskAsync)).ShouldContain("explicitly provides or confirms the exact href", Case.Insensitive);
+        GetDescription(nameof(TaskMutationTools.CompleteTaskAsync)).ShouldContain("explicitly provides or confirms the exact href", Case.Insensitive);
+        GetDescription(nameof(TaskMutationTools.DeleteTaskAsync)).ShouldContain("Do not use this for search-then-delete flows or bulk deletion", Case.Insensitive);
+
+        GetParameterDescription(nameof(TaskMutationTools.DeleteTaskAsync), "href")
+            .ShouldContain("Do not use this for search-then-delete flows or bulk deletion", Case.Insensitive);
+    }
+
+    private static string GetDescription(string methodName)
+    {
+        var method = typeof(TaskMutationTools).GetMethod(methodName);
+        method.ShouldNotBeNull();
+
+        var attr = method!.GetCustomAttribute<DescriptionAttribute>();
+        attr.ShouldNotBeNull();
+        return attr!.Description;
+    }
+
+    private static string GetParameterDescription(string methodName, string parameterName)
+    {
+        var method = typeof(TaskMutationTools).GetMethod(methodName);
+        method.ShouldNotBeNull();
+
+        var parameter = method!.GetParameters().Single(p => p.Name == parameterName);
+        var attr = parameter.GetCustomAttribute<DescriptionAttribute>();
+        attr.ShouldNotBeNull();
+        return attr!.Description;
     }
 
     // ─── update_task data-preservation tests ────────────────────────────────


### PR DESCRIPTION
## Summary
- split the default MCP surface to keep raw href tools behind `CALDAV_EXPOSE_ADVANCED_TOOLS`
- replace hardcoded task list aliases, add structured ambiguity responses, and tighten tool descriptions for harnesses
- align `release.yml` with the CI workflow fixes and add the missing package restore step

## Verification
- `dotnet test`
- `slopwatch analyze --config .slopwatch/slopwatch.json --fail-on warning`
- targeted `opencode run` evals with advanced tools both disabled and enabled