### PR TITLE
Rename tool package and command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,15 +6,27 @@ on:
       - 'v*'
 
 permissions:
-  contents: read
+  contents: write
+  id-token: write
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
   publish:
+    name: Publish NuGet
     runs-on: ubuntu-latest
+    env:
+      BUILD_CONFIGURATION: Release
+      PACKAGE_OUTPUT_DIRECTORY: ${{ github.workspace }}/artifacts
+      PACKAGE_PROJECT_PATH: src/DotnetAgents.CalDav.Mcp/DotnetAgents.CalDav.Mcp.csproj
 
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v5
@@ -28,11 +40,72 @@ jobs:
       - name: Restore packages
         run: dotnet restore
 
+      - name: Determine package version
+        id: version
+        shell: bash
+        run: |
+          PACKAGE_VERSION="${GITHUB_REF_NAME#v}"
+          echo "package_version=${PACKAGE_VERSION}" >> "$GITHUB_OUTPUT"
+
       - name: Build Release
         run: dotnet build -c Release --no-restore
 
+      - name: Run tests
+        run: dotnet test -c Release --no-build
+
       - name: Pack
-        run: dotnet pack -c Release --no-build
+        run: >
+          dotnet pack ${{ env.PACKAGE_PROJECT_PATH }}
+          -c ${{ env.BUILD_CONFIGURATION }}
+          --no-build
+          -o ${{ env.PACKAGE_OUTPUT_DIRECTORY }}
+          /p:Version=${{ steps.version.outputs.package_version }}
+
+      - name: Upload package artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: nuget-package-${{ steps.version.outputs.package_version }}
+          path: |
+            ${{ env.PACKAGE_OUTPUT_DIRECTORY }}/*.nupkg
+            ${{ env.PACKAGE_OUTPUT_DIRECTORY }}/*.snupkg
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: NuGet login
+        id: login
+        uses: NuGet/login@v1
+        with:
+          user: ${{ secrets.NUGET_USER }}
 
       - name: Push to NuGet
-        run: dotnet nuget push "**/bin/Release/*.nupkg" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
+        run: >
+          dotnet nuget push "${{ env.PACKAGE_OUTPUT_DIRECTORY }}/*.nupkg"
+          --api-key "${{ steps.login.outputs.NUGET_API_KEY }}"
+          --source https://api.nuget.org/v3/index.json
+          --skip-duplicate
+
+      - name: Extract latest release notes
+        shell: bash
+        run: |
+          awk '
+            /^## / {
+              if (capture) {
+                exit
+              }
+              capture=1
+            }
+            capture {
+              print
+            }
+          ' RELEASE_NOTES.md > RELEASE_NOTES_LATEST.md
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: dotnet-agents-caldav ${{ steps.version.outputs.package_version }}
+          body_path: RELEASE_NOTES_LATEST.md
+          files: |
+            ${{ env.PACKAGE_OUTPUT_DIRECTORY }}/*.nupkg
+            ${{ env.PACKAGE_OUTPUT_DIRECTORY }}/*.snupkg
+          draft: false
+          prerelease: false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,9 +96,9 @@ CI enforces (in order):
 
 ## Distribution
 
-Published as `DotnetAgents.CalDav.Mcp` on NuGet. Installed via:
+Published as `dotnet-agents-caldav` on NuGet. Installed via:
 ```bash
-dnx --yes DotnetAgents.CalDav.Mcp
+dnx --yes dotnet-agents-caldav
 ```
 
 Requires environment variables: `CALDAV_URL`, `CALDAV_USERNAME`, `CALDAV_PASSWORD`

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Add this MCP server to VS Code, Claude Desktop, Cursor, or any MCP client:
   "mcpServers": {
     "caldav-tasks": {
       "command": "dnx",
-      "args": ["--yes", "DotnetAgents.CalDav.Mcp"],
+      "args": ["--yes", "dotnet-agents-caldav"],
       "env": {
         "CALDAV_URL": "https://caldav.example.com",
         "CALDAV_USERNAME": "user",

--- a/src/DotnetAgents.CalDav.Mcp/.mcp/server.json
+++ b/src/DotnetAgents.CalDav.Mcp/.mcp/server.json
@@ -1,5 +1,5 @@
 {
-  "name": "DotnetAgents.CalDav.Mcp",
+  "name": "dotnet-agents-caldav",
   "version": "0.1.0",
   "description": "MCP server for CalDAV task management — create, update, complete, and query tasks via CalDAV.",
   "transport": {

--- a/src/DotnetAgents.CalDav.Mcp/DotnetAgents.CalDav.Mcp.csproj
+++ b/src/DotnetAgents.CalDav.Mcp/DotnetAgents.CalDav.Mcp.csproj
@@ -3,9 +3,10 @@
   <PropertyGroup>
     <TargetFrameworks>$(NetLibVersion)</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <PackageId>DotnetAgents.CalDav.Mcp</PackageId>
+    <PackageId>dotnet-agents-caldav</PackageId>
     <PackageType>McpServer</PackageType>
     <PackAsTool>true</PackAsTool>
+    <ToolCommandName>dotnet-agents-caldav</ToolCommandName>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/McpMetadataTests.cs
+++ b/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/McpMetadataTests.cs
@@ -114,8 +114,9 @@ public class McpMetadataTests
 
         var csproj = File.ReadAllText(csprojPath);
 
-        csproj.ShouldContain("<PackageId>");
+        csproj.ShouldContain("<PackageId>dotnet-agents-caldav</PackageId>");
         csproj.ShouldContain("<PackageType>");
         csproj.ShouldContain("<PackAsTool>");
+        csproj.ShouldContain("<ToolCommandName>dotnet-agents-caldav</ToolCommandName>");
     }
 }


### PR DESCRIPTION
Rename the published MCP tool to `dotnet-agents-caldav`, set the explicit tool command name, and update release/docs/metadata to match.