### PR TITLE
fix(mcp): return structured list resolution errors and filter coverage reports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
         run: dotnet test -c Release --settings coverage.runsettings --collect:"XPlat Code Coverage" --results-directory TestResults
 
       - name: Generate coverage report
-        run: dotnet reportgenerator -reports:"TestResults/**/coverage.cobertura.xml" -targetdir:"coverage-report" -reporttypes:Cobertura -assemblyfilters:"+DotnetAgents.CalDav.Core;+DotnetAgents.CalDav.Mcp;-*Tests*"
+        run: dotnet reportgenerator -reports:"TestResults/**/coverage.cobertura.xml" -targetdir:"coverage-report" -reporttypes:Cobertura -assemblyfilters:"+DotnetAgents.CalDav.Core;+DotnetAgents.CalDav.Mcp;-*Tests*;-xunit*;-testhost*"
 
       - name: Verify coverage gate
         run: bash scripts/verify-coverage.sh coverage-report 0.90 0.85
@@ -58,8 +58,8 @@ jobs:
 
       - name: Post coverage summary
         run: |
-          LINE_RATE=$(grep -oP 'line-rate="[^"]*"' TestResults/**/coverage.cobertura.xml | head -1 | grep -oP '[\d.]+')
-          BRANCH_RATE=$(grep -oP 'branch-rate="[^"]*"' TestResults/**/coverage.cobertura.xml | head -1 | grep -oP '[\d.]+')
+          LINE_RATE=$(grep -oP 'line-rate="[^"]*"' coverage-report/Cobertura.xml | head -1 | grep -oP '[\d.]+')
+          BRANCH_RATE=$(grep -oP 'branch-rate="[^"]*"' coverage-report/Cobertura.xml | head -1 | grep -oP '[\d.]+')
           LINE_PCT=$(echo "$LINE_RATE * 100" | bc)
           BRANCH_PCT=$(echo "$BRANCH_RATE * 100" | bc | xargs printf "%.1f")
           LINE_PCT_FMT=$(echo "$LINE_RATE * 100" | bc | xargs printf "%.1f")

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,11 +14,11 @@ dotnet build -c Release
 # Run all tests (unit + integration)
 dotnet test
 
-# Run with coverage (outputs to TestResults/)
+# Run with coverage (outputs raw collector files to tests/**/TestResults/)
 dotnet test --settings coverage.runsettings --collect:"XPlat Code Coverage"
 
-# Generate coverage report
-dotnet reportgenerator -reports:"TestResults/**/coverage.cobertura.xml" -targetdir:"coverage-report" -reporttypes:Cobertura
+# Generate filtered coverage report
+dotnet reportgenerator -reports:"TestResults/**/coverage.cobertura.xml" -targetdir:"coverage-report" -reporttypes:Cobertura -assemblyfilters:"+DotnetAgents.CalDav.Core;+DotnetAgents.CalDav.Mcp;-*Tests*;-xunit*;-testhost*"
 
 # Verify coverage thresholds (90% line, 85% branch)
 bash scripts/verify-coverage.sh coverage-report 0.90 0.85

--- a/README.md
+++ b/README.md
@@ -70,7 +70,9 @@ dotnet test
 Coverage:
 
 ```bash
-dotnet test --collect:"XPlat Code Coverage"
+dotnet test --settings coverage.runsettings --collect:"XPlat Code Coverage"
+dotnet reportgenerator -reports:"TestResults/**/coverage.cobertura.xml" -targetdir:"coverage-report" -reporttypes:Cobertura -assemblyfilters:"+DotnetAgents.CalDav.Core;+DotnetAgents.CalDav.Mcp;-*Tests*;-xunit*;-testhost*"
+bash scripts/verify-coverage.sh coverage-report 0.90 0.85
 ```
 
 Slopwatch:

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,17 @@
 # Release Notes
 
+## 0.1.4 — 2026-04-21
+
+### Fixed
+- Chat tools now return structured JSON errors for task list resolution failures instead of generic MCP exceptions
+- `show_tasks` and `add_task` catch `TaskListResolutionException` and return `list_resolution_error` payload with `availableLists`
+- `find_tasks`, `complete_task_by_summary`, and `delete_task_by_summary` handle explicit list name resolution failures with structured errors
+- Normalize `taskListName` and `summary` consistently across all chat tool response payloads
+
+### Changed
+- Coverage pipeline now filters out test assemblies from coverage reports to ensure accurate production code metrics
+- Updated `reportgenerator` invocation to use proper assembly filters
+
 ## 0.1.3 — 2026-04-21
 
 ### Fixed

--- a/scripts/verify-coverage.sh
+++ b/scripts/verify-coverage.sh
@@ -1,14 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-TEST_RESULTS_PATH="${1:-TestResults}"
+TEST_RESULTS_PATH="${1:-coverage-report}"
 LINE_THRESHOLD="${2:-0.90}"
 BRANCH_THRESHOLD="${3:-0.90}"
 
 COBERTURA_FILE=$(find "$TEST_RESULTS_PATH" \( -name "coverage.cobertura.xml" -o -name "Cobertura.xml" \) -print -quit)
 
 if [ -z "$COBERTURA_FILE" ]; then
-  echo "::error::No coverage.cobertura.xml found in $TEST_RESULTS_PATH"
+  echo "::error::No Cobertura coverage file found in $TEST_RESULTS_PATH"
   exit 1
 fi
 

--- a/src/DotnetAgents.CalDav.Mcp/Tools/ChatTaskTools.cs
+++ b/src/DotnetAgents.CalDav.Mcp/Tools/ChatTaskTools.cs
@@ -33,18 +33,27 @@ public sealed class ChatTaskTools
         [Description("Filter by category")] string? category = null,
         CancellationToken cancellationToken = default)
     {
-        var taskList = await ResolveTaskListAsync(taskListName, cancellationToken);
-        var query = new TaskQuery
-        {
-            Status = status is not null ? EnumParsingHelpers.ParseTaskStatus(status) : null,
-            DueAfter = dueAfter,
-            DueBefore = dueBefore,
-            TextSearch = textSearch,
-            Category = category
-        };
+        var normalizedTaskListName = NormalizeTaskListName(taskListName);
 
-        var tasks = await _taskService.GetTasksAsync(taskList.Href, query, cancellationToken);
-        return JsonSerializer.Serialize(tasks);
+        try
+        {
+            var taskList = await ResolveTaskListAsync(normalizedTaskListName, cancellationToken);
+            var query = new TaskQuery
+            {
+                Status = status is not null ? EnumParsingHelpers.ParseTaskStatus(status) : null,
+                DueAfter = dueAfter,
+                DueBefore = dueBefore,
+                TextSearch = textSearch,
+                Category = category
+            };
+
+            var tasks = await _taskService.GetTasksAsync(taskList.Href, query, cancellationToken);
+            return JsonSerializer.Serialize(tasks);
+        }
+        catch (TaskListResolutionException ex)
+        {
+            return ReturnTaskListResolutionError(normalizedTaskListName, ex.Message, ex.AvailableLists);
+        }
     }
 
     [McpServerTool(Name = "add_task"), Description("Create a task in a user-facing task list name. If the user says 'add a task ...' and does not name a list, omit listName so the configured default task list is used. Explicit list names always win over task content. Never choose a list based on what the task sounds like.")]
@@ -57,18 +66,27 @@ public sealed class ChatTaskTools
         [Description("When the task is due")] DateTimeOffset? due = null,
         CancellationToken cancellationToken = default)
     {
-        var taskList = await ResolveTaskListAsync(taskListName, cancellationToken);
-        var task = new TaskItem
-        {
-            Summary = summary,
-            Description = description,
-            Status = status is not null ? EnumParsingHelpers.ParseTaskStatus(status) : CalDavTaskStatus.NeedsAction,
-            Priority = priority is not null ? EnumParsingHelpers.ParseTaskPriority(priority) : TaskPriority.None,
-            Due = due
-        };
+        var normalizedTaskListName = NormalizeTaskListName(taskListName);
 
-        var created = await _taskService.CreateTaskAsync(taskList.Href, task, cancellationToken);
-        return JsonSerializer.Serialize(created);
+        try
+        {
+            var taskList = await ResolveTaskListAsync(normalizedTaskListName, cancellationToken);
+            var task = new TaskItem
+            {
+                Summary = summary,
+                Description = description,
+                Status = status is not null ? EnumParsingHelpers.ParseTaskStatus(status) : CalDavTaskStatus.NeedsAction,
+                Priority = priority is not null ? EnumParsingHelpers.ParseTaskPriority(priority) : TaskPriority.None,
+                Due = due
+            };
+
+            var created = await _taskService.CreateTaskAsync(taskList.Href, task, cancellationToken);
+            return JsonSerializer.Serialize(created);
+        }
+        catch (TaskListResolutionException ex)
+        {
+            return ReturnTaskListResolutionError(normalizedTaskListName, ex.Message, ex.AvailableLists, summary);
+        }
     }
 
     [McpServerTool(Name = "find_tasks"), Description("Find tasks by summary text. If the user named a list, pass listName and search only that list. If they did not name a list, this tool searches all visible lists and returns all matches. Use this for read-only lookup only. Do not use this as the first step of a destructive flow; for mutations, call complete_task_by_summary or delete_task_by_summary directly because they enforce single-target safety.")]
@@ -77,8 +95,17 @@ public sealed class ChatTaskTools
         [Description("Exact task summary to match. If multiple tasks share this summary, all matches are returned.")] string summary,
         CancellationToken cancellationToken = default)
     {
-        var matches = await FindMatchesAsync(taskListName, summary, cancellationToken);
-        return JsonSerializer.Serialize(matches);
+        var normalizedTaskListName = NormalizeTaskListName(taskListName);
+
+        try
+        {
+            var matches = await FindMatchesAsync(normalizedTaskListName, summary, cancellationToken);
+            return JsonSerializer.Serialize(matches);
+        }
+        catch (TaskListResolutionException ex)
+        {
+            return ReturnTaskListResolutionError(normalizedTaskListName, ex.Message, ex.AvailableLists, summary);
+        }
     }
 
     [McpServerTool(Name = "complete_task_by_summary"), Description("Mark a task as completed by summary. If the user named a list, only that list is searched. If they did not name a list, all visible lists are searched. If zero tasks match, returns not_found. If multiple tasks match, returns ambiguous with candidates instead of guessing. This is a single-target tool: never complete multiple tasks in one call or by repeating this tool for a bulk request without explicit per-target confirmation.")]
@@ -88,15 +115,24 @@ public sealed class ChatTaskTools
         [Description("ETag for optimistic concurrency control (null to preserve the fetched ETag)")] string? etag = null,
         CancellationToken cancellationToken = default)
     {
-        var (result, availableLists) = await TryResolveUniqueMatchAsync(taskListName, summary, cancellationToken);
+        var normalizedTaskListName = NormalizeTaskListName(taskListName);
 
-        return result switch
+        try
         {
-            ResolvedMatch match => await CompleteTask(match.Task, etag, cancellationToken),
-            AmbiguousResult a => ReturnAmbiguous(summary, a.Matches),
-            NotFoundResult => ReturnNotFound(summary, taskListName, availableLists),
-            _ => throw new InvalidOperationException($"Unexpected resolve result: {result.GetType().Name}")
-        };
+            var (result, availableLists) = await TryResolveUniqueMatchAsync(normalizedTaskListName, summary, cancellationToken);
+
+            return result switch
+            {
+                ResolvedMatch match => await CompleteTask(match.Task, etag, cancellationToken),
+                AmbiguousResult a => ReturnAmbiguous(summary, a.Matches),
+                NotFoundResult => ReturnNotFound(summary, normalizedTaskListName, availableLists),
+                _ => throw new InvalidOperationException($"Unexpected resolve result: {result.GetType().Name}")
+            };
+        }
+        catch (TaskListResolutionException ex)
+        {
+            return ReturnTaskListResolutionError(normalizedTaskListName, ex.Message, ex.AvailableLists, summary);
+        }
     }
 
     private async Task<string> CompleteTask(TaskItem task, string? etag, CancellationToken cancellationToken)
@@ -119,15 +155,24 @@ public sealed class ChatTaskTools
         [Description("ETag for optimistic concurrency control (null to skip concurrency check)")] string? etag = null,
         CancellationToken cancellationToken = default)
     {
-        var (result, availableLists) = await TryResolveUniqueMatchAsync(taskListName, summary, cancellationToken);
+        var normalizedTaskListName = NormalizeTaskListName(taskListName);
 
-        return result switch
+        try
         {
-            ResolvedMatch match => await DeleteTask(match.Task, etag, cancellationToken),
-            AmbiguousResult a => ReturnAmbiguous(summary, a.Matches),
-            NotFoundResult => ReturnNotFound(summary, taskListName, availableLists),
-            _ => throw new InvalidOperationException($"Unexpected resolve result: {result.GetType().Name}")
-        };
+            var (result, availableLists) = await TryResolveUniqueMatchAsync(normalizedTaskListName, summary, cancellationToken);
+
+            return result switch
+            {
+                ResolvedMatch match => await DeleteTask(match.Task, etag, cancellationToken),
+                AmbiguousResult a => ReturnAmbiguous(summary, a.Matches),
+                NotFoundResult => ReturnNotFound(summary, normalizedTaskListName, availableLists),
+                _ => throw new InvalidOperationException($"Unexpected resolve result: {result.GetType().Name}")
+            };
+        }
+        catch (TaskListResolutionException ex)
+        {
+            return ReturnTaskListResolutionError(normalizedTaskListName, ex.Message, ex.AvailableLists, summary);
+        }
     }
 
     private async Task<string> DeleteTask(TaskItem task, string? etag, CancellationToken cancellationToken)
@@ -205,25 +250,47 @@ public sealed class ChatTaskTools
 
     private static string ReturnAmbiguous(string summary, CandidateMatch[] candidates)
     {
+        var normalizedSummary = summary.Trim();
+
         return JsonSerializer.Serialize(new AmbiguousResponse(
             "ambiguous",
-            summary,
-            $"Multiple tasks match '{summary}'. Specify the task list name to disambiguate.",
+            normalizedSummary,
+            $"Multiple tasks match '{normalizedSummary}'. Specify the task list name to disambiguate.",
             candidates));
     }
 
     private static string ReturnNotFound(string summary, string? taskListName, IReadOnlyList<TaskList> availableLists)
     {
+        var normalizedSummary = summary.Trim();
         var message = string.IsNullOrWhiteSpace(taskListName)
-            ? $"Task '{summary.Trim()}' was not found in any visible task list."
-            : $"Task '{summary.Trim()}' was not found in list '{taskListName.Trim()}'.";
+            ? $"Task '{normalizedSummary}' was not found in any visible task list."
+            : $"Task '{normalizedSummary}' was not found in list '{taskListName.Trim()}'.";
 
         return JsonSerializer.Serialize(new NotFoundResponse(
             "not_found",
-            summary,
+            normalizedSummary,
             message,
             availableLists.Select(tl => tl.DisplayName).ToArray()));
     }
+
+    private static string ReturnTaskListResolutionError(
+        string? taskListName,
+        string message,
+        IReadOnlyList<string> availableLists,
+        string? summary = null)
+    {
+        var normalizedSummary = summary?.Trim();
+
+        return JsonSerializer.Serialize(new TaskListResolutionErrorResponse(
+            "list_resolution_error",
+            taskListName,
+            normalizedSummary,
+            message,
+            availableLists.ToArray()));
+    }
+
+    private static string? NormalizeTaskListName(string? taskListName) =>
+        string.IsNullOrWhiteSpace(taskListName) ? null : taskListName.Trim();
 
     private async Task<IReadOnlyList<TaskList>> GetListsToSearchAsync(string? taskListName, CancellationToken cancellationToken)
     {
@@ -259,6 +326,13 @@ public sealed class ChatTaskTools
     private sealed record NotFoundResponse(
         [property: JsonPropertyName("status")] string Status,
         [property: JsonPropertyName("summary")] string Summary,
+        [property: JsonPropertyName("message")] string Message,
+        [property: JsonPropertyName("availableLists")] string[] AvailableLists);
+
+    private sealed record TaskListResolutionErrorResponse(
+        [property: JsonPropertyName("status")] string Status,
+        [property: JsonPropertyName("taskListName")] string? TaskListName,
+        [property: JsonPropertyName("summary")][property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] string? Summary,
         [property: JsonPropertyName("message")] string Message,
         [property: JsonPropertyName("availableLists")] string[] AvailableLists);
 }

--- a/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/ChatTaskToolsTests.cs
+++ b/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/ChatTaskToolsTests.cs
@@ -2,6 +2,7 @@ using System.Reflection;
 using System.Text.Json;
 using CalDavTaskStatus = DotnetAgents.CalDav.Core.Models.TaskStatus;
 using DotnetAgents.CalDav.Core.Abstractions;
+using DotnetAgents.CalDav.Core;
 using DotnetAgents.CalDav.Core.Models;
 using DotnetAgents.CalDav.Mcp.Tools;
 using NSubstitute;
@@ -105,6 +106,23 @@ public class ChatTaskToolsTests
     }
 
     [Fact]
+    public async Task FindTaskInListAsync_WhenNoTasksMatch_ReturnsEmptyArray()
+    {
+        _taskService.GetTaskListsAsync(Arg.Any<CancellationToken>())
+            .Returns(new[] { new TaskList { Href = "/work/", DisplayName = "Work" } });
+        _taskListResolver.ResolveAsync(Arg.Any<IReadOnlyList<TaskList>>(), "Work", Arg.Any<CancellationToken>())
+            .Returns(new TaskList { Href = "/work/", DisplayName = "Work" });
+        _taskService.GetTasksAsync("/work/", Arg.Any<TaskQuery>(), Arg.Any<CancellationToken>())
+            .Returns([new TaskItem { Href = "/work/1.ics", Summary = "Other task" }]);
+
+        var json = await _sut.FindTaskInListAsync("Work", "Missing", CancellationToken.None);
+        using var doc = JsonDocument.Parse(json);
+
+        doc.RootElement.ValueKind.ShouldBe(JsonValueKind.Array);
+        doc.RootElement.GetArrayLength().ShouldBe(0);
+    }
+
+    [Fact]
     public async Task ListTasksInListAsync_UsesConfiguredDefault_WhenListNameOmitted()
     {
         _taskService.GetTaskListsAsync(Arg.Any<CancellationToken>())
@@ -154,7 +172,7 @@ public class ChatTaskToolsTests
     }
 
     [Fact]
-    public async Task AddTaskToListAsync_ThrowsWhenAliasIsAmbiguous()
+    public async Task AddTaskToListAsync_ListResolutionFailure_ReturnsStructuredJson()
     {
         _taskService.GetTaskListsAsync(Arg.Any<CancellationToken>())
             .Returns([
@@ -162,14 +180,186 @@ public class ChatTaskToolsTests
                 new TaskList { Href = "/work-tasks/", DisplayName = "Work Tasks" }
             ]);
         _taskListResolver.ResolveAsync(Arg.Any<IReadOnlyList<TaskList>>(), "tasks", Arg.Any<CancellationToken>())
-            .Returns<Task<TaskList>>(_ => throw new InvalidOperationException("Task list alias 'tasks' is ambiguous. Matching lists: Personal Tasks, Work Tasks."));
+            .Returns<Task<TaskList>>(_ => throw new TaskListResolutionException(
+                "tasks",
+                ["Personal Tasks", "Work Tasks"],
+                "Task list alias 'tasks' is ambiguous. Matching lists: Personal Tasks, Work Tasks."));
 
-        var ex = await Should.ThrowAsync<InvalidOperationException>(
-            () => _sut.AddTaskToListAsync("tasks", "Plan sprint", cancellationToken: CancellationToken.None));
+        var json = await _sut.AddTaskToListAsync("tasks", "Plan sprint", cancellationToken: CancellationToken.None);
 
-        ex.Message.ShouldContain("ambiguous", Case.Insensitive);
-        ex.Message.ShouldContain("Personal Tasks");
-        ex.Message.ShouldContain("Work Tasks");
+        AssertListResolutionErrorWithSummary(json, "tasks", "Plan sprint", "ambiguous", "Personal Tasks", "Work Tasks");
+    }
+
+    [Fact]
+    public async Task AddTaskToListAsync_WithExplicitListNameNotFound_ReturnsStructuredJsonWhenResolutionFails()
+    {
+        _taskService.GetTaskListsAsync(Arg.Any<CancellationToken>())
+            .Returns([
+                new TaskList { Href = "/personal-tasks/", DisplayName = "Personal Tasks" },
+                new TaskList { Href = "/work-tasks/", DisplayName = "Work Tasks" }
+            ]);
+        _taskListResolver.ResolveAsync(Arg.Any<IReadOnlyList<TaskList>>(), "BadList", Arg.Any<CancellationToken>())
+            .Returns<Task<TaskList>>(_ => throw new TaskListResolutionException(
+                "BadList",
+                ["Personal Tasks", "Work Tasks"],
+                "Task list 'BadList' was not found."));
+
+        var json = await _sut.AddTaskToListAsync("BadList", "Plan sprint", cancellationToken: CancellationToken.None);
+
+        AssertListResolutionErrorWithSummary(json, "BadList", "Plan sprint", "not found", "Personal Tasks", "Work Tasks");
+    }
+
+    [Fact]
+    public async Task AddTaskToListAsync_WithoutListName_ReturnsStructuredJsonWhenDefaultListMissing()
+    {
+        _taskService.GetTaskListsAsync(Arg.Any<CancellationToken>())
+            .Returns([
+                new TaskList { Href = "/personal-tasks/", DisplayName = "Personal Tasks" },
+                new TaskList { Href = "/work-tasks/", DisplayName = "Work Tasks" }
+            ]);
+        _taskListResolver.ResolveAsync(Arg.Any<IReadOnlyList<TaskList>>(), null, Arg.Any<CancellationToken>())
+            .Returns<Task<TaskList>>(_ => throw new TaskListResolutionException(
+                "(null)",
+                ["Personal Tasks", "Work Tasks"],
+                "No default task list configured and no list name provided."));
+
+        var json = await _sut.AddTaskToListAsync(null, "Plan sprint", cancellationToken: CancellationToken.None);
+
+        AssertListResolutionErrorWithSummary(json, null, "Plan sprint", "default task list", "Personal Tasks", "Work Tasks");
+    }
+
+    [Fact]
+    public async Task ListTasksInListAsync_WithoutListName_ReturnsStructuredJsonWhenDefaultListMissing()
+    {
+        _taskService.GetTaskListsAsync(Arg.Any<CancellationToken>())
+            .Returns([
+                new TaskList { Href = "/personal-tasks/", DisplayName = "Personal Tasks" },
+                new TaskList { Href = "/work-tasks/", DisplayName = "Work Tasks" }
+            ]);
+        _taskListResolver.ResolveAsync(Arg.Any<IReadOnlyList<TaskList>>(), null, Arg.Any<CancellationToken>())
+            .Returns<Task<TaskList>>(_ => throw new TaskListResolutionException(
+                "(null)",
+                ["Personal Tasks", "Work Tasks"],
+                "No default task list configured and no list name provided."));
+
+        var json = await _sut.ListTasksInListAsync(cancellationToken: CancellationToken.None);
+
+        AssertListResolutionErrorWithoutSummary(json, null, "default task list", "Personal Tasks", "Work Tasks");
+    }
+
+    [Fact]
+    public async Task ListTasksInListAsync_WithExplicitListName_ReturnsStructuredJsonWhenResolutionFails()
+    {
+        _taskService.GetTaskListsAsync(Arg.Any<CancellationToken>())
+            .Returns([
+                new TaskList { Href = "/personal-tasks/", DisplayName = "Personal Tasks" },
+                new TaskList { Href = "/work-tasks/", DisplayName = "Work Tasks" }
+            ]);
+        _taskListResolver.ResolveAsync(Arg.Any<IReadOnlyList<TaskList>>(), "BadList", Arg.Any<CancellationToken>())
+            .Returns<Task<TaskList>>(_ => throw new TaskListResolutionException(
+                "BadList",
+                ["Personal Tasks", "Work Tasks"],
+                "Task list 'BadList' was not found."));
+
+        var json = await _sut.ListTasksInListAsync("BadList", cancellationToken: CancellationToken.None);
+
+        AssertListResolutionErrorWithoutSummary(json, "BadList", "not found", "Personal Tasks", "Work Tasks");
+    }
+
+    [Fact]
+    public async Task ListTasksInListAsync_TrimsExplicitListNameBeforeResolutionFailureResponse()
+    {
+        _taskService.GetTaskListsAsync(Arg.Any<CancellationToken>())
+            .Returns([
+                new TaskList { Href = "/personal-tasks/", DisplayName = "Personal Tasks" },
+                new TaskList { Href = "/work-tasks/", DisplayName = "Work Tasks" }
+            ]);
+        _taskListResolver.ResolveAsync(Arg.Any<IReadOnlyList<TaskList>>(), "BadList", Arg.Any<CancellationToken>())
+            .Returns<Task<TaskList>>(_ => throw new TaskListResolutionException(
+                "BadList",
+                ["Personal Tasks", "Work Tasks"],
+                "Task list 'BadList' was not found."));
+
+        var json = await _sut.ListTasksInListAsync("  BadList  ", cancellationToken: CancellationToken.None);
+
+        AssertListResolutionErrorWithoutSummary(json, "BadList", "not found", "Personal Tasks", "Work Tasks");
+        await _taskListResolver.Received(1).ResolveAsync(Arg.Any<IReadOnlyList<TaskList>>(), "BadList", Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ListTasksInListAsync_WithAmbiguousExplicitListName_ReturnsStructuredJsonWhenResolutionFails()
+    {
+        _taskService.GetTaskListsAsync(Arg.Any<CancellationToken>())
+            .Returns([
+                new TaskList { Href = "/personal-tasks/", DisplayName = "Personal Tasks" },
+                new TaskList { Href = "/work-tasks/", DisplayName = "Work Tasks" }
+            ]);
+        _taskListResolver.ResolveAsync(Arg.Any<IReadOnlyList<TaskList>>(), "tasks", Arg.Any<CancellationToken>())
+            .Returns<Task<TaskList>>(_ => throw new TaskListResolutionException(
+                "tasks",
+                ["Personal Tasks", "Work Tasks"],
+                "Task list alias 'tasks' is ambiguous."));
+
+        var json = await _sut.ListTasksInListAsync("tasks", cancellationToken: CancellationToken.None);
+
+        AssertListResolutionErrorWithoutSummary(json, "tasks", "ambiguous", "Personal Tasks", "Work Tasks");
+    }
+
+    [Fact]
+    public async Task FindTaskInListAsync_WithExplicitListName_ReturnsStructuredJsonWhenResolutionFails()
+    {
+        _taskService.GetTaskListsAsync(Arg.Any<CancellationToken>())
+            .Returns([
+                new TaskList { Href = "/personal-tasks/", DisplayName = "Personal Tasks" },
+                new TaskList { Href = "/work-tasks/", DisplayName = "Work Tasks" }
+            ]);
+        _taskListResolver.ResolveAsync(Arg.Any<IReadOnlyList<TaskList>>(), "tasks", Arg.Any<CancellationToken>())
+            .Returns<Task<TaskList>>(_ => throw new TaskListResolutionException(
+                "tasks",
+                ["Personal Tasks", "Work Tasks"],
+                "Task list alias 'tasks' is ambiguous."));
+
+        var json = await _sut.FindTaskInListAsync("tasks", "Review", CancellationToken.None);
+
+        AssertListResolutionErrorWithSummary(json, "tasks", "Review", "ambiguous", "Personal Tasks", "Work Tasks");
+    }
+
+    [Fact]
+    public async Task CompleteTaskInListAsync_WithExplicitListName_ReturnsStructuredJsonWhenResolutionFails()
+    {
+        _taskService.GetTaskListsAsync(Arg.Any<CancellationToken>())
+            .Returns([
+                new TaskList { Href = "/personal-tasks/", DisplayName = "Personal Tasks" },
+                new TaskList { Href = "/work-tasks/", DisplayName = "Work Tasks" }
+            ]);
+        _taskListResolver.ResolveAsync(Arg.Any<IReadOnlyList<TaskList>>(), "tasks", Arg.Any<CancellationToken>())
+            .Returns<Task<TaskList>>(_ => throw new TaskListResolutionException(
+                "tasks",
+                ["Personal Tasks", "Work Tasks"],
+                "Task list alias 'tasks' is ambiguous."));
+
+        var json = await _sut.CompleteTaskInListAsync("tasks", "Review", cancellationToken: CancellationToken.None);
+
+        AssertListResolutionErrorWithSummary(json, "tasks", "Review", "ambiguous", "Personal Tasks", "Work Tasks");
+    }
+
+    [Fact]
+    public async Task DeleteTaskInListAsync_WithExplicitListName_ReturnsStructuredJsonWhenResolutionFails()
+    {
+        _taskService.GetTaskListsAsync(Arg.Any<CancellationToken>())
+            .Returns([
+                new TaskList { Href = "/personal-tasks/", DisplayName = "Personal Tasks" },
+                new TaskList { Href = "/work-tasks/", DisplayName = "Work Tasks" }
+            ]);
+        _taskListResolver.ResolveAsync(Arg.Any<IReadOnlyList<TaskList>>(), "tasks", Arg.Any<CancellationToken>())
+            .Returns<Task<TaskList>>(_ => throw new TaskListResolutionException(
+                "tasks",
+                ["Personal Tasks", "Work Tasks"],
+                "Task list alias 'tasks' is ambiguous."));
+
+        var json = await _sut.DeleteTaskInListAsync("tasks", "Review", cancellationToken: CancellationToken.None);
+
+        AssertListResolutionErrorWithSummary(json, "tasks", "Review", "ambiguous", "Personal Tasks", "Work Tasks");
     }
 
     [Fact]
@@ -208,6 +398,7 @@ public class ChatTaskToolsTests
         using var doc = JsonDocument.Parse(json);
 
         doc.RootElement.GetArrayLength().ShouldBe(2);
+        await _taskListResolver.DidNotReceiveWithAnyArgs().ResolveAsync(default!, default, TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -233,6 +424,28 @@ public class ChatTaskToolsTests
         candidates[0].GetProperty("summary").GetString().ShouldBe("Strawberry");
         candidates[0].GetProperty("taskListName").GetString().ShouldBe("Tasks");
         candidates[0].GetProperty("href").GetString().ShouldBe("/tasks/1.ics");
+        await _taskListResolver.DidNotReceiveWithAnyArgs().ResolveAsync(default!, default, TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task CompleteTaskInListAsync_AmbiguousAcrossLists_TrimsSummaryInStructuredResponse()
+    {
+        _taskService.GetTaskListsAsync(Arg.Any<CancellationToken>())
+            .Returns([
+                new TaskList { Href = "/tasks/", DisplayName = "Tasks" },
+                new TaskList { Href = "/shopping/", DisplayName = "Shopping" }
+            ]);
+        _taskService.GetTasksAsync("/tasks/", Arg.Any<TaskQuery>(), Arg.Any<CancellationToken>())
+            .Returns([new TaskItem { Href = "/tasks/1.ics", Summary = "Strawberry", ETag = "\"1\"" }]);
+        _taskService.GetTasksAsync("/shopping/", Arg.Any<TaskQuery>(), Arg.Any<CancellationToken>())
+            .Returns([new TaskItem { Href = "/shopping/1.ics", Summary = "Strawberry", ETag = "\"2\"" }]);
+
+        var json = await _sut.CompleteTaskInListAsync(null, "  Strawberry  ", cancellationToken: CancellationToken.None);
+        using var doc = JsonDocument.Parse(json);
+
+        doc.RootElement.GetProperty("status").GetString().ShouldBe("ambiguous");
+        doc.RootElement.GetProperty("summary").GetString().ShouldBe("Strawberry");
+        doc.RootElement.GetProperty("message").GetString()!.ShouldContain("'Strawberry'");
     }
 
     [Fact]
@@ -318,6 +531,55 @@ public class ChatTaskToolsTests
         doc.RootElement.GetProperty("message").GetString()!.ShouldContain("not found");
         var availableLists = doc.RootElement.GetProperty("availableLists");
         availableLists.GetArrayLength().ShouldBe(2);
+        await _taskListResolver.DidNotReceiveWithAnyArgs().ResolveAsync(default!, default, TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task DeleteTaskInListAsync_NotFound_WithoutListName_TrimsSummaryInStructuredResponse()
+    {
+        _taskService.GetTaskListsAsync(Arg.Any<CancellationToken>())
+            .Returns([
+                new TaskList { Href = "/tasks/", DisplayName = "Tasks" },
+                new TaskList { Href = "/shopping/", DisplayName = "Shopping" }
+            ]);
+        _taskService.GetTasksAsync("/tasks/", Arg.Any<TaskQuery>(), Arg.Any<CancellationToken>())
+            .Returns([new TaskItem { Href = "/tasks/1.ics", Summary = "Other task" }]);
+        _taskService.GetTasksAsync("/shopping/", Arg.Any<TaskQuery>(), Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<TaskItem>());
+
+        var json = await _sut.DeleteTaskInListAsync(null, "  Nonexistent  ", cancellationToken: CancellationToken.None);
+        using var doc = JsonDocument.Parse(json);
+
+        doc.RootElement.GetProperty("status").GetString().ShouldBe("not_found");
+        doc.RootElement.GetProperty("summary").GetString().ShouldBe("Nonexistent");
+        doc.RootElement.GetProperty("message").GetString()!.ShouldContain("'Nonexistent'");
+    }
+
+    [Fact]
+    public async Task CompleteTaskInListAsync_NotFound_WithoutListName_ReturnsStructuredJsonWithAvailableLists()
+    {
+        _taskService.GetTaskListsAsync(Arg.Any<CancellationToken>())
+            .Returns([
+                new TaskList { Href = "/tasks/", DisplayName = "Tasks" },
+                new TaskList { Href = "/shopping/", DisplayName = "Shopping" }
+            ]);
+        _taskService.GetTasksAsync("/tasks/", Arg.Any<TaskQuery>(), Arg.Any<CancellationToken>())
+            .Returns([new TaskItem { Href = "/tasks/1.ics", Summary = "Other task" }]);
+        _taskService.GetTasksAsync("/shopping/", Arg.Any<TaskQuery>(), Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<TaskItem>());
+
+        var json = await _sut.CompleteTaskInListAsync(null, "  Nonexistent  ", cancellationToken: CancellationToken.None);
+        using var doc = JsonDocument.Parse(json);
+
+        doc.RootElement.GetProperty("status").GetString().ShouldBe("not_found");
+        doc.RootElement.GetProperty("summary").GetString().ShouldBe("Nonexistent");
+        doc.RootElement.GetProperty("message").GetString()!.ShouldContain("not found");
+        doc.RootElement.GetProperty("message").GetString()!.ShouldContain("Nonexistent");
+        var availableLists = doc.RootElement.GetProperty("availableLists");
+        availableLists.GetArrayLength().ShouldBe(2);
+        availableLists[0].GetString().ShouldBe("Tasks");
+        availableLists[1].GetString().ShouldBe("Shopping");
+        await _taskListResolver.DidNotReceiveWithAnyArgs().ResolveAsync(default!, default, TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -365,6 +627,28 @@ public class ChatTaskToolsTests
         doc.RootElement.GetProperty("message").GetString()!.ShouldContain("Work");
         var availableLists = doc.RootElement.GetProperty("availableLists");
         availableLists.GetArrayLength().ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task DeleteTaskInListAsync_NotFound_WithExplicitListName_ReturnsStructuredJson()
+    {
+        _taskService.GetTaskListsAsync(Arg.Any<CancellationToken>())
+            .Returns([new TaskList { Href = "/work/", DisplayName = "Work" }]);
+        _taskListResolver.ResolveAsync(Arg.Any<IReadOnlyList<TaskList>>(), "Work", Arg.Any<CancellationToken>())
+            .Returns(new TaskList { Href = "/work/", DisplayName = "Work" });
+        _taskService.GetTasksAsync("/work/", Arg.Any<TaskQuery>(), Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<TaskItem>());
+
+        var json = await _sut.DeleteTaskInListAsync("Work", "Missing task", cancellationToken: CancellationToken.None);
+        using var doc = JsonDocument.Parse(json);
+
+        doc.RootElement.GetProperty("status").GetString().ShouldBe("not_found");
+        doc.RootElement.GetProperty("summary").GetString().ShouldBe("Missing task");
+        doc.RootElement.GetProperty("message").GetString()!.ShouldContain("not found");
+        doc.RootElement.GetProperty("message").GetString()!.ShouldContain("Work");
+        var availableLists = doc.RootElement.GetProperty("availableLists");
+        availableLists.GetArrayLength().ShouldBe(1);
+        availableLists[0].GetString().ShouldBe("Work");
     }
 
     [Fact]
@@ -416,5 +700,50 @@ public class ChatTaskToolsTests
         await _sut.DeleteTaskInListAsync("Work", "Review", etag: "\"override\"", cancellationToken: CancellationToken.None);
 
         await _taskService.Received(1).DeleteTaskAsync("/work/1.ics", "\"override\"", Arg.Any<CancellationToken>());
+    }
+
+    private static void AssertListResolutionErrorWithSummary(
+        string json,
+        string? expectedTaskListName,
+        string expectedSummary,
+        string expectedMessageFragment,
+        params string[] expectedAvailableLists)
+    {
+        using var doc = JsonDocument.Parse(json);
+
+        doc.RootElement.GetProperty("status").GetString().ShouldBe("list_resolution_error");
+        doc.RootElement.GetProperty("taskListName").GetString().ShouldBe(expectedTaskListName);
+        doc.RootElement.GetProperty("summary").GetString().ShouldBe(expectedSummary);
+        doc.RootElement.GetProperty("message").GetString()!.ShouldContain(expectedMessageFragment, Case.Insensitive);
+
+        var availableLists = doc.RootElement.GetProperty("availableLists");
+        availableLists.GetArrayLength().ShouldBe(expectedAvailableLists.Length);
+
+        for (var index = 0; index < expectedAvailableLists.Length; index++)
+        {
+            availableLists[index].GetString().ShouldBe(expectedAvailableLists[index]);
+        }
+    }
+
+    private static void AssertListResolutionErrorWithoutSummary(
+        string json,
+        string? expectedTaskListName,
+        string expectedMessageFragment,
+        params string[] expectedAvailableLists)
+    {
+        using var doc = JsonDocument.Parse(json);
+
+        doc.RootElement.GetProperty("status").GetString().ShouldBe("list_resolution_error");
+        doc.RootElement.GetProperty("taskListName").GetString().ShouldBe(expectedTaskListName);
+        doc.RootElement.GetProperty("message").GetString()!.ShouldContain(expectedMessageFragment, Case.Insensitive);
+        doc.RootElement.TryGetProperty("summary", out _).ShouldBeFalse();
+
+        var availableLists = doc.RootElement.GetProperty("availableLists");
+        availableLists.GetArrayLength().ShouldBe(expectedAvailableLists.Length);
+
+        for (var index = 0; index < expectedAvailableLists.Length; index++)
+        {
+            availableLists[index].GetString().ShouldBe(expectedAvailableLists[index]);
+        }
     }
 }


### PR DESCRIPTION
## Summary

Chat tools now return structured JSON errors for task list resolution failures instead of throwing generic MCP exceptions. Also fixes coverage pipeline to exclude test assemblies from reports.

## Changes

### MCP Tools
- `show_tasks` and `add_task` catch `TaskListResolutionException` and return `list_resolution_error` payload with `availableLists`
- `find_tasks`, `complete_task_by_summary`, and `delete_task_by_summary` handle explicit list name resolution failures with structured errors
- Normalize `taskListName` and `summary` consistently across all chat tool response payloads
- Added comprehensive tests for all list resolution failure scenarios

### Coverage Pipeline
- Updated `reportgenerator` invocation with proper assembly filters
- `verify-coverage.sh` now defaults to `coverage-report` directory
- CI reads coverage metrics from filtered report

## Testing

- All 300 tests passing (147 Core + 114 MCP + 39 Integration)
- Coverage thresholds: 99.25% line, 87.53% branch (above 90%/85% gates)
- Slopwatch analysis: 0 issues

## Related

Priority 1: Do not throw exceptions for expected task-list resolution errors
Priority 2: Add test for `show_tasks(null)` with missing default task list