### PR TITLE
Deepen task completion behind one MCP module

### DIFF
--- a/src/DotnetAgents.CalDav.Mcp/Hosting/CalDavHostBuilder.cs
+++ b/src/DotnetAgents.CalDav.Mcp/Hosting/CalDavHostBuilder.cs
@@ -42,6 +42,7 @@ public sealed class CalDavHostBuilder
         }
 
         builder.Services.AddSingleton(TimeProvider.System);
+        builder.Services.AddTransient<TaskCompletion>();
 
         return builder;
     }

--- a/src/DotnetAgents.CalDav.Mcp/InternalsVisibleTo.cs
+++ b/src/DotnetAgents.CalDav.Mcp/InternalsVisibleTo.cs
@@ -1,3 +1,4 @@
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("DotnetAgents.CalDav.Mcp.Tests.Unit")]
+[assembly: InternalsVisibleTo("DotnetAgents.CalDav.IntegrationTests")]

--- a/src/DotnetAgents.CalDav.Mcp/TaskCompletion.cs
+++ b/src/DotnetAgents.CalDav.Mcp/TaskCompletion.cs
@@ -1,0 +1,32 @@
+using CalDavTaskStatus = DotnetAgents.CalDav.Core.Models.TaskStatus;
+using DotnetAgents.CalDav.Core.Abstractions;
+using DotnetAgents.CalDav.Core.Models;
+
+namespace DotnetAgents.CalDav.Mcp;
+
+internal sealed class TaskCompletion
+{
+    private readonly ITaskService _taskService;
+    private readonly TimeProvider _timeProvider;
+
+    public TaskCompletion(ITaskService taskService, TimeProvider timeProvider)
+    {
+        _taskService = taskService;
+        _timeProvider = timeProvider;
+    }
+
+    public Task<TaskItem> CompleteAsync(
+        TaskItem task,
+        string? etag,
+        CancellationToken cancellationToken)
+    {
+        var completed = task with
+        {
+            Status = CalDavTaskStatus.Completed,
+            Completed = _timeProvider.GetUtcNow(),
+            ETag = etag ?? task.ETag
+        };
+
+        return _taskService.UpdateTaskAsync(completed, cancellationToken);
+    }
+}

--- a/src/DotnetAgents.CalDav.Mcp/Tools/ChatTaskTools.cs
+++ b/src/DotnetAgents.CalDav.Mcp/Tools/ChatTaskTools.cs
@@ -10,17 +10,20 @@ using System.Text.Json.Serialization;
 namespace DotnetAgents.CalDav.Mcp.Tools;
 
 [McpServerToolType]
-public sealed class ChatTaskTools
+internal sealed class ChatTaskTools
 {
     private readonly ITaskService _taskService;
     private readonly ITaskListResolver _taskListResolver;
-    private readonly TimeProvider _timeProvider;
+    private readonly TaskCompletion _taskCompletion;
 
-    public ChatTaskTools(ITaskService taskService, ITaskListResolver taskListResolver, TimeProvider timeProvider)
+    public ChatTaskTools(
+        ITaskService taskService,
+        ITaskListResolver taskListResolver,
+        TaskCompletion taskCompletion)
     {
         _taskService = taskService;
         _taskListResolver = taskListResolver;
-        _timeProvider = timeProvider;
+        _taskCompletion = taskCompletion;
     }
 
     [McpServerTool(Name = "show_tasks"), Description("List tasks in a user-facing task list name. If the user says 'task list' or 'my tasks', omit listName to use the configured default list. Never guess based on task content; this tool resolves list names deterministically and fails with candidates when ambiguous.")]
@@ -123,7 +126,8 @@ public sealed class ChatTaskTools
 
             return result switch
             {
-                ResolvedMatch match => await CompleteTask(match.Task, etag, cancellationToken),
+                ResolvedMatch match => JsonSerializer.Serialize(
+                    await _taskCompletion.CompleteAsync(match.Task, etag, cancellationToken)),
                 AmbiguousResult a => ReturnAmbiguous(summary, a.Matches),
                 NotFoundResult => ReturnNotFound(summary, normalizedTaskListName, availableLists),
                 _ => throw new InvalidOperationException($"Unexpected resolve result: {result.GetType().Name}")
@@ -133,19 +137,6 @@ public sealed class ChatTaskTools
         {
             return ReturnTaskListResolutionError(normalizedTaskListName, ex.Message, ex.AvailableLists, summary);
         }
-    }
-
-    private async Task<string> CompleteTask(TaskItem task, string? etag, CancellationToken cancellationToken)
-    {
-        var updated = task with
-        {
-            Status = CalDavTaskStatus.Completed,
-            Completed = _timeProvider.GetUtcNow(),
-            ETag = etag ?? task.ETag
-        };
-
-        var completed = await _taskService.UpdateTaskAsync(updated, cancellationToken);
-        return JsonSerializer.Serialize(completed);
     }
 
     [McpServerTool(Name = "delete_task_by_summary"), Description("Delete a task by summary. If the user named a list, only that list is searched. If they did not name a list, all visible lists are searched. If zero tasks match, returns not_found. If multiple tasks match, returns ambiguous with candidates instead of guessing. This is a single-target tool: never delete multiple tasks in one call or by repeating this tool for a bulk request without explicit per-target confirmation.")]

--- a/src/DotnetAgents.CalDav.Mcp/Tools/TaskMutationTools.cs
+++ b/src/DotnetAgents.CalDav.Mcp/Tools/TaskMutationTools.cs
@@ -11,15 +11,15 @@ namespace DotnetAgents.CalDav.Mcp.Tools;
 /// MCP mutation tools for creating, updating, completing, and deleting tasks.
 /// </summary>
 [McpServerToolType]
-public sealed class TaskMutationTools
+internal sealed class TaskMutationTools
 {
     private readonly ITaskService _taskService;
-    private readonly TimeProvider _timeProvider;
+    private readonly TaskCompletion _taskCompletion;
 
-    public TaskMutationTools(ITaskService taskService, TimeProvider timeProvider)
+    public TaskMutationTools(ITaskService taskService, TaskCompletion taskCompletion)
     {
         _taskService = taskService;
-        _timeProvider = timeProvider;
+        _taskCompletion = taskCompletion;
     }
 
     [McpServerTool(Name = "create_task"), Description("Create a new task in a CalDAV task list by absolute href. Only use this when the user explicitly provides or confirms the exact href. Prefer the chat-oriented add-to-list tool for normal agent workflows.")]
@@ -82,14 +82,7 @@ public sealed class TaskMutationTools
         var existing = await _taskService.GetTaskAsync(href, cancellationToken)
             ?? throw new InvalidOperationException($"Task not found: {href}");
 
-        var task = existing with
-        {
-            Status = CalDavTaskStatus.Completed,
-            Completed = _timeProvider.GetUtcNow(),
-            ETag = etag ?? existing.ETag
-        };
-
-        var completed = await _taskService.UpdateTaskAsync(task, cancellationToken);
+        var completed = await _taskCompletion.CompleteAsync(existing, etag, cancellationToken);
         return JsonSerializer.Serialize(completed);
     }
 

--- a/tests/DotnetAgents.CalDav.IntegrationTests/McpToolsIntegrationTests.cs
+++ b/tests/DotnetAgents.CalDav.IntegrationTests/McpToolsIntegrationTests.cs
@@ -4,6 +4,7 @@ using DotnetAgents.CalDav.Core.Configuration;
 using DotnetAgents.CalDav.Core.DependencyInjection;
 using DotnetAgents.CalDav.Core.Models;
 using DotnetAgents.CalDav.IntegrationTests.Fixtures;
+using DotnetAgents.CalDav.Mcp;
 using DotnetAgents.CalDav.Mcp.Tests.Unit;
 using DotnetAgents.CalDav.Mcp.Tools;
 using Microsoft.Extensions.DependencyInjection;
@@ -41,8 +42,9 @@ public sealed class McpToolsIntegrationTests : IAsyncLifetime
         var taskListResolver = serviceProvider.GetRequiredService<Core.Abstractions.ITaskListResolver>();
         _taskListTools = new TaskListTools(_fixture.TaskService, taskListResolver);
         _taskQueryTools = new TaskQueryTools(_fixture.TaskService);
-        _taskMutationTools = new TaskMutationTools(_fixture.TaskService, new FixedTimeProvider(FixedNow));
-        _chatTaskTools = new ChatTaskTools(_fixture.TaskService, taskListResolver, new FixedTimeProvider(FixedNow));
+        var taskCompletion = new TaskCompletion(_fixture.TaskService, new FixedTimeProvider(FixedNow));
+        _taskMutationTools = new TaskMutationTools(_fixture.TaskService, taskCompletion);
+        _chatTaskTools = new ChatTaskTools(_fixture.TaskService, taskListResolver, taskCompletion);
     }
 
     public ValueTask InitializeAsync() => ValueTask.CompletedTask;

--- a/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/CalDavHostBuilderTests.cs
+++ b/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/CalDavHostBuilderTests.cs
@@ -121,6 +121,18 @@ public class CalDavHostBuilderTests
     }
 
     [Fact]
+    public void CreateBuilder_RegistersTaskCompletionAsTransient()
+    {
+        var builder = CalDavHostBuilder.CreateBuilder();
+
+        var registration = builder.Services.SingleOrDefault(
+            descriptor => descriptor.ServiceType == typeof(TaskCompletion));
+
+        registration.ShouldNotBeNull();
+        registration.Lifetime.ShouldBe(ServiceLifetime.Transient);
+    }
+
+    [Fact]
     public void CreateBuilder_HasNoConsoleLoggingProviders()
     {
         // The MCP server uses stdio transport (JSON-RPC over stdin/stdout).

--- a/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/ChatTaskToolsTests.cs
+++ b/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/ChatTaskToolsTests.cs
@@ -21,7 +21,10 @@ public class ChatTaskToolsTests
     {
         _taskService = Substitute.For<ITaskService>();
         _taskListResolver = Substitute.For<ITaskListResolver>();
-        _sut = new ChatTaskTools(_taskService, _taskListResolver, TimeProvider.System);
+        _sut = new ChatTaskTools(
+            _taskService,
+            _taskListResolver,
+            new TaskCompletion(_taskService, TimeProvider.System));
     }
 
     [Fact]
@@ -668,6 +671,13 @@ public class ChatTaskToolsTests
     [Fact]
     public async Task CompleteTaskInListAsync_UniqueMatch_CompletesSuccessfully()
     {
+        var persisted = new TaskItem
+        {
+            Href = "/tasks/1.ics",
+            Summary = "Buy milk",
+            Status = CalDavTaskStatus.Completed,
+            ETag = "\"etag-persisted\""
+        };
         _taskService.GetTaskListsAsync(Arg.Any<CancellationToken>())
             .Returns([new TaskList { Href = "/tasks/", DisplayName = "Tasks" }]);
         _taskListResolver.ResolveAsync(Arg.Any<IReadOnlyList<TaskList>>(), "Tasks", Arg.Any<CancellationToken>())
@@ -675,13 +685,14 @@ public class ChatTaskToolsTests
         _taskService.GetTasksAsync("/tasks/", Arg.Any<TaskQuery>(), Arg.Any<CancellationToken>())
             .Returns([new TaskItem { Href = "/tasks/1.ics", Summary = "Buy milk", ETag = "\"etag1\"" }]);
         _taskService.UpdateTaskAsync(Arg.Any<TaskItem>(), Arg.Any<CancellationToken>())
-            .Returns(ci => ci.Arg<TaskItem>());
+            .Returns(persisted);
 
         var json = await _sut.CompleteTaskInListAsync("Tasks", "Buy milk", cancellationToken: CancellationToken.None);
+        using var doc = JsonDocument.Parse(json);
 
-        json.ShouldContain("Completed");
+        doc.RootElement.GetProperty("ETag").GetString().ShouldBe(persisted.ETag);
         await _taskService.Received(1).UpdateTaskAsync(
-            Arg.Is<TaskItem>(t => t.Status == CalDavTaskStatus.Completed && t.ETag == "\"etag1\""),
+            Arg.Is<TaskItem>(task => task.Href == "/tasks/1.ics"),
             Arg.Any<CancellationToken>());
     }
 

--- a/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/TaskCompletionTests.cs
+++ b/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/TaskCompletionTests.cs
@@ -1,0 +1,120 @@
+using CalDavTaskStatus = DotnetAgents.CalDav.Core.Models.TaskStatus;
+using DotnetAgents.CalDav.Core.Abstractions;
+using DotnetAgents.CalDav.Core.Models;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using Shouldly;
+using Xunit;
+
+namespace DotnetAgents.CalDav.Mcp.Tests.Unit;
+
+public class TaskCompletionTests
+{
+    private static readonly DateTimeOffset FixedNow = new(2025, 6, 15, 12, 30, 0, TimeSpan.Zero);
+
+    [Fact]
+    public async Task CompleteAsync_UsesCurrentTimeAndReturnsPersistedTask()
+    {
+        var taskService = Substitute.For<ITaskService>();
+        var fetched = new TaskItem
+        {
+            Href = "/tasks/1.ics",
+            Uid = "task-1",
+            Summary = "Review",
+            Status = CalDavTaskStatus.InProcess,
+            ETag = "\"etag-old\""
+        };
+        var persisted = fetched with
+        {
+            Status = CalDavTaskStatus.Completed,
+            Completed = FixedNow,
+            ETag = "\"etag-new\""
+        };
+        taskService.UpdateTaskAsync(Arg.Any<TaskItem>(), Arg.Any<CancellationToken>())
+            .Returns(persisted);
+        var sut = new TaskCompletion(taskService, new FixedTimeProvider(FixedNow));
+
+        var result = await sut.CompleteAsync(fetched, null, CancellationToken.None);
+
+        result.ShouldBeSameAs(persisted);
+        await taskService.Received(1).UpdateTaskAsync(
+            Arg.Is<TaskItem>(task =>
+                task.Status == CalDavTaskStatus.Completed &&
+                task.Completed == FixedNow &&
+                task.ETag == fetched.ETag),
+            CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task CompleteAsync_AlreadyCompletedTask_ReplacesCompletionTimeAndPreservesAllOtherData()
+    {
+        var taskService = Substitute.For<ITaskService>();
+        var fetched = new TaskItem
+        {
+            Href = "/tasks/recurring.ics",
+            Uid = "task-recurring",
+            Summary = "Weekly review",
+            Description = "Review every active project",
+            Due = new DateTimeOffset(2025, 6, 20, 17, 0, 0, TimeSpan.Zero),
+            Start = new DateTimeOffset(2025, 6, 20, 9, 0, 0, TimeSpan.Zero),
+            Completed = new DateTimeOffset(2025, 6, 1, 8, 0, 0, TimeSpan.Zero),
+            Priority = TaskPriority.High,
+            Status = CalDavTaskStatus.Completed,
+            Categories = ["work", "review"],
+            RecurrenceRule = "FREQ=WEEKLY;COUNT=4",
+            ETag = "\"etag-fetched\""
+        };
+        TaskItem? submitted = null;
+        taskService.UpdateTaskAsync(Arg.Do<TaskItem>(task => submitted = task), Arg.Any<CancellationToken>())
+            .Returns(call => call.Arg<TaskItem>());
+        var sut = new TaskCompletion(taskService, new FixedTimeProvider(FixedNow));
+
+        await sut.CompleteAsync(fetched, null, CancellationToken.None);
+
+        submitted.ShouldBe(fetched with { Completed = FixedNow });
+    }
+
+    [Fact]
+    public async Task CompleteAsync_ExplicitEtagOverridesFetchedEtag()
+    {
+        var taskService = Substitute.For<ITaskService>();
+        var fetched = new TaskItem { Href = "/tasks/1.ics", ETag = "\"etag-fetched\"" };
+        TaskItem? submitted = null;
+        taskService.UpdateTaskAsync(Arg.Do<TaskItem>(task => submitted = task), Arg.Any<CancellationToken>())
+            .Returns(call => call.Arg<TaskItem>());
+        var sut = new TaskCompletion(taskService, new FixedTimeProvider(FixedNow));
+
+        await sut.CompleteAsync(fetched, "\"etag-caller\"", CancellationToken.None);
+
+        submitted!.ETag.ShouldBe("\"etag-caller\"");
+    }
+
+    [Fact]
+    public async Task CompleteAsync_ForwardsCancellationToken()
+    {
+        var taskService = Substitute.For<ITaskService>();
+        var cancellationToken = new CancellationTokenSource().Token;
+        taskService.UpdateTaskAsync(Arg.Any<TaskItem>(), cancellationToken)
+            .Returns(call => call.Arg<TaskItem>());
+        var sut = new TaskCompletion(taskService, new FixedTimeProvider(FixedNow));
+
+        await sut.CompleteAsync(new TaskItem(), null, cancellationToken);
+
+        await taskService.Received(1).UpdateTaskAsync(Arg.Any<TaskItem>(), cancellationToken);
+    }
+
+    [Fact]
+    public async Task CompleteAsync_UpdateFailurePropagatesUnchanged()
+    {
+        var taskService = Substitute.For<ITaskService>();
+        var failure = new InvalidOperationException("Concurrency conflict");
+        taskService.UpdateTaskAsync(Arg.Any<TaskItem>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(failure);
+        var sut = new TaskCompletion(taskService, new FixedTimeProvider(FixedNow));
+
+        var thrown = await Should.ThrowAsync<InvalidOperationException>(
+            () => sut.CompleteAsync(new TaskItem(), null, CancellationToken.None));
+
+        thrown.ShouldBeSameAs(failure);
+    }
+}

--- a/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/TaskMutationToolsTests.cs
+++ b/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/TaskMutationToolsTests.cs
@@ -16,15 +16,15 @@ public class TaskMutationToolsTests
 {
     private readonly ITaskService _taskService;
     private readonly TaskMutationTools _sut;
-    private readonly TimeProvider _timeProvider;
 
     private static readonly DateTimeOffset FixedNow = new(2025, 6, 15, 12, 30, 0, TimeSpan.Zero);
 
     public TaskMutationToolsTests()
     {
         _taskService = Substitute.For<ITaskService>();
-        _timeProvider = new FixedTimeProvider(FixedNow);
-        _sut = new TaskMutationTools(_taskService, _timeProvider);
+        _sut = new TaskMutationTools(
+            _taskService,
+            new TaskCompletion(_taskService, new FixedTimeProvider(FixedNow)));
     }
 
     // ─── create_task ────────────────────────────────────────────────────────
@@ -357,103 +357,6 @@ public class TaskMutationToolsTests
         root.GetProperty("ETag").GetString().ShouldBe("\"etag-done\"");
     }
 
-    [Fact]
-    public async Task CompleteTaskAsync_SetsStatusToCompletedAndCompletedTimestamp()
-    {
-        // Arrange
-        var existingTask = new TaskItem
-        {
-            Href = "/calendars/user/tasks/task-7.ics",
-            Uid = "task-7",
-            Summary = "Some task",
-            Status = CalDavTaskStatus.InProcess,
-            ETag = "\"etag-v0\""
-        };
-
-        _taskService.GetTaskAsync("/calendars/user/tasks/task-7.ics", Arg.Any<CancellationToken>())
-            .Returns(existingTask);
-        _taskService.UpdateTaskAsync(Arg.Any<TaskItem>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(new TaskItem { Uid = "c1", Summary = "C", Href = "/c" }));
-
-        // Act
-        await _sut.CompleteTaskAsync(
-            href: "/calendars/user/tasks/task-7.ics",
-            etag: "\"etag-v1\"",
-            cancellationToken: CancellationToken.None);
-
-        // Assert — Status must be Completed, Completed timestamp must be the fixed time,
-        // and the explicit etag overrides the fetched task's etag
-        await _taskService.Received(1).UpdateTaskAsync(
-            Arg.Is<TaskItem>(t =>
-                t.Href == "/calendars/user/tasks/task-7.ics" &&
-                t.Uid == existingTask.Uid &&
-                t.Summary == existingTask.Summary &&
-                t.Status == CalDavTaskStatus.Completed &&
-                t.Completed == FixedNow &&
-                t.ETag == "\"etag-v1\""),
-            Arg.Any<CancellationToken>());
-    }
-
-    [Fact]
-    public async Task CompleteTaskAsync_WithNoEtag_PreservesFetchedEtag()
-    {
-        // Arrange
-        var existingTask = new TaskItem
-        {
-            Href = "/calendars/user/tasks/task-8.ics",
-            Uid = "task-8",
-            Summary = "Another task",
-            Status = CalDavTaskStatus.InProcess,
-            ETag = "\"etag-existing\""
-        };
-
-        _taskService.GetTaskAsync("/calendars/user/tasks/task-8.ics", Arg.Any<CancellationToken>())
-            .Returns(existingTask);
-        _taskService.UpdateTaskAsync(Arg.Any<TaskItem>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(new TaskItem { Uid = "c2", Summary = "C", Href = "/c" }));
-
-        // Act — no explicit etag, so fetched task's etag should be preserved
-        await _sut.CompleteTaskAsync(
-            href: "/calendars/user/tasks/task-8.ics",
-            etag: null,
-            cancellationToken: CancellationToken.None);
-
-        // Assert
-        await _taskService.Received(1).UpdateTaskAsync(
-            Arg.Is<TaskItem>(t =>
-                t.Href == "/calendars/user/tasks/task-8.ics" &&
-                t.Status == CalDavTaskStatus.Completed &&
-                t.Completed == FixedNow &&
-                t.ETag == existingTask.ETag),
-            Arg.Any<CancellationToken>());
-    }
-
-    [Fact]
-    public async Task CompleteTaskAsync_ServiceThrowsException_ExceptionPropagates()
-    {
-        // Arrange
-        var existingTask = new TaskItem
-        {
-            Href = "/calendars/user/tasks/missing.ics",
-            Summary = "Missing",
-            Status = CalDavTaskStatus.NeedsAction,
-            ETag = "\"etag-x\""
-        };
-        _taskService.GetTaskAsync("/calendars/user/tasks/missing.ics", Arg.Any<CancellationToken>())
-            .Returns(existingTask);
-        _taskService.UpdateTaskAsync(Arg.Any<TaskItem>(), Arg.Any<CancellationToken>())
-            .ThrowsAsync(new InvalidOperationException("Not found"));
-
-        // Act & Assert
-        var ex = await Should.ThrowAsync<InvalidOperationException>(
-            () => _sut.CompleteTaskAsync(
-                href: "/calendars/user/tasks/missing.ics",
-                etag: null,
-                cancellationToken: CancellationToken.None));
-
-        ex.Message.ShouldBe("Not found");
-    }
-
     // ─── delete_task ──────────────────────────────────────────────────────────
 
     [Fact]
@@ -530,76 +433,6 @@ public class TaskMutationToolsTests
                 cancellationToken: CancellationToken.None));
 
         ex.Message.ShouldBe("Server error");
-    }
-
-    // ─── complete_task data-preservation tests ──────────────────────────────
-
-    [Fact]
-    public async Task CompleteTaskAsync_PreservesExistingFieldsFromFetchedTask()
-    {
-        // Arrange — simulate an existing task with meaningful data
-        var existingTask = new TaskItem
-        {
-            Href = "/calendars/user/tasks/task-7.ics",
-            Uid = "task-7",
-            Summary = "Important task",
-            Description = "Detailed description",
-            Status = CalDavTaskStatus.InProcess,
-            Priority = TaskPriority.High,
-            Due = new DateTimeOffset(2025, 12, 31, 17, 0, 0, TimeSpan.Zero),
-            Categories = ["work", "urgent"],
-            Start = new DateTimeOffset(2025, 6, 1, 9, 0, 0, TimeSpan.Zero),
-            RecurrenceRule = "FREQ=WEEKLY;COUNT=4",
-            ETag = "\"etag-original\""
-        };
-
-        _taskService.GetTaskAsync(existingTask.Href, Arg.Any<CancellationToken>())
-            .Returns(existingTask);
-        _taskService.UpdateTaskAsync(Arg.Any<TaskItem>(), Arg.Any<CancellationToken>())
-            .Returns(ci => ci.ArgAt<TaskItem>(0) with { ETag = "\"etag-done\"" });
-
-        // Act
-        await _sut.CompleteTaskAsync(
-            href: existingTask.Href,
-            etag: null,
-            cancellationToken: CancellationToken.None);
-
-        // Assert — existing fields must be preserved; only Status and Completed change
-        await _taskService.Received(1).UpdateTaskAsync(
-            Arg.Is<TaskItem>(t => MatchesCompletedTaskPreservingExistingFields(t, existingTask)),
-            Arg.Any<CancellationToken>());
-    }
-
-    [Fact]
-    public async Task CompleteTaskAsync_ExplicitEtagOverridesFetchedEtag()
-    {
-        // Arrange
-        var existingTask = new TaskItem
-        {
-            Href = "/calendars/user/tasks/task-7.ics",
-            Uid = "task-7",
-            Summary = "Some task",
-            Status = CalDavTaskStatus.InProcess,
-            ETag = "\"etag-original\""
-        };
-
-        _taskService.GetTaskAsync(existingTask.Href, Arg.Any<CancellationToken>())
-            .Returns(existingTask);
-        _taskService.UpdateTaskAsync(Arg.Any<TaskItem>(), Arg.Any<CancellationToken>())
-            .Returns(ci => ci.ArgAt<TaskItem>(0));
-
-        // Act — caller provides an explicit etag
-        await _sut.CompleteTaskAsync(
-            href: existingTask.Href,
-            etag: "\"etag-caller\"",
-            cancellationToken: CancellationToken.None);
-
-        // Assert — the explicit etag overrides the fetched task's etag
-        await _taskService.Received(1).UpdateTaskAsync(
-            Arg.Is<TaskItem>(t =>
-                t.ETag == "\"etag-caller\"" &&
-                t.Status == CalDavTaskStatus.Completed),
-            Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -736,21 +569,6 @@ public class TaskMutationToolsTests
             Arg.Is<TaskItem>(t => MatchesUpdatedTaskPreservingExistingFields(t, existingTask)),
             Arg.Any<CancellationToken>());
     }
-
-    private static bool MatchesCompletedTaskPreservingExistingFields(TaskItem actual, TaskItem existingTask) =>
-        All(
-            actual.Href == existingTask.Href,
-            actual.Uid == existingTask.Uid,
-            actual.Summary == existingTask.Summary,
-            actual.Description == existingTask.Description,
-            actual.Priority == existingTask.Priority,
-            actual.Due == existingTask.Due,
-            actual.Start == existingTask.Start,
-            actual.Categories.SequenceEqual(existingTask.Categories),
-            actual.RecurrenceRule == existingTask.RecurrenceRule,
-            actual.Status == CalDavTaskStatus.Completed,
-            actual.Completed == FixedNow,
-            actual.ETag == existingTask.ETag);
 
     private static bool MatchesUpdatedTaskPreservingExistingFields(TaskItem actual, TaskItem existingTask) =>
         All(


### PR DESCRIPTION
## Summary

- add an internal transient `TaskCompletion` module that owns completion timestamp, status, ETag selection, persistence, and result forwarding
- route both chat-safe and href-based completion tools through the shared seam while preserving targeting and JSON contracts
- move the completion policy matrix into focused module tests and retain one successful adapter path per tool style

## Verification

- Release build: 0 warnings, 0 errors
- 302 tests passed, including 40 Docker-backed integration tests
- line coverage: 98.2%
- branch coverage: 88.0%
- Slopwatch: 0 issues

Closes #12