### PR TITLE
fix(release): restore NuGet/login@v1 and add Node 24 opt-in

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       BUILD_CONFIGURATION: Release
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
       PACKAGE_OUTPUT_DIRECTORY: ${{ github.workspace }}/artifacts
       PACKAGE_PROJECT_PATH: src/DotnetAgents.CalDav.Mcp/DotnetAgents.CalDav.Mcp.csproj
 
@@ -81,7 +82,7 @@ jobs:
 
       - name: NuGet login
         id: login
-        uses: NuGet/login@v2
+        uses: NuGet/login@v1
         with:
           user: ${{ secrets.NUGET_USER }}
 
@@ -108,7 +109,7 @@ jobs:
           ' RELEASE_NOTES.md > RELEASE_NOTES_LATEST.md
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2.2.1
+        uses: softprops/action-gh-release@v3
         with:
           name: dotnet-agents-caldav ${{ steps.version.outputs.package_version }}
           body_path: RELEASE_NOTES_LATEST.md

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,7 +7,9 @@
 - Strengthen `StdioLoggingIntegrationTests` to verify both invalid config (stderr contains error) and valid config (both stdout and stderr are clean) scenarios
 
 ### Changed
-- Update GitHub Actions: `NuGet/login@v1` → `v2`, `softprops/action-gh-release@v2` → `v2.2.1`
+- Keep `NuGet/login@v1` because that is the version currently documented by NuGet/Microsoft for trusted publishing
+- Opt the release workflow into the GitHub Actions Node 24 runtime early via `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true`
+- Update `softprops/action-gh-release` from `v2` to `v3` for Node 24 runner compatibility
 
 ## 0.1.2 — 2026-04-21
 


### PR DESCRIPTION
## Summary

Fixes the broken release workflow caused by the non-existent `NuGet/login@v2` action.

### Changes

- **Restore `NuGet/login@v1`** - This is the version documented by Microsoft/NuGet for trusted publishing with OIDC
- **Update `softprops/action-gh-release` to v3** - Node 24 compatible version
- **Add `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true`** - Opt into the Node 24 runtime early to validate compatibility

### Background

The previous attempt to update to `NuGet/login@v2` failed because that version doesn't exist. The `v1` version is the current official release from NuGet, even though it still uses an older Node runtime.

By adding `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true`, we opt into the new Node 24 runtime early, which will become the default on June 2, 2026.

### Related

- Fixes release workflow failure
- Prepares for GitHub Actions Node 24 migration