### PR TITLE
Document CALDAV_EXPOSE_ADVANCED_TOOLS flag and tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ Add this MCP server to VS Code, Claude Desktop, Cursor, or any MCP client:
       "env": {
         "CALDAV_URL": "https://caldav.example.com",
         "CALDAV_USERNAME": "user",
-        "CALDAV_PASSWORD": "password"
+        "CALDAV_PASSWORD": "password",
+        "CALDAV_EXPOSE_ADVANCED_TOOLS": "true"
       }
     }
   }
@@ -32,16 +33,27 @@ Add this MCP server to VS Code, Claude Desktop, Cursor, or any MCP client:
 | `CALDAV_USERNAME` | Yes | Username for Basic auth |
 | `CALDAV_PASSWORD` | Yes | Password for Basic auth |
 | `CALDAV_TASK_LISTS` | No | Comma-separated task list hrefs to expose; omit to auto-discover |
+| `CALDAV_EXPOSE_ADVANCED_TOOLS` | No | Set to `true` to expose href-based tools like `get_task`, `update_task`, `complete_task`, and `delete_task` |
 
 ## Available tools
 
+### Chat-safe tools
+
 - `list_task_lists` — List available CalDAV task lists.
+- `caldav_add_task` — Create a task using a user-facing list name.
+- `caldav_complete_task_by_summary` — Mark a task complete by summary.
+- `caldav_delete_task_by_summary` — Delete a task by summary.
+
+### Advanced tools
+
 - `list_tasks` — List tasks with optional filters such as task list, text search, status, due date, and completion state.
 - `get_task` — Fetch a single task by ID or href.
 - `create_task` — Create a new task in a task list.
 - `update_task` — Update task fields while preserving server state via ETag checks.
 - `complete_task` — Mark a task complete.
 - `delete_task` — Delete a task.
+
+By default, the server exposes only the chat-safe tools: `list_task_lists`, `caldav_add_task`, `caldav_complete_task_by_summary`, and `caldav_delete_task_by_summary`. Set `CALDAV_EXPOSE_ADVANCED_TOOLS=true` to also expose the href-based advanced tools.
 
 ## Supported servers
 


### PR DESCRIPTION
This pull request updates the documentation in `README.md` to clarify how to enable and use advanced CalDAV tools. It introduces a new environment variable, explains its purpose, and reorganizes the tool listing for better clarity.

Configuration and environment variables:

* Added the `CALDAV_EXPOSE_ADVANCED_TOOLS` environment variable, allowing users to expose advanced href-based tools by setting it to `true`.
* Documented the new variable in the environment variable table, explaining its effect.

Tool categorization and documentation:

* Split the available tools into "Chat-safe tools" and "Advanced tools" sections, clarifying which tools are exposed by default and which require the advanced flag.
* Added a note that only chat-safe tools are exposed by default, and advanced tools become available when `CALDAV_EXPOSE_ADVANCED_TOOLS` is set.