### PR TITLE
fix: actually clear default console logger and add integration test

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -10,7 +10,7 @@
       "rollForward": false
     },
     "dotnet-reportgenerator-globaltool": {
-      "version": "5.5.5",
+      "version": "5.5.6",
       "commands": [
         "reportgenerator"
       ],

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,14 @@ jobs:
           PACKAGE_VERSION="${GITHUB_REF_NAME#v}"
           echo "package_version=${PACKAGE_VERSION}" >> "$GITHUB_OUTPUT"
 
+      - name: Sync server.json version
+        shell: bash
+        run: |
+          jq --arg ver "${{ steps.version.outputs.package_version }}" \
+             '.version = $ver | .packages[0].version = $ver' \
+             src/DotnetAgents.CalDav.Mcp/.mcp/server.json > server.json.tmp
+          mv server.json.tmp src/DotnetAgents.CalDav.Mcp/.mcp/server.json
+
       - name: Build Release
         run: dotnet build -c Release --no-restore
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -25,7 +25,7 @@
 
   <!-- Version Management -->
   <PropertyGroup>
-    <VersionPrefix>0.1.1</VersionPrefix>
+    <VersionPrefix>0.0.0-local</VersionPrefix>
     <PackageReleaseNotes>See RELEASE_NOTES.md</PackageReleaseNotes>
   </PropertyGroup>
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![CI](https://github.com/Jhonattan-Souza/dotnet-agents-caldav/actions/workflows/ci.yml/badge.svg)](https://github.com/Jhonattan-Souza/dotnet-agents-caldav/actions/workflows/ci.yml)
+[![Release](https://github.com/Jhonattan-Souza/dotnet-agents-caldav/actions/workflows/release.yml/badge.svg)](https://github.com/Jhonattan-Souza/dotnet-agents-caldav/actions/workflows/release.yml)
 
 # CalDAV Tasks MCP Server
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,15 @@
 # Release Notes
 
+## 0.1.2 — 2026-04-21
+
+### Fixed
+- Include `README.md` in NuGet package to resolve NuGet.org warning
+- Include `.mcp/server.json` in NuGet package and update to MCP Registry schema so NuGet.org can generate VS Code MCP configuration
+- Set `VersionPrefix` to `0.0.0-local` and use `0.0.0` placeholders in `server.json` to avoid misleading version numbers in source
+
+### Changed
+- Release workflow now automatically syncs `server.json` version with the git tag before publishing
+
 ## 0.1.1 — 2026-04-20
 
 ### Fixed

--- a/src/DotnetAgents.CalDav.Mcp/.mcp/server.json
+++ b/src/DotnetAgents.CalDav.Mcp/.mcp/server.json
@@ -1,34 +1,61 @@
 {
-  "name": "dotnet-agents-caldav",
-  "version": "0.1.0",
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.jhonattan-souza/dotnet-agents-caldav",
   "description": "MCP server for CalDAV task management — create, update, complete, and query tasks via CalDAV.",
-  "transport": {
-    "type": "stdio"
+  "version": "0.0.0",
+  "packages": [
+    {
+      "registryType": "nuget",
+      "registryBaseUrl": "https://api.nuget.org/v3/index.json",
+      "identifier": "dotnet-agents-caldav",
+      "version": "0.0.0",
+      "runtimeHint": "dnx",
+      "transport": {
+        "type": "stdio"
+      },
+      "environmentVariables": [
+        {
+          "name": "CALDAV_URL",
+          "description": "Base URL of the CalDAV server (e.g. https://caldav.example.com)",
+          "isRequired": true
+        },
+        {
+          "name": "CALDAV_USERNAME",
+          "description": "Username for CalDAV Basic authentication",
+          "isRequired": true
+        },
+        {
+          "name": "CALDAV_PASSWORD",
+          "description": "Password for CalDAV Basic authentication",
+          "isRequired": true,
+          "isSecret": true
+        },
+        {
+          "name": "CALDAV_TASK_LISTS",
+          "description": "Comma-separated list of task list hrefs to expose (optional; omit to auto-discover)",
+          "isRequired": false
+        },
+        {
+          "name": "CALDAV_DEFAULT_TASK_LIST",
+          "description": "Display name of the default task list to use when chat requests omit an explicit list name (optional)",
+          "isRequired": false
+        },
+        {
+          "name": "CALDAV_EXPOSE_ADVANCED_TOOLS",
+          "description": "Set to true to expose advanced href-based tools alongside the chat-safe surface (optional)",
+          "isRequired": false
+        }
+      ]
+    }
+  ],
+  "repository": {
+    "url": "https://github.com/Jhonattan-Souza/dotnet-agents-caldav",
+    "source": "github"
   },
-  "env": {
-    "CALDAV_URL": {
-      "description": "Base URL of the CalDAV server (e.g. https://caldav.example.com)",
-      "required": true
-    },
-    "CALDAV_USERNAME": {
-      "description": "Username for CalDAV Basic authentication",
-      "required": true
-    },
-    "CALDAV_PASSWORD": {
-      "description": "Password for CalDAV Basic authentication",
-      "required": true
-    },
-    "CALDAV_TASK_LISTS": {
-      "description": "Comma-separated list of task list hrefs to expose (optional; omit to auto-discover)",
-      "required": false
-    },
-    "CALDAV_DEFAULT_TASK_LIST": {
-      "description": "Display name of the default task list to use when chat requests omit an explicit list name (optional)",
-      "required": false
-    },
-    "CALDAV_EXPOSE_ADVANCED_TOOLS": {
-      "description": "Set to true to expose advanced href-based tools alongside the chat-safe surface (optional)",
-      "required": false
+  "_meta": {
+    "io.modelcontextprotocol.registry/publisher-provided": {
+      "tool": "dotnet-publisher",
+      "version": "0.0.0"
     }
   }
 }

--- a/src/DotnetAgents.CalDav.Mcp/DotnetAgents.CalDav.Mcp.csproj
+++ b/src/DotnetAgents.CalDav.Mcp/DotnetAgents.CalDav.Mcp.csproj
@@ -7,6 +7,7 @@
     <PackageType>McpServer</PackageType>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>dotnet-agents-caldav</ToolCommandName>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <ItemGroup>
@@ -20,7 +21,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include=".mcp/server.json">
+    <None Include="../../README.md" Pack="true" PackagePath="\" />
+    <None Include=".mcp/server.json" Pack="true" PackagePath=".mcp/server.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>

--- a/src/DotnetAgents.CalDav.Mcp/Hosting/CalDavHostBuilder.cs
+++ b/src/DotnetAgents.CalDav.Mcp/Hosting/CalDavHostBuilder.cs
@@ -28,6 +28,7 @@ public sealed class CalDavHostBuilder
     {
         var builder = Host.CreateApplicationBuilder();
 
+        builder.Logging.ClearProviders();
         builder.Logging.AddConsole(options =>
             options.LogToStandardErrorThreshold = LogLevel.Trace);
 

--- a/tests/DotnetAgents.CalDav.IntegrationTests/StdioLoggingIntegrationTests.cs
+++ b/tests/DotnetAgents.CalDav.IntegrationTests/StdioLoggingIntegrationTests.cs
@@ -1,0 +1,108 @@
+using System.Diagnostics;
+using System.Reflection;
+using Shouldly;
+using Xunit;
+
+namespace DotnetAgents.CalDav.IntegrationTests;
+
+/// <summary>
+/// Verifies that the MCP server process keeps stdout clean for JSON-RPC
+/// by redirecting all .NET console logging to stderr.
+/// </summary>
+public sealed class StdioLoggingIntegrationTests
+{
+    /// <summary>
+    /// Launches the MCP server exe with no CalDAV env vars so that config
+    /// validation fails and the process exits with code 1. Asserts that
+    /// stdout is completely empty (no log lines polluting JSON-RPC) and
+    /// that the validation error appears on stderr.
+    /// </summary>
+    [Fact]
+    public async Task McpProcess_WritesNoLogLinesToStdout()
+    {
+        var mcpDll = GetMcpDllPath();
+
+        using var process = new Process();
+        process.StartInfo = new ProcessStartInfo
+        {
+            FileName = "dotnet",
+            Arguments = mcpDll,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            RedirectStandardInput = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+
+        // Strip all CALDAV_ env vars so the process hits validation failure
+        // and exits immediately — no server needed for this test.
+        process.StartInfo.Environment.Remove("CALDAV_URL");
+        process.StartInfo.Environment.Remove("CALDAV_USERNAME");
+        process.StartInfo.Environment.Remove("CALDAV_PASSWORD");
+
+        process.Start();
+
+        // Close stdin so the stdio transport doesn't block waiting for input.
+        process.StandardInput.Close();
+
+        var stdoutTask = process.StandardOutput.ReadToEndAsync(TestContext.Current.CancellationToken);
+        var stderrTask = process.StandardError.ReadToEndAsync(TestContext.Current.CancellationToken);
+
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(
+            TestContext.Current.CancellationToken);
+        cts.CancelAfter(TimeSpan.FromSeconds(15));
+        await process.WaitForExitAsync(cts.Token);
+
+        var stdout = await stdoutTask;
+        var stderr = await stderrTask;
+
+        // The process should exit with code 1 (config validation failure).
+        process.ExitCode.ShouldBe(1, $"stderr was: {stderr}");
+
+        // stdout MUST be completely empty — any non-JSON-RPC line here
+        // would break MCP clients parsing the stdio transport.
+        stdout.ShouldBeEmpty(
+            $"stdout must be empty for JSON-RPC, but contained:\n{stdout}");
+
+        // stderr should contain the validation error, confirming logs
+        // were correctly redirected.
+        stderr.ShouldContain("CalDAV configuration error");
+    }
+
+    /// <summary>
+    /// Resolves the path to the MCP server DLL relative to the test assembly,
+    /// walking up from the test bin/ to the src project bin/.
+    /// </summary>
+    private static string GetMcpDllPath()
+    {
+        // The MCP project builds to:
+        //   src/DotnetAgents.CalDav.Mcp/bin/{Config}/{TFM}/DotnetAgents.CalDav.Mcp.dll
+        // The test assembly is at:
+        //   tests/DotnetAgents.CalDav.IntegrationTests/bin/{Config}/{TFM}/...
+        var testAssemblyDir = Path.GetDirectoryName(
+            Assembly.GetExecutingAssembly().Location)!;
+
+        // Walk up: bin/{Config}/{TFM} → bin/{Config} → bin → project → tests → root
+        var repoRoot = Path.GetFullPath(
+            Path.Combine(testAssemblyDir, "..", "..", "..", "..", ".."));
+
+        // Determine configuration and TFM from test assembly path
+        var tfm = Path.GetFileName(testAssemblyDir); // e.g. "net10.0"
+        var config = Path.GetFileName(
+            Path.GetDirectoryName(testAssemblyDir)!); // e.g. "Release"
+
+        var mcpDll = Path.Combine(repoRoot,
+            "src", "DotnetAgents.CalDav.Mcp",
+            "bin", config, tfm,
+            "DotnetAgents.CalDav.Mcp.dll");
+
+        if (!File.Exists(mcpDll))
+        {
+            throw new FileNotFoundException(
+                $"MCP server DLL not found at: {mcpDll}. " +
+                "Ensure the MCP project is built before running integration tests.");
+        }
+
+        return mcpDll;
+    }
+}

--- a/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/McpMetadataTests.cs
+++ b/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/McpMetadataTests.cs
@@ -47,13 +47,11 @@ public class McpMetadataTests
         using var doc = JsonDocument.Parse(json);
         var root = doc.RootElement;
 
-        // Must have an env or environmentVariables section with the expected keys
-        var envVars = root.TryGetProperty("env", out var env)
-            ? env
-            : root.GetProperty("environmentVariables");
+        // MCP Registry schema: environmentVariables are inside packages[0]
+        var envVars = root.GetProperty("packages")[0].GetProperty("environmentVariables");
 
-        var envVarNames = envVars.EnumerateObject()
-            .Select(p => p.Name)
+        var envVarNames = envVars.EnumerateArray()
+            .Select(e => e.GetProperty("name").GetString()!)
             .ToList();
 
         envVarNames.ShouldContain("CALDAV_URL");
@@ -71,12 +69,10 @@ public class McpMetadataTests
         using var doc = JsonDocument.Parse(json);
         var root = doc.RootElement;
 
-        var envVars = root.TryGetProperty("env", out var env)
-            ? env
-            : root.GetProperty("environmentVariables");
+        var envVars = root.GetProperty("packages")[0].GetProperty("environmentVariables");
 
-        var envVarNames = envVars.EnumerateObject()
-            .Select(p => p.Name)
+        var envVarNames = envVars.EnumerateArray()
+            .Select(e => e.GetProperty("name").GetString()!)
             .ToList();
 
         envVarNames.ShouldContain("CALDAV_TASK_LISTS");
@@ -92,12 +88,10 @@ public class McpMetadataTests
         using var doc = JsonDocument.Parse(json);
         var root = doc.RootElement;
 
-        var envVars = root.TryGetProperty("env", out var env)
-            ? env
-            : root.GetProperty("environmentVariables");
+        var envVars = root.GetProperty("packages")[0].GetProperty("environmentVariables");
 
-        var envVarNames = envVars.EnumerateObject()
-            .Select(p => p.Name)
+        var envVarNames = envVars.EnumerateArray()
+            .Select(e => e.GetProperty("name").GetString()!)
             .ToList();
 
         envVarNames.ShouldContain("CALDAV_DEFAULT_TASK_LIST");


### PR DESCRIPTION
The previous fix stacked a stderr logger on top of the default stdout logger. This clears the default providers first, effectively preventing stdout pollution. Also adds an integration test that runs the process to ensure no stdout output leaks.