### PR TITLE
Update NuGet dependencies and repository guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,118 +1,53 @@
 # CalDAV Tasks MCP Server
 
-MCP server for CalDAV VTODO management, distributed via `dnx`. Built with .NET 10 and ModelContextProtocol SDK.
+.NET 10 stdio MCP server for CalDAV VTODOs, packaged as the `dotnet-agents-caldav` `dnx` tool.
 
-## Build & Test
+## Commands
+
+- Restore local tools and NuGet packages separately; `dotnet tool restore` does not restore project dependencies.
 
 ```bash
-# Restore tools first (required for slopwatch, reportgenerator)
 dotnet tool restore
-
-# Build
-dotnet build -c Release
-
-# Run all tests (unit + integration)
-dotnet test
-
-# Run with coverage (outputs raw collector files to tests/**/TestResults/)
-dotnet test --settings coverage.runsettings --collect:"XPlat Code Coverage"
-
-# Generate filtered coverage report
-dotnet reportgenerator -reports:"TestResults/**/coverage.cobertura.xml" -targetdir:"coverage-report" -reporttypes:Cobertura -assemblyfilters:"+DotnetAgents.CalDav.Core;+DotnetAgents.CalDav.Mcp;-*Tests*;-xunit*;-testhost*"
-
-# Verify coverage thresholds (90% line, 85% branch)
-bash scripts/verify-coverage.sh coverage-report 0.90 0.85
-
-# Run Slopwatch quality gates
-slopwatch analyze --config .slopwatch/slopwatch.json --fail-on warning
+dotnet restore
 ```
 
-## Project Structure
+- Run one unit-test project, or focus a class/method with the verified VSTest filter form:
 
-- **`src/DotnetAgents.CalDav.Core/`** — Domain models, abstractions, and CalDAV client
-  - `Abstractions/` — `ITaskService`, `ICalDavClient` interfaces
-  - `Models/` — `TaskItem`, `TaskList`, enums (immutable records with `with` semantics)
-  - `Services/` — `TaskService` implementation (thin wrapper over client)
-  - `Internal/` — `CalDavClient`, WebDAV protocol handling, iCalendar (Ical.Net) parsing
-
-- **`src/DotnetAgents.CalDav.Mcp/`** — MCP server entry point and tool definitions
-  - `Tools/` — MCP tool classes with `[McpServerTool]` attributes:
-    - `TaskListTools` — list task lists
-    - `TaskQueryTools` — list/get tasks
-    - `TaskMutationTools` — create/update/complete/delete
-    - `ChatTaskTools` — chat-oriented wrappers (list-name resolution)
-  - `Hosting/` — `CalDavMcpRunner`, DI configuration
-  - `Program.cs` — Entry point, delegates to runner
-
-- **`tests/`** — Three test projects:
-  - `DotnetAgents.CalDav.Core.Tests.Unit/` — Unit tests with NSubstitute
-  - `DotnetAgents.CalDav.Mcp.Tests.Unit/` — MCP tool unit tests
-  - `DotnetAgents.CalDav.IntegrationTests/` — Integration tests using TestContainers (Radicale)
-
-## Architecture
-
-Layered flow:
-```
-MCP Tools → ITaskService → CalDavClient → HttpClient + Ical.Net
-```
-
-Key patterns:
-- **Immutable models** — Use `with` expressions for updates (e.g., `task with { Status = Completed }`)
-- **Optimistic concurrency** — ETag-based; always pass ETag on updates/deletes
-- **Chat-oriented vs href-based tools** — Tools with "by summary" or "in list" naming accept display names; others require absolute hrefs
-- **Time abstraction** — `TimeProvider` injected for testability (not DateTimeOffset.Now)
-
-## Tool Naming Conventions
-
-The MCP exposes two styles of tools:
-
-1. **Href-based** (for known IDs): `create_task`, `update_task`, `complete_task`, `delete_task` — require absolute hrefs
-2. **Chat-oriented** (for user-facing workflows): `caldav_add_task`, `caldav_complete_task_by_summary`, etc. — accept display names and resolve hrefs internally
-
-When adding new tools, follow the existing pattern: href-based for raw API access, chat-oriented wrappers for common user workflows.
-
-## Testing Notes
-
-- **Unit tests** — Fast, use NSubstitute for mocks, Shouldly for assertions
-- **Integration tests** — Use TestContainers with Radicale (Docker required). Fixture in `Fixtures/RadicaleFixture.cs` spins up container per test class
-- **Coverage thresholds** — 90% line, 85% branch enforced in CI
-- **CRAP analysis** — Cyclomatic complexity limit 10 (CA1502); check coverage report for hotspots
-
-## Quality Gates
-
-CI enforces (in order):
-1. Build with `TreatWarningsAsErrors=true`
-2. CA1502 cyclomatic complexity ≤ 10
-3. Test pass with coverage collection
-4. Coverage thresholds (90% line, 85% branch)
-5. Slopwatch analysis (SW001-SW006 rules)
-
-## Key Dependencies
-
-- `ModelContextProtocol` 1.2.0 — MCP SDK
-- `Ical.Net` 5.2.1 — iCalendar parsing/generation
-- `Testcontainers` 4.11.0 — Integration test infrastructure
-- `xunit.v3` 3.2.2 — Testing framework
-
-## Distribution
-
-Published as `dotnet-agents-caldav` on NuGet. Installed via:
 ```bash
-dnx --yes dotnet-agents-caldav
+dotnet test tests/DotnetAgents.CalDav.Core.Tests.Unit/DotnetAgents.CalDav.Core.Tests.Unit.csproj -c Release
+dotnet test tests/DotnetAgents.CalDav.Core.Tests.Unit/DotnetAgents.CalDav.Core.Tests.Unit.csproj -c Release --filter "FullyQualifiedName~TypeOrMethod"
 ```
 
-Requires environment variables: `CALDAV_URL`, `CALDAV_USERNAME`, `CALDAV_PASSWORD`
+- The integration project requires Docker. Its `RadicaleCollection` shares one `tomsquest/docker-radicale` Testcontainer and seeds `Tasks`, `Shopping`, and `Work` collections.
+- Match CI in this order; `--results-directory TestResults` is required because the report command reads the root `TestResults/` tree:
 
-[dotnet-skills]|IMPORTANT: Prefer retrieval-led reasoning over pretraining for any .NET work.
-|flow:{skim repo patterns -> consult dotnet-skills by name -> implement smallest-change -> note conflicts}
-|route:
-|akka:{akka-net-best-practices,akka-net-testing-patterns,akka-hosting-actor-patterns,akka-net-aspire-configuration,akka-net-management}
-|csharp:{modern-csharp-coding-standards,csharp-concurrency-patterns,api-design,type-design-performance}
-|aspnetcore-web:{aspire-integration-testing,aspire-configuration,aspire-service-defaults,mailpit-integration,mjml-email-templates}
-|data:{efcore-patterns,database-performance}
-|di-config:{microsoft-extensions-configuration,dependency-injection-patterns}
-|testing:{testcontainers-integration-tests,playwright-blazor-testing,snapshot-testing,verify-email-snapshots,playwright-ci-caching}
-|dotnet:{dotnet-project-structure,dotnet-local-tools,package-management,serialization,dotnet-devcert-trust,ilspy-decompile,OpenTelemetry-NET-Instrumentation}
-|quality-gates:{dotnet-slopwatch,crap-analysis}
-|meta:{marketplace-publishing,skills-index-snippets}
-|agents:{akka-net-specialist,docfx-specialist,dotnet-benchmark-designer,dotnet-concurrency-specialist,dotnet-performance-analyst,roslyn-incremental-generator-specialist}
+```bash
+dotnet build -c Release --no-restore
+dotnet test -c Release --settings coverage.runsettings --collect:"XPlat Code Coverage" --results-directory TestResults
+dotnet reportgenerator -reports:"TestResults/**/coverage.cobertura.xml" -targetdir:"coverage-report" -reporttypes:Cobertura -assemblyfilters:"+DotnetAgents.CalDav.Core;+DotnetAgents.CalDav.Mcp;-*Tests*;-xunit*;-testhost*"
+bash scripts/verify-coverage.sh coverage-report 0.90 0.85
+dotnet tool run slopwatch analyze --config .slopwatch/slopwatch.json --fail-on warning
+```
+
+- CI enforces warnings as errors, method complexity at most 10, 90% line coverage, and 85% branch coverage. Markdown-only pull requests do not trigger CI.
+
+## Boundaries
+
+- Runtime flow is `MCP tools -> ITaskService -> TaskService -> CalDavClient -> HttpClient`; `TaskService` stays thin. WebDAV request/response logic belongs under `Core/Internal/Xml`, and iCalendar mapping belongs under `Core/Internal/Ical`.
+- `Program.cs` maps `CALDAV_*` environment variables, then delegates startup to `CalDavMcpRunner` and `CalDavHostBuilder`; keep startup testable through those types rather than adding logic to top-level statements.
+- The default host exposes only `TaskListTools` and `ChatTaskTools`. `CALDAV_EXPOSE_ADVANCED_TOOLS=true` additionally registers href-based `TaskQueryTools` and `TaskMutationTools`.
+- `.opencode/opencode.jsonc` launches the published NuGet tool through `dnx`; it does not run the current checkout. Do not treat that configuration as source-level end-to-end validation.
+
+## Invariants
+
+- Keep console providers disabled. Stdout is the JSON-RPC transport, and integration tests require a valid server run to leave both stdout and stderr clean; only startup validation failures write human-readable stderr.
+- `TaskItem` and `TaskList` are immutable records. Modify them with `with`, preserve fetched ETags on updates/deletes, and use injected `TimeProvider` for completion timestamps.
+- Chat tools resolve explicit display names first, then `CALDAV_DEFAULT_TASK_LIST`; they never infer a list from task content. Summary-based mutations must return `not_found` or `ambiguous` unless exactly one task matches.
+- Href-based tools are the advanced/raw surface. Keep their descriptions requiring an explicitly provided or confirmed absolute href; normal chat flows use list-name tools.
+- Package versions are centralized in `Directory.Packages.props`; project files keep versionless `PackageReference` entries.
+- For Ical.Net, `.ics`, VTODO, or recurrence changes, load the repo-local `ical-net` skill before editing.
+
+## Packaging
+
+- `src/DotnetAgents.CalDav.Mcp/.mcp/server.json` is packed metadata. Keep its source versions at `0.0.0`; the `v*` release workflow replaces both versions from the tag.
+- When environment variables or packaged MCP metadata change, update `.mcp/server.json` and `McpMetadataTests` alongside the runtime mapping. The NuGet package is produced only from `src/DotnetAgents.CalDav.Mcp/DotnetAgents.CalDav.Mcp.csproj`.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,9 @@
+# CalDAV Tasks
+
+This context exposes CalDAV task lists and tasks to conversational and href-based workflows while preserving deterministic targeting and concurrency safety.
+
+## Language
+
+**Task Completion**:
+A transition that marks exactly one task as completed at a specific time while retaining its other task data.
+_Avoid_: Done flag, finish operation

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,58 +2,53 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
-
   <!-- Shared version variables -->
   <PropertyGroup Label="SharedVersions">
-    <McpSdkVersion>1.2.0</McpSdkVersion>
-    <IcalNetVersion>5.2.1</IcalNetVersion>
+    <McpSdkVersion>2.2.0</McpSdkVersion>
+    <IcalNetVersion>5.2.3</IcalNetVersion>
     <XunitV3Version>3.2.2</XunitV3Version>
     <AutoFixtureVersion>4.18.1</AutoFixtureVersion>
     <TestContainersVersion>4.11.0</TestContainersVersion>
-    <MicrosoftExtensionsVersion>10.0.6</MicrosoftExtensionsVersion>
+    <MicrosoftExtensionsVersion>10.0.11</MicrosoftExtensionsVersion>
   </PropertyGroup>
-
   <!-- MCP SDK -->
   <ItemGroup Label="MCP">
     <PackageVersion Include="ModelContextProtocol" Version="$(McpSdkVersion)" />
+    <PackageVersion Include="SSH.NET" Version="2026.0.0" />
   </ItemGroup>
-
   <!-- Core Dependencies -->
   <ItemGroup Label="Core">
     <PackageVersion Include="Ical.Net" Version="$(IcalNetVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Http" Version="$(MicrosoftExtensionsVersion)" />
-    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.5.0" />
+    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.9.0" />
     <PackageVersion Include="Microsoft.Extensions.Options" Version="$(MicrosoftExtensionsVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="$(MicrosoftExtensionsVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftExtensionsVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="$(MicrosoftExtensionsVersion)" />
   </ItemGroup>
-
   <!-- Build / SourceLink / Analyzers -->
   <ItemGroup Label="Build">
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.202" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.202" />
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.400" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.400" />
   </ItemGroup>
-
   <!-- Testing -->
   <ItemGroup Label="Testing">
     <PackageVersion Include="xunit.v3" Version="$(XunitV3Version)" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
-    <PackageVersion Include="coverlet.collector" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
+    <PackageVersion Include="coverlet.collector" Version="10.0.1" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="NSubstitute.Analyzers.CSharp" Version="1.0.17" />
     <PackageVersion Include="AutoFixture" Version="$(AutoFixtureVersion)" />
     <PackageVersion Include="AutoFixture.AutoNSubstitute" Version="$(AutoFixtureVersion)" />
     <PackageVersion Include="Shouldly" Version="4.3.0" />
-    <PackageVersion Include="Verify.XunitV3" Version="31.16.1" />
-    <PackageVersion Include="RichardSzalay.MockHttp" Version="7.0.0" />
+    <PackageVersion Include="Verify.XunitV3" Version="31.28.0" />
+    <PackageVersion Include="RichardSzalay.MockHttp" Version="7.1.0" />
     <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="$(MicrosoftExtensionsVersion)" />
   </ItemGroup>
-
   <!-- Integration Testing -->
   <ItemGroup Label="Integration Testing">
-    <PackageVersion Include="Testcontainers" Version="$(TestContainersVersion)" />
+    <PackageVersion Include="Testcontainers" Version="4.13.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="$(MicrosoftExtensionsVersion)" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="$(MicrosoftExtensionsVersion)" />

--- a/src/DotnetAgents.CalDav.Core/Internal/Ical/TaskItemMapper.cs
+++ b/src/DotnetAgents.CalDav.Core/Internal/Ical/TaskItemMapper.cs
@@ -48,7 +48,7 @@ internal static class TaskItemMapper
             Categories = todo.Categories?
                 .SelectMany(c => c?.Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries) ?? [])
                 .ToList() as IReadOnlyList<string> ?? [],
-            RecurrenceRule = todo.RecurrenceRules?.FirstOrDefault()?.ToString(),
+            RecurrenceRule = todo.RecurrenceRule?.ToString(),
             ETag = etag,
             Href = href ?? string.Empty
         };
@@ -94,7 +94,7 @@ internal static class TaskItemMapper
         {
             var recurrence = RecurrenceMapper.FromString(task.RecurrenceRule);
             if (recurrence is not null)
-                todo.RecurrenceRules = [recurrence];
+                todo.RecurrenceRule = recurrence;
         }
 
         return todo;

--- a/tests/DotnetAgents.CalDav.Core.Tests.Unit/Internal/Ical/TaskItemMapperTests.cs
+++ b/tests/DotnetAgents.CalDav.Core.Tests.Unit/Internal/Ical/TaskItemMapperTests.cs
@@ -170,7 +170,7 @@ public class TaskItemMapperTests
         var todo = new Todo
         {
             Uid = "recurring",
-            RecurrenceRules = [new RecurrencePattern(FrequencyType.Daily, 1) { Count = 5 }],
+            RecurrenceRule = new RecurrencePattern(FrequencyType.Daily, 1) { Count = 5 },
         };
 
         var task = TaskItemMapper.FromTodo(todo);
@@ -287,7 +287,7 @@ Priority = CalDavTaskPriority.High,
     }
 
     [Fact]
-    public void ToTodo_WithRecurrenceRule_SetsRecurrenceRules()
+    public void ToTodo_WithRecurrenceRule_SetsRecurrenceRule()
     {
         var task = new TaskItem
         {
@@ -297,12 +297,11 @@ Priority = CalDavTaskPriority.High,
         };
 
         var todo = TaskItemMapper.ToTodo(task);
-        todo.RecurrenceRules.ShouldNotBeNull();
-        todo.RecurrenceRules.Count.ShouldBe(1);
+        todo.RecurrenceRule.ShouldNotBeNull();
     }
 
     [Fact]
-    public void ToTodo_NullRecurrenceRule_NoRecurrenceRules()
+    public void ToTodo_NullRecurrenceRule_NoRecurrenceRule()
     {
         var task = new TaskItem
         {
@@ -312,8 +311,7 @@ Priority = CalDavTaskPriority.High,
         };
 
         var todo = TaskItemMapper.ToTodo(task);
-        // RecurrenceRules should be null or empty when no recurrence is set
-        (todo.RecurrenceRules == null || todo.RecurrenceRules.Count == 0).ShouldBeTrue();
+        todo.RecurrenceRule.ShouldBeNull();
     }
 
     [Fact]

--- a/tests/DotnetAgents.CalDav.IntegrationTests/DotnetAgents.CalDav.IntegrationTests.csproj
+++ b/tests/DotnetAgents.CalDav.IntegrationTests/DotnetAgents.CalDav.IntegrationTests.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="SSH.NET" />
     <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />


### PR DESCRIPTION
## Summary

- upgrade supported NuGet dependencies, including ModelContextProtocol, Ical.Net, Microsoft.Extensions, test tooling, and Testcontainers
- migrate recurrence mapping to Ical.Net's singular `RecurrenceRule` API
- pin SSH.NET 2026.0.0 to replace the vulnerable transitive version required by Testcontainers
- refresh `AGENTS.md` and add `CONTEXT.md`

## Compatibility

NSubstitute remains at 5.3.0 because the latest stable AutoFixture.AutoNSubstitute package requires NSubstitute versions below 6.0.0.

## Validation

- 301 tests passed
- line coverage: 98.2%
- branch coverage: 88.1%
- Slopwatch: no issues
- NuGet vulnerability audit: no vulnerable direct or transitive packages
- final dotnet-outdated scan: no remaining supported updates