### PR TITLE
Add unified calendars list surface

### DIFF
--- a/src/DotnetAgents.CalDav.Core/Abstractions/ICalendarClient.cs
+++ b/src/DotnetAgents.CalDav.Core/Abstractions/ICalendarClient.cs
@@ -1,0 +1,10 @@
+using DotnetAgents.CalDav.Core.Models;
+
+namespace DotnetAgents.CalDav.Core.Abstractions;
+
+/// <summary>Low-level CalDAV discovery client for Calendar collections.</summary>
+public interface ICalendarClient
+{
+    /// <summary>Discovers every Calendar collection visible to the configured account.</summary>
+    Task<IReadOnlyList<CalendarDescriptor>> GetCalendarsAsync(CancellationToken cancellationToken);
+}

--- a/src/DotnetAgents.CalDav.Core/Abstractions/ICalendarService.cs
+++ b/src/DotnetAgents.CalDav.Core/Abstractions/ICalendarService.cs
@@ -1,0 +1,15 @@
+using DotnetAgents.CalDav.Core.Models;
+
+namespace DotnetAgents.CalDav.Core.Abstractions;
+
+/// <summary>High-level Calendar discovery service used by unified MCP tools.</summary>
+public interface ICalendarService
+{
+    /// <summary>Lists the Calendars in the configured Calendar Scope.</summary>
+    Task<CalendarDiscoveryResult> GetCalendarsAsync(CancellationToken cancellationToken);
+
+    /// <summary>Resolves the configured default Calendar for one Entity Kind without fallback.</summary>
+    Task<CalendarSelectionResult> ResolveDefaultCalendarAsync(
+        CalendarEntityKind entityKind,
+        CancellationToken cancellationToken);
+}

--- a/src/DotnetAgents.CalDav.Core/Configuration/CalDavOptions.cs
+++ b/src/DotnetAgents.CalDav.Core/Configuration/CalDavOptions.cs
@@ -25,6 +25,15 @@ public sealed class CalDavOptions
     /// <summary>Display name of the default task list used when no explicit list is specified by the user.</summary>
     public string? DefaultTaskList { get; set; }
 
+    /// <summary>Comma-separated exact canonical Calendar href allowlist. Empty means every discovered Calendar.</summary>
+    public string? CalendarHrefs { get; set; }
+
+    /// <summary>Display name of the default Calendar for To-do operations.</summary>
+    public string? DefaultTodoCalendarName { get; set; }
+
+    /// <summary>Display name of the default Calendar for Event operations.</summary>
+    public string? DefaultEventCalendarName { get; set; }
+
     /// <summary>Optional timeout for HTTP requests. Defaults to 30 seconds.</summary>
     public TimeSpan RequestTimeout { get; set; } = TimeSpan.FromSeconds(30);
 

--- a/src/DotnetAgents.CalDav.Core/DependencyInjection/CalDavServiceCollectionExtensions.cs
+++ b/src/DotnetAgents.CalDav.Core/DependencyInjection/CalDavServiceCollectionExtensions.cs
@@ -1,3 +1,5 @@
+using System.Net;
+using System.Net.Http.Headers;
 using System.Text;
 using DotnetAgents.CalDav.Core.Abstractions;
 using DotnetAgents.CalDav.Core.Configuration;
@@ -8,8 +10,6 @@ using Microsoft.Extensions.Http.Resilience;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Polly;
-using System.Net;
-using System.Net.Http.Headers;
 
 namespace DotnetAgents.CalDav.Core.DependencyInjection;
 
@@ -51,13 +51,13 @@ public static class CalDavServiceCollectionExtensions
         // - PooledConnectionIdleTimeout: close idle connections that Radicale may have already closed
         //
         // Auto-redirect is disabled because CalDAV uses non-standard HTTP methods (PROPFIND, REPORT,
-        // MKCOL) that must be preserved across redirects. SocketsHttpHandler does not follow
-        // redirects by default, so no AllowAutoRedirect setting is needed.
+        // MKCOL) that must be preserved across redirects. Disable automatic redirects explicitly
+        // so a cross-origin Location cannot receive the configured Basic credentials.
         //
         // Standard resilience handler adds retry with exponential backoff (handles HttpRequestException
         // including HttpIOException/ResponseEnded from transient connection drops), circuit breaker,
         // attempt timeout, and total request timeout — all configured via Polly v8 resilience pipeline.
-        services.AddHttpClient<ICalDavClient, CalDavClient>((serviceProvider, client) =>
+        services.AddHttpClient<CalDavClient>((serviceProvider, client) =>
         {
             var options = serviceProvider.GetRequiredService<IOptions<CalDavOptions>>().Value;
             client.BaseAddress = new Uri(options.BaseUrl.TrimEnd('/') + "/");
@@ -71,6 +71,7 @@ public static class CalDavServiceCollectionExtensions
         })
         .ConfigurePrimaryHttpMessageHandler(() => new SocketsHttpHandler
         {
+            AllowAutoRedirect = false,
             AutomaticDecompression = DecompressionMethods.All,
             PooledConnectionLifetime = TimeSpan.FromMinutes(2),
             PooledConnectionIdleTimeout = TimeSpan.FromMinutes(1)
@@ -94,7 +95,11 @@ public static class CalDavServiceCollectionExtensions
             options.CircuitBreaker.SamplingDuration = TimeSpan.FromSeconds(30);
         });
 
-        // ITaskService is transient to match the ICalDavClient typed-client lifetime.
+        services.AddTransient<ICalDavClient>(serviceProvider => serviceProvider.GetRequiredService<CalDavClient>());
+        services.AddTransient<ICalendarClient>(serviceProvider => serviceProvider.GetRequiredService<CalDavClient>());
+        services.AddTransient<ICalendarService, CalendarService>();
+
+        // ITaskService is retained internally during the staged 0.2.0 replacement.
         services.AddTransient<ITaskService, TaskService>();
         services.AddSingleton<ITaskListResolver, TaskListResolver>();
 

--- a/src/DotnetAgents.CalDav.Core/Internal/CalDavClient.cs
+++ b/src/DotnetAgents.CalDav.Core/Internal/CalDavClient.cs
@@ -17,7 +17,7 @@ namespace DotnetAgents.CalDav.Core.Internal;
 /// HttpClient-based CalDAV client focused on VTODO operations.
 /// Handles PROPFIND, REPORT, GET, PUT, DELETE verbs with XML/iCalendar encoding.
 /// </summary>
-internal sealed class CalDavClient : ICalDavClient
+internal sealed class CalDavClient : ICalDavClient, ICalendarClient
 {
     private static readonly ActivitySource ActivitySource = new("DotnetAgents.CalDav", "0.1.0");
     private static readonly HttpMethod PropFindMethod = new("PROPFIND");
@@ -51,9 +51,9 @@ internal sealed class CalDavClient : ICalDavClient
 
         // Step 2: PROPFIND the calendar-home-set to list calendars (Depth: 1 to return child collections)
         var propfindBody = DavRequestBuilder.BuildPropFindCalendarProperties();
-        var responseXml = await SendPropFindAsync(homeSetHref, propfindBody, depth: 1, cancellationToken);
+        var response = await SendPropFindAsync(homeSetHref, propfindBody, depth: 1, cancellationToken);
 
-        var taskLists = DavResponseParser.ParseTaskLists(responseXml);
+        var taskLists = DavResponseParser.ParseTaskLists(response.Content);
 
         // Step 3: Filter to only calendars supporting VTODO
         var filtered = taskLists
@@ -70,6 +70,37 @@ internal sealed class CalDavClient : ICalDavClient
 
         _logger.LogInformation("Discovered {Count} task list(s)", filtered.Count);
         return filtered;
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<CalendarDescriptor>> GetCalendarsAsync(CancellationToken cancellationToken)
+    {
+        using var activity = ActivitySource.StartActivity("caldav.get_calendars", ActivityKind.Client);
+
+        var homeSetHref = await DiscoverCalendarHomeSetAsync(cancellationToken, failOnNotFound: true);
+        if (homeSetHref is null)
+            return [];
+
+        var configuredBaseUri = new Uri(_options.Value.BaseUrl, UriKind.Absolute);
+        if (!TryCanonicalizeCalendarHref(configuredBaseUri, homeSetHref, out var canonicalHomeSetHref))
+            throw new CalendarDiscoveryProtocolException("Unsafe calendar-home-set href.");
+
+        var propfindBody = DavRequestBuilder.BuildPropFindCalendarProperties();
+        var response = await SendPropFindAsync(canonicalHomeSetHref, propfindBody, depth: 1, cancellationToken);
+        var homeSetUri = response.RequestUri;
+
+        var calendars = new List<CalendarDescriptor>();
+        foreach (var calendar in DavResponseParser.ParseCalendars(response.Content))
+        {
+            if (TryCanonicalizeCalendarHref(homeSetUri, calendar.Href, out var canonicalHref))
+                calendars.Add(calendar with { Href = canonicalHref });
+            else
+                throw new CalendarDiscoveryProtocolException("Unsafe Calendar href.");
+        }
+
+        return calendars
+            .OrderBy(calendar => calendar.Href, StringComparer.Ordinal)
+            .ToArray();
     }
 
     /// <inheritdoc/>
@@ -271,47 +302,61 @@ internal sealed class CalDavClient : ICalDavClient
         throw new CalDavConflictException(href, currentEtag);
     }
 
-    private async Task<string?> DiscoverCalendarHomeSetAsync(CancellationToken cancellationToken)
+    private async Task<string?> DiscoverCalendarHomeSetAsync(CancellationToken cancellationToken, bool failOnNotFound = false)
     {
         var principalBody = DavRequestBuilder.BuildPropFindCalendarHomeSet();
         var principalHref = "/.well-known/caldav";
 
-        var wellKnownResult = await TryDiscoverFromPathAsync(principalHref, principalBody, depth: 0, cancellationToken);
+        var suppressUpstreamFailures = !failOnNotFound;
+        var wellKnownResult = await TryDiscoverFromPathAsync(principalHref, principalBody, depth: 0, cancellationToken, suppressUpstreamFailures);
         if (wellKnownResult.HomeSet is not null)
             return wellKnownResult.HomeSet;
 
         if (wellKnownResult.PrincipalUrl is null)
         {
-            var baseUrlResult = await TryDiscoverFromBaseUrlAsync(principalBody, depth: 0, cancellationToken);
+            var baseUrlResult = await TryDiscoverFromBaseUrlAsync(principalBody, depth: 0, cancellationToken, suppressUpstreamFailures);
             if (baseUrlResult.HomeSet is not null)
                 return baseUrlResult.HomeSet;
 
             if (baseUrlResult.PrincipalUrl is null)
             {
                 _logger.LogWarning("Failed to discover calendar-home-set from {BaseUrl}", _options.Value.BaseUrl);
+                if (failOnNotFound)
+                    throw new CalendarDiscoveryProtocolException("Calendar-home-set was not discovered.");
                 return null;
             }
 
             wellKnownResult = baseUrlResult;
         }
 
-        return await TryDiscoverFromPrincipalAsync(wellKnownResult.PrincipalUrl!, principalBody, depth: 0, cancellationToken);
+        var discoveredHomeSet = await TryDiscoverFromPrincipalAsync(wellKnownResult.PrincipalUrl!, principalBody, depth: 0, cancellationToken, suppressUpstreamFailures);
+        if (discoveredHomeSet is null && failOnNotFound)
+            throw new CalendarDiscoveryProtocolException("Calendar-home-set was not discovered.");
+        return discoveredHomeSet;
     }
 
     private async Task<(string? HomeSet, string? PrincipalUrl)> TryDiscoverFromPathAsync(
-        string path, string body, int depth, CancellationToken cancellationToken)
+        string path, string body, int depth, CancellationToken cancellationToken, bool suppressUpstreamFailures)
     {
         try
         {
-            var responseXml = await SendPropFindAsync(path, body, depth, cancellationToken);
-            var homeSet = DavResponseParser.ParseCalendarHomeSet(responseXml);
+            var response = await SendPropFindAsync(path, body, depth, cancellationToken);
+            var homeSet = DavResponseParser.ParseCalendarHomeSet(response.Content);
             if (homeSet is not null)
-                return (homeSet, null);
+            {
+                if (!TryCanonicalizeCalendarHref(response.RequestUri, homeSet, out var canonicalHomeSet))
+                    throw new CalendarDiscoveryProtocolException("Unsafe calendar-home-set href.");
+                return (canonicalHomeSet, null);
+            }
 
-            var principalUrl = DavResponseParser.ParseCurrentUserPrincipal(responseXml);
-            return (null, principalUrl);
+            var principalUrl = DavResponseParser.ParseCurrentUserPrincipal(response.Content);
+            if (principalUrl is null)
+                return (null, null);
+            if (!TryCanonicalizeCalendarHref(response.RequestUri, principalUrl, out var canonicalPrincipal))
+                throw new CalendarDiscoveryProtocolException("Unsafe current-user-principal href.");
+            return (null, canonicalPrincipal);
         }
-        catch (HttpRequestException)
+        catch (HttpRequestException exception) when (suppressUpstreamFailures || exception.StatusCode == HttpStatusCode.NotFound)
         {
             _logger.LogDebug("CalDAV path not found: {Path}", path);
             return (null, null);
@@ -319,40 +364,50 @@ internal sealed class CalDavClient : ICalDavClient
     }
 
     private async Task<(string? HomeSet, string? PrincipalUrl)> TryDiscoverFromBaseUrlAsync(
-        string body, int depth, CancellationToken cancellationToken)
+        string body, int depth, CancellationToken cancellationToken, bool suppressUpstreamFailures)
     {
         var baseUrl = _options.Value.BaseUrl.TrimEnd('/');
         var uri = new Uri(baseUrl);
         var path = uri.AbsolutePath.TrimEnd('/') + "/";
-        return await TryDiscoverFromPathAsync(path, body, depth, cancellationToken);
+        return await TryDiscoverFromPathAsync(path, body, depth, cancellationToken, suppressUpstreamFailures);
     }
 
     private async Task<string?> TryDiscoverFromPrincipalAsync(
-        string principalUrl, string body, int depth, CancellationToken cancellationToken)
+        string principalUrl, string body, int depth, CancellationToken cancellationToken, bool suppressUpstreamFailures)
     {
         try
         {
             _logger.LogDebug("PROPFIND principal at {PrincipalUrl} for calendar-home-set", principalUrl);
-            var responseXml = await SendPropFindAsync(principalUrl, body, depth, cancellationToken);
-            return DavResponseParser.ParseCalendarHomeSet(responseXml);
+            var response = await SendPropFindAsync(principalUrl, body, depth, cancellationToken);
+            var homeSet = DavResponseParser.ParseCalendarHomeSet(response.Content);
+            if (homeSet is null)
+                return null;
+            if (!TryCanonicalizeCalendarHref(response.RequestUri, homeSet, out var canonicalHomeSet))
+                throw new CalendarDiscoveryProtocolException("Unsafe calendar-home-set href.");
+            return canonicalHomeSet;
         }
-        catch (HttpRequestException ex)
+        catch (HttpRequestException ex) when (suppressUpstreamFailures || ex.StatusCode == HttpStatusCode.NotFound)
         {
             _logger.LogWarning(ex, "Failed to discover calendar-home-set from principal at {PrincipalUrl}", principalUrl);
             return null;
         }
     }
 
-    private async Task<string> SendPropFindAsync(string href, string body, int depth, CancellationToken cancellationToken)
+    private async Task<(string Content, Uri RequestUri)> SendPropFindAsync(string href, string body, int depth, CancellationToken cancellationToken)
     {
-        var request = new HttpRequestMessage(PropFindMethod, BuildUrl(href))
+        if (!TryCanonicalizeCalendarHref(new Uri(_options.Value.BaseUrl, UriKind.Absolute), href, out var canonicalHref))
+            throw new CalendarDiscoveryProtocolException("Unsafe CalDAV discovery href.");
+
+        var request = new HttpRequestMessage(PropFindMethod, canonicalHref)
         {
             Content = new StringContent(body, Encoding.UTF8, "application/xml")
         };
         request.Headers.Add("Depth", depth.ToString(CultureInfo.InvariantCulture));
 
-        var response = await SendWithRedirectHandlingAsync(request, body, cancellationToken);
-        return await response.Content.ReadAsStringAsync(cancellationToken);
+        using var response = await SendWithRedirectHandlingAsync(request, body, cancellationToken);
+        var requestUri = response.RequestMessage?.RequestUri ?? new Uri(canonicalHref, UriKind.Absolute);
+        var content = await response.Content.ReadAsStringAsync(cancellationToken);
+        return (content, requestUri);
     }
 
     private async Task<string> SendReportAsync(string href, string body, CancellationToken cancellationToken)
@@ -363,7 +418,7 @@ internal sealed class CalDavClient : ICalDavClient
         };
         request.Headers.Add("Depth", "1");
 
-        var response = await SendWithRedirectHandlingAsync(request, body, cancellationToken);
+        using var response = await SendWithRedirectHandlingAsync(request, body, cancellationToken);
         return await response.Content.ReadAsStringAsync(cancellationToken);
     }
 
@@ -374,7 +429,7 @@ internal sealed class CalDavClient : ICalDavClient
     /// like PROPFIND and REPORT must be preserved across redirects.
     /// </summary>
     private async Task<HttpResponseMessage> SendWithRedirectHandlingAsync(
-        HttpRequestMessage originalRequest, string body, CancellationToken cancellationToken, int maxRedirects = 3)
+        HttpRequestMessage originalRequest, string body, CancellationToken cancellationToken, int maxRedirects = 5)
     {
         HttpResponseMessage? response = null;
         var currentRequest = originalRequest;
@@ -389,25 +444,56 @@ internal sealed class CalDavClient : ICalDavClient
             response?.Dispose();
             response = await _httpClient.SendAsync(currentRequest, cancellationToken);
 
-            var redirectUrl = GetRedirectUrl(response, currentRequest.RequestUri);
-            if (redirectUrl is null)
+            var redirectRequest = CreateRedirectRequest(response, currentRequest, method, body, contentType, depthValues, attempt, maxRedirects);
+            if (redirectRequest is null)
                 break;
-
-            _logger.LogDebug("{Method} redirect {StatusCode} -> {RedirectUrl}", method, (int)response.StatusCode, redirectUrl);
-
-            currentRequest = new HttpRequestMessage(method, redirectUrl)
-            {
-                Content = new StringContent(body, Encoding.UTF8, contentType)
-            };
-
-            foreach (var depthValue in depthValues)
-            {
-                currentRequest.Headers.Add("Depth", depthValue);
-            }
+            currentRequest = redirectRequest;
         }
 
-        response!.EnsureSuccessStatusCode();
+        try
+        {
+            response!.EnsureSuccessStatusCode();
+        }
+        catch
+        {
+            response!.Dispose();
+            throw;
+        }
         return response;
+    }
+
+    private HttpRequestMessage? CreateRedirectRequest(
+        HttpResponseMessage response,
+        HttpRequestMessage currentRequest,
+        HttpMethod method,
+        string body,
+        string contentType,
+        IReadOnlyList<string> depthValues,
+        int attempt,
+        int maxRedirects)
+    {
+        var redirectUrl = GetRedirectUrl(response, currentRequest.RequestUri);
+        if (redirectUrl is null)
+            return null;
+        if (attempt == maxRedirects)
+        {
+            response.Dispose();
+            throw new CalendarDiscoveryProtocolException("CalDAV redirect limit was exceeded.");
+        }
+        if (!TryCanonicalizeCalendarHref(new Uri(_options.Value.BaseUrl, UriKind.Absolute), redirectUrl, out var canonicalRedirectUrl))
+        {
+            response.Dispose();
+            throw new CalendarDiscoveryProtocolException("Unsafe CalDAV redirect href.");
+        }
+
+        _logger.LogDebug("{Method} redirect {StatusCode} within the configured origin", method, (int)response.StatusCode);
+        var redirectRequest = new HttpRequestMessage(method, canonicalRedirectUrl)
+        {
+            Content = new StringContent(body, Encoding.UTF8, contentType)
+        };
+        foreach (var depthValue in depthValues)
+            redirectRequest.Headers.Add("Depth", depthValue);
+        return redirectRequest;
     }
 
     private static string? GetRedirectUrl(HttpResponseMessage response, Uri? requestUri)
@@ -452,6 +538,29 @@ internal sealed class CalDavClient : ICalDavClient
         var baseWithPath = new Uri(baseUri, baseUri.AbsolutePath.TrimEnd('/') + "/");
         var resolved = new Uri(baseWithPath, href);
         return resolved.AbsoluteUri;
+    }
+
+    private bool TryCanonicalizeCalendarHref(Uri homeSetUri, string href, out string canonicalHref)
+    {
+        canonicalHref = string.Empty;
+        if (!Uri.TryCreate(homeSetUri, href, out var candidate)
+            || !candidate.IsAbsoluteUri
+            || !string.IsNullOrEmpty(candidate.UserInfo)
+            || !string.IsNullOrEmpty(candidate.Fragment))
+        {
+            return false;
+        }
+
+        var configuredBaseUri = new Uri(_options.Value.BaseUrl, UriKind.Absolute);
+        if (!string.Equals(candidate.Scheme, configuredBaseUri.Scheme, StringComparison.OrdinalIgnoreCase)
+            || !string.Equals(candidate.Host, configuredBaseUri.Host, StringComparison.OrdinalIgnoreCase)
+            || candidate.Port != configuredBaseUri.Port)
+        {
+            return false;
+        }
+
+        canonicalHref = candidate.AbsoluteUri;
+        return true;
     }
 
     private static bool MatchesQuery(TaskItem task, TaskQuery query)

--- a/src/DotnetAgents.CalDav.Core/Internal/Xml/DavRequestBuilder.cs
+++ b/src/DotnetAgents.CalDav.Core/Internal/Xml/DavRequestBuilder.cs
@@ -37,7 +37,8 @@ internal static class DavRequestBuilder
                     new XElement(Dav + "displayname"),
                     new XElement(Dav + "resourcetype"),
                     new XElement(CalDav + "supported-calendar-component-set"),
-                    new XElement(Dav + "description", new XAttribute(XNamespace.Xmlns + "d", Dav.NamespaceName)),
+                    new XElement(CalDav + "calendar-description"),
+                    new XElement(Dav + "description"),
                     new XElement(AppleCs + "calendar-color"),
                     new XElement(CalServer + "getctag")
                 )

--- a/src/DotnetAgents.CalDav.Core/Internal/Xml/DavResponseParser.cs
+++ b/src/DotnetAgents.CalDav.Core/Internal/Xml/DavResponseParser.cs
@@ -22,6 +22,16 @@ internal static class DavResponseParser
             .ToList();
     }
 
+    /// <summary>Parses every discovered Calendar collection with independent component evidence.</summary>
+    public static IReadOnlyList<CalendarDescriptor> ParseCalendars(string multistatusXml)
+    {
+        var doc = XDocument.Parse(multistatusXml);
+        return doc.Descendants(Dav + "response")
+            .Select(TryParseCalendar)
+            .OfType<CalendarDescriptor>()
+            .ToList();
+    }
+
     /// <summary>Parses a multistatus response to extract the calendar-home-set URL.</summary>
     public static string? ParseCalendarHomeSet(string multistatusXml)
     {
@@ -76,6 +86,37 @@ internal static class DavResponseParser
         };
     }
 
+    private static CalendarDescriptor? TryParseCalendar(XElement response)
+    {
+        var href = response.Element(Dav + "href")?.Value?.Trim() ?? string.Empty;
+        if (string.IsNullOrEmpty(href) || !IsCalendarCollection(response))
+            return null;
+
+        var displayNameProperty = GetSuccessfulProperty(response, Dav + "displayname");
+        var displayName = displayNameProperty?.Value.Trim();
+        var (name, provenance) = GetDisplayName(displayName, href, displayNameProperty is not null);
+        var componentsProperty = GetSuccessfulProperty(response, CalDav + "supported-calendar-component-set");
+        var components = componentsProperty is null
+            ? []
+            : componentsProperty.Descendants(CalDav + "comp")
+                .Select(component => component.Attribute("name")?.Value)
+                .OfType<string>()
+                .ToArray();
+
+        return new CalendarDescriptor
+        {
+            Href = href,
+            DisplayName = name,
+            DisplayNameProvenance = provenance,
+            Description = GetPropValue(response, CalDav + "calendar-description"),
+            Color = GetPropValue(response, AppleCs + "calendar-color"),
+            EventSupport = GetComponentSupport(componentsProperty, components, "VEVENT"),
+            TodoSupport = GetComponentSupport(componentsProperty, components, "VTODO"),
+            EventEvidence = GetComponentEvidence(componentsProperty, components),
+            TodoEvidence = GetComponentEvidence(componentsProperty, components)
+        };
+    }
+
     private static (string Href, string? ETag, string ICalData)? TryParseCalendarDataResponse(XElement response)
     {
         var href = response.Element(Dav + "href")?.Value?.Trim() ?? string.Empty;
@@ -105,6 +146,46 @@ internal static class DavResponseParser
         GetPropValue(response, Dav + "displayname")
         ?? href.TrimEnd('/').Split('/').Last();
 
+    private static (string? Name, DisplayNameProvenance Provenance) GetDisplayName(
+        string? displayName,
+        string href,
+        bool displayNameWasPresent)
+    {
+        if (!string.IsNullOrWhiteSpace(displayName))
+            return (displayName, DisplayNameProvenance.DavDisplayName);
+
+        if (displayNameWasPresent)
+            return (null, DisplayNameProvenance.Missing);
+
+        var derivedName = href.TrimEnd('/').Split('/').LastOrDefault();
+        return string.IsNullOrWhiteSpace(derivedName)
+            ? (null, DisplayNameProvenance.Missing)
+            : (derivedName, DisplayNameProvenance.DerivedFromHref);
+    }
+
+    private static EntityKindSupport GetComponentSupport(
+        XElement? componentsProperty,
+        IReadOnlyCollection<string> components,
+        string componentName)
+    {
+        if (componentsProperty is null)
+            return EntityKindSupport.Unknown;
+
+        return components.Contains(componentName, StringComparer.OrdinalIgnoreCase)
+            ? EntityKindSupport.Advertised
+            : EntityKindSupport.NotAdvertised;
+    }
+
+    private static IReadOnlyList<CapabilityEvidence> GetComponentEvidence(
+        XElement? componentsProperty,
+        IReadOnlyCollection<string> components)
+    {
+        if (componentsProperty is null)
+            return [];
+
+        return [new CapabilityEvidence("supported-calendar-component-set", string.Join(',', components))];
+    }
+
     private static bool HasSuccessStatus(XElement response)
     {
         var status = response.Element(Dav + "status")?.Value;
@@ -112,6 +193,11 @@ internal static class DavResponseParser
     }
 
     private static string? GetPropValue(XElement response, XName propertyName)
+    {
+        return GetSuccessfulProperty(response, propertyName)?.Value;
+    }
+
+    private static XElement? GetSuccessfulProperty(XElement response, XName propertyName)
     {
         var propStats = response.Descendants(Dav + "propstat");
         foreach (var propStat in propStats)
@@ -121,7 +207,7 @@ internal static class DavResponseParser
             {
                 var prop = propStat.Element(Dav + "prop")?.Element(propertyName);
                 if (prop is not null)
-                    return prop.Value;
+                    return prop;
             }
         }
 

--- a/src/DotnetAgents.CalDav.Core/Models/CalendarDescriptor.cs
+++ b/src/DotnetAgents.CalDav.Core/Models/CalendarDescriptor.cs
@@ -1,0 +1,45 @@
+namespace DotnetAgents.CalDav.Core.Models;
+
+/// <summary>Describes one discovered CalDAV Calendar collection.</summary>
+public sealed record CalendarDescriptor
+{
+    /// <summary>Canonical absolute href that identifies the Calendar.</summary>
+    public required string Href { get; init; }
+
+    /// <summary>Server-provided or href-derived display name; never identity.</summary>
+    public string? DisplayName { get; init; }
+
+    /// <summary>Explains how <see cref="DisplayName"/> was obtained.</summary>
+    public required DisplayNameProvenance DisplayNameProvenance { get; init; }
+
+    public string? Description { get; init; }
+
+    public string? Color { get; init; }
+
+    public required EntityKindSupport EventSupport { get; init; }
+
+    public required EntityKindSupport TodoSupport { get; init; }
+
+    public IReadOnlyList<CapabilityEvidence> EventEvidence { get; init; } = [];
+
+    public IReadOnlyList<CapabilityEvidence> TodoEvidence { get; init; } = [];
+}
+
+/// <summary>Provenance for a Calendar display name.</summary>
+public enum DisplayNameProvenance
+{
+    DavDisplayName,
+    DerivedFromHref,
+    Missing
+}
+
+/// <summary>Advertisement state for one Calendar Entity Kind.</summary>
+public enum EntityKindSupport
+{
+    Advertised,
+    NotAdvertised,
+    Unknown
+}
+
+/// <summary>Raw standards discovery evidence for a capability state.</summary>
+public sealed record CapabilityEvidence(string Source, string Value);

--- a/src/DotnetAgents.CalDav.Core/Models/CalendarDiscoveryResult.cs
+++ b/src/DotnetAgents.CalDav.Core/Models/CalendarDiscoveryResult.cs
@@ -1,0 +1,55 @@
+namespace DotnetAgents.CalDav.Core.Models;
+
+/// <summary>Scoped Calendar discovery result returned by the Calendar service.</summary>
+public sealed record CalendarDiscoveryResult(
+    IReadOnlyList<CalendarDescriptor> Items,
+    IReadOnlyList<CalendarDiagnostic> Diagnostics);
+
+/// <summary>Bounded, non-sensitive discovery diagnostic.</summary>
+public sealed record CalendarDiagnostic(string Code, string Message, CalendarDiagnosticSeverity Severity);
+
+/// <summary>Severity of a Calendar discovery diagnostic.</summary>
+public enum CalendarDiagnosticSeverity
+{
+    Info,
+    Warning,
+    Error
+}
+
+/// <summary>Calendar Entity Kind used for independent default selection.</summary>
+public enum CalendarEntityKind
+{
+    Event,
+    Todo
+}
+
+/// <summary>Signals that Calendar discovery exceeded the bounded admission limit.</summary>
+public sealed class CalendarDiscoveryLimitException(int calendarCount) : Exception
+{
+    public int CalendarCount { get; } = calendarCount;
+}
+
+/// <summary>Signals a CalDAV discovery response that cannot be used safely.</summary>
+public sealed class CalendarDiscoveryProtocolException(string message) : Exception(message);
+
+/// <summary>Typed outcome of resolving a configured default Calendar.</summary>
+public sealed record CalendarSelectionResult(
+    CalendarSelectionCode Code,
+    CalendarDescriptor? Calendar,
+    IReadOnlyList<CalendarDescriptor> Candidates)
+{
+    public static CalendarSelectionResult Success(CalendarDescriptor calendar) => new(CalendarSelectionCode.Success, calendar, []);
+
+    public static CalendarSelectionResult Failure(CalendarSelectionCode code, IReadOnlyList<CalendarDescriptor>? candidates = null) =>
+        new(code, null, candidates ?? []);
+}
+
+/// <summary>Closed selection result codes available to Calendar default resolution.</summary>
+public enum CalendarSelectionCode
+{
+    Success,
+    NotFound,
+    Ambiguous,
+    OutsideScope,
+    UnsupportedCapability
+}

--- a/src/DotnetAgents.CalDav.Core/Services/CalendarService.cs
+++ b/src/DotnetAgents.CalDav.Core/Services/CalendarService.cs
@@ -1,0 +1,138 @@
+using DotnetAgents.CalDav.Core.Abstractions;
+using DotnetAgents.CalDav.Core.Configuration;
+using DotnetAgents.CalDav.Core.Models;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace DotnetAgents.CalDav.Core.Services;
+
+/// <summary>Applies configured Calendar Scope to standards-based Calendar discovery.</summary>
+internal sealed class CalendarService : ICalendarService
+{
+    private const int MaximumDiagnostics = 32;
+    private const int MaximumCalendars = 256;
+    private readonly ICalendarClient _calendarClient;
+    private readonly IOptions<CalDavOptions> _options;
+    private readonly ILogger<CalendarService> _logger;
+
+    public CalendarService(
+        ICalendarClient calendarClient,
+        IOptions<CalDavOptions> options,
+        ILogger<CalendarService> logger)
+    {
+        _calendarClient = calendarClient;
+        _options = options;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task<CalendarDiscoveryResult> GetCalendarsAsync(CancellationToken cancellationToken)
+    {
+        var discovered = await _calendarClient.GetCalendarsAsync(cancellationToken);
+        return ApplyScope(discovered);
+    }
+
+    /// <inheritdoc />
+    public async Task<CalendarSelectionResult> ResolveDefaultCalendarAsync(
+        CalendarEntityKind entityKind,
+        CancellationToken cancellationToken)
+    {
+        var discovered = await _calendarClient.GetCalendarsAsync(cancellationToken);
+        var scoped = ApplyScope(discovered).Items;
+        var authorizedCandidates = scoped.Take(MaximumDiagnostics).ToArray();
+        var name = GetDefaultName(entityKind);
+        if (string.IsNullOrWhiteSpace(name))
+            return CalendarSelectionResult.Failure(CalendarSelectionCode.NotFound, authorizedCandidates);
+
+        var normalizedName = name.Trim();
+        var matchingDiscovered = discovered.Where(calendar =>
+            string.Equals(calendar.DisplayName?.Trim(), normalizedName, StringComparison.OrdinalIgnoreCase)).ToArray();
+        if (matchingDiscovered.Length == 0)
+            return CalendarSelectionResult.Failure(CalendarSelectionCode.NotFound, authorizedCandidates);
+
+        var matchingScoped = scoped.Where(calendar =>
+            string.Equals(calendar.DisplayName?.Trim(), normalizedName, StringComparison.OrdinalIgnoreCase)).ToArray();
+        if (matchingScoped.Length == 0)
+            return CalendarSelectionResult.Failure(CalendarSelectionCode.OutsideScope, authorizedCandidates);
+
+        if (matchingScoped.Length > 1)
+            return CalendarSelectionResult.Failure(CalendarSelectionCode.Ambiguous, matchingScoped.Take(MaximumDiagnostics).ToArray());
+
+        return SupportsEntityKind(matchingScoped[0], entityKind)
+            ? CalendarSelectionResult.Success(matchingScoped[0])
+            : CalendarSelectionResult.Failure(CalendarSelectionCode.UnsupportedCapability, matchingScoped);
+    }
+
+    private CalendarDiscoveryResult ApplyScope(IReadOnlyList<CalendarDescriptor> discovered)
+    {
+        var scope = ParseScope(_options.Value.CalendarHrefs);
+        var scopedHrefs = scope.ToHashSet(StringComparer.Ordinal);
+        var uniqueDiscovered = discovered
+            .GroupBy(calendar => calendar.Href, StringComparer.Ordinal)
+            .Select(group => group.First())
+            .ToArray();
+        if (uniqueDiscovered.Length > MaximumCalendars)
+            throw new CalendarDiscoveryLimitException(uniqueDiscovered.Length);
+
+        var scopedItems = scopedHrefs.Count == 0
+            ? uniqueDiscovered
+            : uniqueDiscovered.Where(calendar => scopedHrefs.Contains(calendar.Href)).ToArray();
+        var uniqueItems = scopedItems
+            .GroupBy(calendar => calendar.Href, StringComparer.Ordinal)
+            .Select(group => group.First())
+            .OrderBy(calendar => calendar.Href, StringComparer.Ordinal)
+            .ToArray();
+        var diagnostics = BuildDiagnostics(scope, discovered, MaximumDiagnostics);
+        var items = uniqueItems;
+
+        _logger.LogDebug("Discovered {DiscoveredCount} Calendar(s), {InScopeCount} in scope", discovered.Count, items.Length);
+        return new CalendarDiscoveryResult(items, diagnostics);
+    }
+
+    private string? GetDefaultName(CalendarEntityKind entityKind) => entityKind switch
+    {
+        CalendarEntityKind.Event => _options.Value.DefaultEventCalendarName,
+        CalendarEntityKind.Todo => _options.Value.DefaultTodoCalendarName,
+        _ => null
+    };
+
+    private static bool SupportsEntityKind(CalendarDescriptor calendar, CalendarEntityKind entityKind) => entityKind switch
+    {
+        CalendarEntityKind.Event => calendar.EventSupport != EntityKindSupport.NotAdvertised,
+        CalendarEntityKind.Todo => calendar.TodoSupport != EntityKindSupport.NotAdvertised,
+        _ => false
+    };
+
+    private static IReadOnlyList<string> ParseScope(string? calendarHrefs) =>
+        calendarHrefs is null
+            ? []
+            : calendarHrefs.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .ToArray();
+
+    private static IReadOnlyList<CalendarDiagnostic> BuildDiagnostics(
+        IReadOnlyList<string> scope,
+        IReadOnlyList<CalendarDescriptor> discovered,
+        int maximumDiagnostics)
+    {
+        if (scope.Count == 0)
+            return [];
+
+        var duplicateHrefs = scope.GroupBy(href => href, StringComparer.Ordinal)
+            .Where(group => group.Count() > 1)
+            .Select(group => group.Key);
+        var discoveredHrefs = discovered.Select(calendar => calendar.Href).ToHashSet(StringComparer.Ordinal);
+        var missingHrefs = scope.Where(href => !discoveredHrefs.Contains(href))
+            .Distinct(StringComparer.Ordinal);
+
+        return duplicateHrefs.Select(_ => CreateDuplicateDiagnostic())
+            .Concat(missingHrefs.Select(_ => CreateMissingDiagnostic()))
+            .Take(maximumDiagnostics)
+            .ToArray();
+    }
+
+    private static CalendarDiagnostic CreateDuplicateDiagnostic() =>
+        new("duplicate_calendar_href", "A Calendar href is configured more than once.", CalendarDiagnosticSeverity.Warning);
+
+    private static CalendarDiagnostic CreateMissingDiagnostic() =>
+        new("calendar_href_not_found", "A configured Calendar href was not discovered.", CalendarDiagnosticSeverity.Warning);
+}

--- a/src/DotnetAgents.CalDav.Mcp/.mcp/server.json
+++ b/src/DotnetAgents.CalDav.Mcp/.mcp/server.json
@@ -31,6 +31,21 @@
           "isSecret": true
         },
         {
+          "name": "CALDAV_CALENDAR_HREFS",
+          "description": "Comma-separated exact canonical Calendar href allowlist (optional; omit to discover every Calendar)",
+          "isRequired": false
+        },
+        {
+          "name": "CALDAV_DEFAULT_TODO_CALENDAR_NAME",
+          "description": "Display name of the default Calendar for To-do operations (optional)",
+          "isRequired": false
+        },
+        {
+          "name": "CALDAV_DEFAULT_EVENT_CALENDAR_NAME",
+          "description": "Display name of the default Calendar for Event operations (optional)",
+          "isRequired": false
+        },
+        {
           "name": "CALDAV_TASK_LISTS",
           "description": "Comma-separated list of task list hrefs to expose (optional; omit to auto-discover)",
           "isRequired": false

--- a/src/DotnetAgents.CalDav.Mcp/DotnetAgents.CalDav.Mcp.csproj
+++ b/src/DotnetAgents.CalDav.Mcp/DotnetAgents.CalDav.Mcp.csproj
@@ -22,6 +22,7 @@
 
   <ItemGroup>
     <None Include="../../README.md" Pack="true" PackagePath="\" />
+    <EmbeddedResource Include="../../contracts/0.2.0/mcp-tool-catalog.json" LogicalName="DotnetAgents.CalDav.Mcp.CalendarToolCatalog.json" />
     <None Include=".mcp/server.json" Pack="true" PackagePath=".mcp/server.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/src/DotnetAgents.CalDav.Mcp/Hosting/CalDavEnvironmentMapper.cs
+++ b/src/DotnetAgents.CalDav.Mcp/Hosting/CalDavEnvironmentMapper.cs
@@ -10,9 +10,7 @@ namespace DotnetAgents.CalDav.Mcp.Hosting;
 public static class CalDavEnvironmentMapper
 {
     /// <summary>
-    /// Creates a configure action that reads CALDAV_URL, CALDAV_USERNAME,
-    /// CALDAV_PASSWORD, CALDAV_TASK_LISTS, and CALDAV_DEFAULT_TASK_LIST
-    /// from environment variables.
+    /// Creates a configure action that reads the 0.2.0 Calendar and legacy task environment variables.
     /// </summary>
     /// <param name="envProvider">
     /// Override for environment variable access. Defaults to <see cref="Environment.GetEnvironmentVariable"/>.
@@ -26,6 +24,9 @@ public static class CalDavEnvironmentMapper
             options.BaseUrl = getEnv("CALDAV_URL") ?? string.Empty;
             options.Username = getEnv("CALDAV_USERNAME") ?? string.Empty;
             options.Password = getEnv("CALDAV_PASSWORD") ?? string.Empty;
+            options.CalendarHrefs = getEnv("CALDAV_CALENDAR_HREFS");
+            options.DefaultTodoCalendarName = getEnv("CALDAV_DEFAULT_TODO_CALENDAR_NAME");
+            options.DefaultEventCalendarName = getEnv("CALDAV_DEFAULT_EVENT_CALENDAR_NAME");
             options.TaskLists = getEnv("CALDAV_TASK_LISTS");
             options.DefaultTaskList = getEnv("CALDAV_DEFAULT_TASK_LIST");
         };

--- a/src/DotnetAgents.CalDav.Mcp/Hosting/CalDavHostBuilder.cs
+++ b/src/DotnetAgents.CalDav.Mcp/Hosting/CalDavHostBuilder.cs
@@ -4,6 +4,7 @@ using DotnetAgents.CalDav.Mcp.Tools;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace DotnetAgents.CalDav.Mcp.Hosting;
 
@@ -18,19 +19,16 @@ public sealed class CalDavHostBuilder
     /// The caller must configure <see cref="CalDavOptions"/> via <see cref="ConfigureCalDav"/>
     /// before calling <see cref="HostApplicationBuilder.Build"/>.
     /// </summary>
-    /// <param name="exposeAdvancedTools">
-    /// When <c>true</c>, registers all tool classes including <see cref="TaskQueryTools"/> and
-    /// <see cref="TaskMutationTools"/> (href-based, advanced tools). When <c>false</c> (default),
-    /// registers only chat-safe tools: <see cref="TaskListTools"/> and <see cref="ChatTaskTools"/>.
-    /// </param>
+    /// <param name="exposeAdvancedTools">Whether to retain the existing legacy href-based tool surface.</param>
     public static HostApplicationBuilder CreateBuilder(bool exposeAdvancedTools = false)
     {
         var builder = Host.CreateApplicationBuilder();
 
         builder.Logging.ClearProviders();
 
-        var mcpBuilder = builder.Services.AddMcpServer()
+        var mcpBuilder = builder.Services.AddMcpServer(options => options.ProtocolVersion = "2026-07-28")
             .WithStdioServerTransport()
+            .WithTools<CalendarTools>()
             .WithTools<TaskListTools>()
             .WithTools<ChatTaskTools>();
 
@@ -41,10 +39,26 @@ public sealed class CalDavHostBuilder
                 .WithTools<TaskMutationTools>();
         }
 
+        builder.Services.PostConfigure<ModelContextProtocol.Server.McpServerOptions>(ConfigureCalendarToolContract);
+
         builder.Services.AddSingleton(TimeProvider.System);
         builder.Services.AddTransient<TaskCompletion>();
 
         return builder;
+    }
+
+    private static void ConfigureCalendarToolContract(ModelContextProtocol.Server.McpServerOptions options)
+    {
+        if (options.ToolCollection is null || !options.ToolCollection.TryGetPrimitive("calendars.list", out var tool))
+            return;
+
+        options.ToolCollection = new OrderedToolCollection(options.ToolCollection.ToArray());
+        tool.ProtocolTool.InputSchema = CalendarToolContract.GetInputSchema();
+        tool.ProtocolTool.OutputSchema = CalendarToolContract.GetOutputSchema();
+        tool.ProtocolTool.Meta = new System.Text.Json.Nodes.JsonObject
+        {
+            ["cache"] = CalendarToolContract.GetCacheMetadata()
+        };
     }
 }
 

--- a/src/DotnetAgents.CalDav.Mcp/Hosting/CalendarToolContract.cs
+++ b/src/DotnetAgents.CalDav.Mcp/Hosting/CalendarToolContract.cs
@@ -1,0 +1,79 @@
+using System.Reflection;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace DotnetAgents.CalDav.Mcp.Hosting;
+
+/// <summary>Loads the frozen 0.2.0 schemas and cache metadata for the Calendar tracer bullet.</summary>
+internal static class CalendarToolContract
+{
+    private const string ResourceName = "DotnetAgents.CalDav.Mcp.CalendarToolCatalog.json";
+    private static readonly JsonObject Catalog = LoadCatalog();
+
+    public static JsonElement GetInputSchema() => GetSchema("inputSchema");
+
+    public static JsonElement GetOutputSchema() => GetSchema("outputSchema");
+
+    public static JsonObject GetCacheMetadata() => FindCalendarTool()["cache"]!.DeepClone().AsObject();
+
+    private static JsonElement GetSchema(string schemaProperty)
+    {
+        var reference = FindCalendarTool()[schemaProperty]!["$ref"]!.GetValue<string>();
+        var definitionName = reference.Split('/').Last();
+        var schema = Catalog["$defs"]![definitionName]!.DeepClone().AsObject();
+        var definitions = GetReferencedDefinitions(schema);
+        if (definitions.Count > 0)
+            schema["$defs"] = definitions;
+        return JsonSerializer.SerializeToElement(schema);
+    }
+
+    private static JsonObject GetReferencedDefinitions(JsonNode schema)
+    {
+        var definitions = new JsonObject();
+        var pending = new Queue<string>(GetDefinitionReferences(schema));
+
+        while (pending.TryDequeue(out var definitionName))
+        {
+            if (definitions.ContainsKey(definitionName))
+                continue;
+
+            var definition = Catalog["$defs"]![definitionName]!.DeepClone();
+            definitions[definitionName] = definition;
+            foreach (var nestedReference in GetDefinitionReferences(definition))
+                pending.Enqueue(nestedReference);
+        }
+
+        return definitions;
+    }
+
+    private static IEnumerable<string> GetDefinitionReferences(JsonNode? node)
+    {
+        return node switch
+        {
+            JsonObject obj => GetObjectReferences(obj),
+            JsonArray array => array.SelectMany(GetDefinitionReferences),
+            _ => []
+        };
+    }
+
+    private static IEnumerable<string> GetObjectReferences(JsonObject obj)
+    {
+        const string Prefix = "#/$defs/";
+        var directReference = obj["$ref"]?.GetValue<string>();
+        IEnumerable<string> direct = directReference is not null && directReference.StartsWith(Prefix, StringComparison.Ordinal)
+            ? [directReference[Prefix.Length..]]
+            : Array.Empty<string>();
+        return direct.Concat(obj.Where(property => property.Key != "$ref").SelectMany(property => GetDefinitionReferences(property.Value)));
+    }
+
+    private static JsonObject FindCalendarTool() => Catalog["tools"]!.AsArray()
+        .Select(item => item!.AsObject())
+        .Single(tool => tool["name"]!.GetValue<string>() == "calendars.list");
+
+    private static JsonObject LoadCatalog()
+    {
+        using var stream = Assembly.GetExecutingAssembly().GetManifestResourceStream(ResourceName)
+            ?? throw new InvalidOperationException($"Embedded contract resource '{ResourceName}' was not found.");
+        return JsonNode.Parse(stream)!.AsObject();
+    }
+}

--- a/src/DotnetAgents.CalDav.Mcp/Hosting/OrderedToolCollection.cs
+++ b/src/DotnetAgents.CalDav.Mcp/Hosting/OrderedToolCollection.cs
@@ -1,0 +1,34 @@
+using ModelContextProtocol.Server;
+
+namespace DotnetAgents.CalDav.Mcp.Hosting;
+
+/// <summary>Provides a deterministic wire order while retaining SDK tool lookup behavior.</summary>
+internal sealed class OrderedToolCollection : McpServerPrimitiveCollection<McpServerTool>
+{
+    private static readonly IReadOnlyDictionary<string, int> Ranks = new Dictionary<string, int>(StringComparer.Ordinal)
+    {
+        ["calendars.list"] = 0,
+        ["list_task_lists"] = 1,
+        ["show_tasks"] = 2,
+        ["add_task"] = 3,
+        ["find_tasks"] = 4,
+        ["complete_task_by_summary"] = 5,
+        ["delete_task_by_summary"] = 6
+    };
+
+    public OrderedToolCollection(IEnumerable<McpServerTool> tools)
+        : base(StringComparer.Ordinal)
+    {
+        foreach (var tool in tools)
+            Add(tool);
+    }
+
+    public override McpServerTool[] ToArray() => base.ToArray()
+        .OrderBy(GetRank)
+        .ThenBy(tool => tool.ProtocolTool.Name, StringComparer.Ordinal)
+        .ToArray();
+
+    public override IEnumerator<McpServerTool> GetEnumerator() => ((IEnumerable<McpServerTool>)ToArray()).GetEnumerator();
+
+    private static int GetRank(McpServerTool tool) => Ranks.GetValueOrDefault(tool.ProtocolTool.Name, int.MaxValue);
+}

--- a/src/DotnetAgents.CalDav.Mcp/Tools/CalendarTools.cs
+++ b/src/DotnetAgents.CalDav.Mcp/Tools/CalendarTools.cs
@@ -1,0 +1,198 @@
+using System.ComponentModel;
+using System.Net;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Xml;
+using DotnetAgents.CalDav.Core.Abstractions;
+using DotnetAgents.CalDav.Core.Models;
+using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
+
+namespace DotnetAgents.CalDav.Mcp.Tools;
+
+/// <summary>Unified MCP Calendar discovery tools.</summary>
+[McpServerToolType]
+public sealed class CalendarTools
+{
+    private readonly ICalendarService _calendarService;
+
+    public CalendarTools(ICalendarService calendarService)
+    {
+        _calendarService = calendarService;
+    }
+
+    /// <summary>Lists all Calendars in the configured Calendar Scope.</summary>
+    [McpServerTool(
+        Name = "calendars.list",
+        ReadOnly = true,
+        Destructive = false,
+        Idempotent = true,
+        OpenWorld = true,
+        UseStructuredContent = true,
+        OutputSchemaType = typeof(CalendarListResult)),
+     Description("List every configured Calendar with independent Event and To-do capability evidence.")]
+    public async Task<CallToolResult> ListAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            var discovery = await _calendarService.GetCalendarsAsync(cancellationToken);
+            return CreateResult(new CalendarListResult(
+                "success",
+                discovery.Items.Select(CalendarListItem.FromDescriptor).ToArray(),
+                discovery.Diagnostics.Select(CalendarDiagnosticResult.FromDiagnostic).ToArray(),
+                new CalendarPagination("non_snapshot", null)));
+        }
+        catch (CalendarDiscoveryLimitException exception)
+        {
+            return CreateResult(
+                new CalendarErrorResult("limit_exhausted", "Calendar discovery exceeded the safe item limit.", false, "admissionAndPayload", "limitsAndAdmission", new CalendarExecutionLimits(exception.CalendarCount)),
+                isError: true);
+        }
+        catch (HttpRequestException exception)
+        {
+            return CreateResult(MapHttpFailure(exception), isError: true);
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            return CreateResult(new CalendarErrorResult("upstream_unavailable", "Calendar discovery is temporarily unavailable.", true, "selectionDiscoveryCapability"), isError: true);
+        }
+        catch (TimeoutException)
+        {
+            return CreateResult(new CalendarErrorResult("upstream_unavailable", "Calendar discovery is temporarily unavailable.", true, "selectionDiscoveryCapability"), isError: true);
+        }
+        catch (XmlException)
+        {
+            return CreateResult(new CalendarErrorResult("upstream_protocol_error", "Calendar discovery returned an invalid response.", false, "selectionDiscoveryCapability"), isError: true);
+        }
+        catch (CalendarDiscoveryProtocolException)
+        {
+            return CreateResult(new CalendarErrorResult("upstream_protocol_error", "Calendar discovery returned an invalid response.", false, "selectionDiscoveryCapability"), isError: true);
+        }
+    }
+
+    private static CalendarErrorResult MapHttpFailure(HttpRequestException exception) => exception.StatusCode switch
+    {
+        HttpStatusCode.Unauthorized => new("upstream_unauthorized", "Calendar discovery was not authorized.", false, "selectionDiscoveryCapability"),
+        HttpStatusCode.Forbidden => new("upstream_forbidden", "Calendar discovery was forbidden.", false, "selectionDiscoveryCapability"),
+        HttpStatusCode.TooManyRequests => new("upstream_rate_limited", "Calendar discovery is rate limited.", true, "selectionDiscoveryCapability"),
+        HttpStatusCode.MethodNotAllowed or HttpStatusCode.NotImplemented => new("unsupported_capability", "The upstream Calendar server does not support discovery.", false, "selectionDiscoveryCapability", "capabilityAndProjection"),
+        HttpStatusCode.RequestEntityTooLarge => new("payload_too_large", "Calendar discovery returned an oversized response.", false, "admissionAndPayload", "limitsAndAdmission"),
+        HttpStatusCode.InsufficientStorage => new("upstream_unavailable", "Calendar discovery is temporarily unavailable.", false, "selectionDiscoveryCapability"),
+        null => new("upstream_unavailable", "Calendar discovery is temporarily unavailable.", true, "selectionDiscoveryCapability"),
+        >= HttpStatusCode.InternalServerError => new("upstream_unavailable", "Calendar discovery is temporarily unavailable.", true, "selectionDiscoveryCapability"),
+        _ => new("upstream_protocol_error", "Calendar discovery returned an invalid response.", false, "selectionDiscoveryCapability")
+    };
+
+    private static CallToolResult CreateResult(object content, bool isError = false) => new()
+    {
+        IsError = isError,
+        StructuredContent = JsonSerializer.SerializeToElement(content),
+        Content = [new TextContentBlock { Text = isError ? "Calendar discovery failed." : "Calendar discovery completed." }]
+    };
+}
+
+/// <summary>Structured success outcome for <c>calendars.list</c>.</summary>
+public sealed record CalendarListResult(
+    [property: JsonPropertyName("outcome")] string Outcome,
+    [property: JsonPropertyName("items")] IReadOnlyList<CalendarListItem> Items,
+    [property: JsonPropertyName("diagnostics")] IReadOnlyList<CalendarDiagnosticResult> Diagnostics,
+    [property: JsonPropertyName("pagination")] CalendarPagination Pagination);
+
+/// <summary>Structured error outcome for a failed Calendar discovery request.</summary>
+public sealed record CalendarErrorResult(
+    [property: JsonPropertyName("code")] string Code,
+    [property: JsonPropertyName("message")] string Message,
+    [property: JsonPropertyName("retryable")] bool Retryable,
+    [property: JsonPropertyName("phase")] string Phase,
+    [property: JsonPropertyName("category")] string Category = "upstream",
+    [property: JsonPropertyName("limits"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] CalendarExecutionLimits? Limits = null);
+
+/// <summary>Bounded execution limits returned with an admission failure.</summary>
+public sealed record CalendarExecutionLimits([property: JsonPropertyName("calendarCount")] int CalendarCount);
+
+/// <summary>Public Calendar descriptor with href-only identity.</summary>
+public sealed record CalendarListItem(
+    [property: JsonPropertyName("calendar")] CalendarHref Calendar,
+    [property: JsonPropertyName("displayName")] string? DisplayName,
+    [property: JsonPropertyName("displayNameProvenance")] string DisplayNameProvenance,
+    [property: JsonPropertyName("description")] string? Description,
+    [property: JsonPropertyName("color")] string? Color,
+    [property: JsonPropertyName("entityKinds")] CalendarEntityKinds EntityKinds)
+{
+    internal static CalendarListItem FromDescriptor(CalendarDescriptor descriptor) => new(
+        new CalendarHref(descriptor.Href),
+        descriptor.DisplayName,
+        ToWireValue(descriptor.DisplayNameProvenance),
+        descriptor.Description,
+        GetSchemaColor(descriptor.Color),
+        new CalendarEntityKinds(
+            CalendarEntityKindCapability.From(descriptor.EventSupport, descriptor.EventEvidence),
+            CalendarEntityKindCapability.From(descriptor.TodoSupport, descriptor.TodoEvidence)));
+
+    private static string ToWireValue(DisplayNameProvenance provenance) => provenance switch
+    {
+        DotnetAgents.CalDav.Core.Models.DisplayNameProvenance.DavDisplayName => "dav-displayname",
+        DotnetAgents.CalDav.Core.Models.DisplayNameProvenance.DerivedFromHref => "derived-from-href",
+        DotnetAgents.CalDav.Core.Models.DisplayNameProvenance.Missing => "missing",
+        _ => throw new ArgumentOutOfRangeException(nameof(provenance), provenance, null)
+    };
+
+    private static string? GetSchemaColor(string? color) =>
+        color is { Length: 7 } && color[0] == '#' && color.AsSpan(1).ToString().All(Uri.IsHexDigit)
+            ? color
+            : null;
+}
+
+/// <summary>Canonical Calendar href identity.</summary>
+public sealed record CalendarHref([property: JsonPropertyName("href")] string Href);
+
+/// <summary>Independent Event and To-do capability evidence.</summary>
+public sealed record CalendarEntityKinds(
+    [property: JsonPropertyName("event")] CalendarEntityKindCapability Event,
+    [property: JsonPropertyName("todo")] CalendarEntityKindCapability Todo);
+
+/// <summary>Advertised, explicitly absent, or unknown capability evidence.</summary>
+public sealed record CalendarEntityKindCapability(
+    [property: JsonPropertyName("state")] string State,
+    [property: JsonPropertyName("evidence")] IReadOnlyList<CalendarCapabilityEvidence> Evidence)
+{
+    internal static CalendarEntityKindCapability From(
+        EntityKindSupport support,
+        IReadOnlyList<CapabilityEvidence> evidence) => new(
+        support switch
+        {
+            EntityKindSupport.Advertised => "advertised",
+            EntityKindSupport.NotAdvertised => "not_advertised",
+            EntityKindSupport.Unknown => "unknown",
+            _ => throw new ArgumentOutOfRangeException(nameof(support), support, null)
+        },
+        evidence.Select(item => new CalendarCapabilityEvidence(item.Source, item.Value)).ToArray());
+}
+
+/// <summary>Raw, inert capability evidence.</summary>
+public sealed record CalendarCapabilityEvidence(
+    [property: JsonPropertyName("source")] string Source,
+    [property: JsonPropertyName("value")] string Value);
+
+/// <summary>Bounded diagnostic for the current discovery result.</summary>
+public sealed record CalendarDiagnosticResult(
+    [property: JsonPropertyName("code")] string Code,
+    [property: JsonPropertyName("message")] string Message,
+    [property: JsonPropertyName("severity")] string Severity)
+{
+    internal static CalendarDiagnosticResult FromDiagnostic(CalendarDiagnostic diagnostic) => new(
+        diagnostic.Code,
+        diagnostic.Message,
+        diagnostic.Severity switch
+        {
+            CalendarDiagnosticSeverity.Info => "info",
+            CalendarDiagnosticSeverity.Warning => "warning",
+            CalendarDiagnosticSeverity.Error => "error",
+            _ => throw new ArgumentOutOfRangeException(nameof(diagnostic), diagnostic.Severity, null)
+        });
+}
+
+/// <summary>List pagination deliberately has no snapshot continuity guarantee.</summary>
+public sealed record CalendarPagination(
+    [property: JsonPropertyName("mode")] string Mode,
+    [property: JsonPropertyName("nextCursor")] string? NextCursor);

--- a/tests/DotnetAgents.CalDav.Core.Tests.Unit/DependencyInjection/CalDavServiceCollectionExtensionsTests.cs
+++ b/tests/DotnetAgents.CalDav.Core.Tests.Unit/DependencyInjection/CalDavServiceCollectionExtensionsTests.cs
@@ -1,0 +1,41 @@
+using DotnetAgents.CalDav.Core.Abstractions;
+using DotnetAgents.CalDav.Core.Configuration;
+using DotnetAgents.CalDav.Core.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Http;
+using Shouldly;
+using Xunit;
+
+namespace DotnetAgents.CalDav.Core.Tests.Unit.DependencyInjection;
+
+public sealed class CalDavServiceCollectionExtensionsTests
+{
+    [Fact]
+    public void AddCalDavTasks_DisablesAutomaticRedirectsOnTheConfiguredHandler()
+    {
+        SocketsHttpHandler? handler = null;
+        var services = new ServiceCollection();
+        services.AddSingleton<IHttpMessageHandlerBuilderFilter>(new CapturingHandlerFilter(candidate => handler = candidate as SocketsHttpHandler));
+        services.AddCalDavTasks(options =>
+        {
+            options.BaseUrl = "https://cal.example";
+            options.Username = "user";
+            options.Password = "password";
+        });
+        using var provider = services.BuildServiceProvider();
+
+        _ = provider.GetRequiredService<ICalDavClient>();
+
+        handler.ShouldNotBeNull();
+        handler.AllowAutoRedirect.ShouldBeFalse();
+    }
+
+    private sealed class CapturingHandlerFilter(Action<HttpMessageHandler> capture) : IHttpMessageHandlerBuilderFilter
+    {
+        public Action<HttpMessageHandlerBuilder> Configure(Action<HttpMessageHandlerBuilder> next) => builder =>
+        {
+            next(builder);
+            capture(builder.PrimaryHandler);
+        };
+    }
+}

--- a/tests/DotnetAgents.CalDav.Core.Tests.Unit/Internal/CalDavClientTests.cs
+++ b/tests/DotnetAgents.CalDav.Core.Tests.Unit/Internal/CalDavClientTests.cs
@@ -523,6 +523,138 @@ public class CalDavClientTests
     #region PROPFIND and REPORT Tests
 
     [Fact]
+    public async Task GetCalendarsAsync_ReturnsCanonicalAbsoluteHrefsForEveryCalendar()
+    {
+        var requests = new List<HttpRequestMessage>();
+        var handler = CreateSequencedHandler(
+        [
+            CreateCalendarHomeSetResponse(),
+            new HttpResponseMessage(HttpStatusCode.MultiStatus)
+            {
+                Content = new StringContent("""
+                    <d:multistatus xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:caldav">
+                      <d:response><d:href>events/</d:href><d:propstat><d:prop><d:resourcetype><c:calendar/></d:resourcetype><c:supported-calendar-component-set><c:comp name="VEVENT"/></c:supported-calendar-component-set></d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat></d:response>
+                      <d:response><d:href>/calendars/user/todos/</d:href><d:propstat><d:prop><d:resourcetype><c:calendar/></d:resourcetype></d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat></d:response>
+                      <d:response><d:href>https://example.com/calendars/user/shared/</d:href><d:propstat><d:prop><d:resourcetype><c:calendar/></d:resourcetype></d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat></d:response>
+                    </d:multistatus>
+                    """, Encoding.UTF8, "application/xml")
+            }
+        ], requests);
+        var sut = CreateSut(handler, "https://example.com/remote.php/dav/");
+
+        var calendars = await sut.GetCalendarsAsync(CancellationToken.None);
+
+        calendars.Select(calendar => calendar.Href).ShouldBe(
+        [
+            "https://example.com/calendars/user/events/",
+            "https://example.com/calendars/user/shared/",
+            "https://example.com/calendars/user/todos/"
+        ]);
+        calendars[0].EventSupport.ShouldBe(EntityKindSupport.Advertised);
+        calendars[0].TodoSupport.ShouldBe(EntityKindSupport.NotAdvertised);
+        requests.Select(request => request.Headers.GetValues("Depth").Single()).ShouldBe(["0", "1"]);
+    }
+
+    [Fact]
+    public async Task GetCalendarsAsync_DoesNotFollowUnsafeCalendarHomeSetHref()
+    {
+        var requests = new List<HttpRequestMessage>();
+        var handler = CreateSequencedHandler(
+        [
+            new HttpResponseMessage(HttpStatusCode.MultiStatus)
+            {
+                Content = new StringContent("""
+                    <d:multistatus xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:caldav">
+                      <d:response><d:href>/</d:href><d:propstat><d:prop><c:calendar-home-set><d:href>https://other.example/calendars/user/</d:href></c:calendar-home-set></d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat></d:response>
+                    </d:multistatus>
+                    """, Encoding.UTF8, "application/xml")
+            }
+        ], requests);
+        var sut = CreateSut(handler, "https://example.com/remote.php/dav/");
+
+        await Should.ThrowAsync<CalendarDiscoveryProtocolException>(() =>
+            sut.GetCalendarsAsync(CancellationToken.None));
+        requests.Count.ShouldBe(1);
+        requests[0].RequestUri!.Host.ShouldBe("example.com");
+    }
+
+    [Fact]
+    public async Task GetCalendarsAsync_RejectsUnsafeCalendarHrefWithoutPartialItems()
+    {
+        var requests = new List<HttpRequestMessage>();
+        var handler = CreateSequencedHandler(
+        [
+            CreateCalendarHomeSetResponse(),
+            new HttpResponseMessage(HttpStatusCode.MultiStatus)
+            {
+                Content = new StringContent("""
+                    <d:multistatus xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:caldav">
+                      <d:response><d:href>/calendars/user/safe/</d:href><d:propstat><d:prop><d:resourcetype><c:calendar/></d:resourcetype></d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat></d:response>
+                      <d:response><d:href>https://other.example/calendars/user/unsafe/</d:href><d:propstat><d:prop><d:resourcetype><c:calendar/></d:resourcetype></d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat></d:response>
+                    </d:multistatus>
+                    """, Encoding.UTF8, "application/xml")
+            }
+        ], requests);
+        var sut = CreateSut(handler, "https://example.com/remote.php/dav/");
+
+        await Should.ThrowAsync<CalendarDiscoveryProtocolException>(() =>
+            sut.GetCalendarsAsync(CancellationToken.None));
+
+        requests.Count.ShouldBe(2);
+        requests.ShouldAllBe(request => request.RequestUri!.Host == "example.com");
+    }
+
+    [Theory]
+    [InlineData("https://user:secret@example.com/calendars/user/unsafe/")]
+    [InlineData("/calendars/user/unsafe/#fragment")]
+    public async Task GetCalendarsAsync_RejectsCredentialsAndFragmentsInCalendarHrefs(string unsafeHref)
+    {
+        var requests = new List<HttpRequestMessage>();
+        var handler = CreateSequencedHandler(
+        [
+            CreateCalendarHomeSetResponse(),
+            new HttpResponseMessage(HttpStatusCode.MultiStatus)
+            {
+                Content = new StringContent($"""
+                    <d:multistatus xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:caldav">
+                      <d:response><d:href>{unsafeHref}</d:href><d:propstat><d:prop><d:resourcetype><c:calendar/></d:resourcetype></d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat></d:response>
+                    </d:multistatus>
+                    """, Encoding.UTF8, "application/xml")
+            }
+        ], requests);
+        var sut = CreateSut(handler, "https://example.com/remote.php/dav/");
+
+        await Should.ThrowAsync<CalendarDiscoveryProtocolException>(() =>
+            sut.GetCalendarsAsync(CancellationToken.None));
+
+        requests.Count.ShouldBe(2);
+        requests.All(request => request.RequestUri!.UserInfo.Length == 0).ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task GetCalendarsAsync_DoesNotFollowUnsafeCurrentUserPrincipalHref()
+    {
+        var requests = new List<HttpRequestMessage>();
+        var handler = CreateSequencedHandler(
+        [
+            new HttpResponseMessage(HttpStatusCode.MultiStatus)
+            {
+                Content = new StringContent("""
+                    <d:multistatus xmlns:d="DAV:">
+                      <d:response><d:href>/</d:href><d:propstat><d:prop><d:current-user-principal><d:href>https://other.example/principals/user/</d:href></d:current-user-principal></d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat></d:response>
+                    </d:multistatus>
+                    """, Encoding.UTF8, "application/xml")
+            }
+        ], requests);
+        var sut = CreateSut(handler, "https://example.com/remote.php/dav/");
+
+        await Should.ThrowAsync<CalendarDiscoveryProtocolException>(() =>
+            sut.GetCalendarsAsync(CancellationToken.None));
+        requests.Count.ShouldBe(1);
+        requests.ShouldAllBe(request => request.RequestUri!.Host == "example.com");
+    }
+
+    [Fact]
     public async Task GetTaskListsAsync_SendsPropFindWithDepthHeader()
     {
         // Arrange
@@ -1752,6 +1884,16 @@ public class CalDavClientTests
             return responseFactory();
         });
     }
+
+    private static HttpResponseMessage CreateCalendarHomeSetResponse() =>
+        new(HttpStatusCode.MultiStatus)
+        {
+            Content = new StringContent("""
+                <d:multistatus xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:caldav">
+                  <d:response><d:href>/calendars/user/</d:href><d:propstat><d:prop><c:calendar-home-set><d:href>/calendars/user/</d:href></c:calendar-home-set></d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat></d:response>
+                </d:multistatus>
+                """, Encoding.UTF8, "application/xml")
+        };
 
     #endregion
 }

--- a/tests/DotnetAgents.CalDav.Core.Tests.Unit/Internal/Xml/DavRequestBuilderTests.cs
+++ b/tests/DotnetAgents.CalDav.Core.Tests.Unit/Internal/Xml/DavRequestBuilderTests.cs
@@ -52,6 +52,7 @@ public class DavRequestBuilderTests
         prop.Element(Dav + "displayname").ShouldNotBeNull();
         prop.Element(Dav + "resourcetype").ShouldNotBeNull();
         prop.Element(CalDav + "supported-calendar-component-set").ShouldNotBeNull();
+        prop.Element(CalDav + "calendar-description").ShouldNotBeNull();
         prop.Element(Dav + "description").ShouldNotBeNull();
         prop.Element(AppleCs + "calendar-color").ShouldNotBeNull();
         prop.Element(CalServer + "getctag").ShouldNotBeNull();

--- a/tests/DotnetAgents.CalDav.Core.Tests.Unit/Internal/Xml/DavResponseParserTests.cs
+++ b/tests/DotnetAgents.CalDav.Core.Tests.Unit/Internal/Xml/DavResponseParserTests.cs
@@ -13,6 +13,39 @@ public class DavResponseParserTests
     private static readonly XNamespace AppleCs = "http://apple.com/ns/ical/";
 
     [Fact]
+    public void ParseCalendars_PreservesEveryCalendarAndIndependentComponentEvidence()
+    {
+        var xml = BuildMultistatusXml(doc =>
+        {
+            doc.Element(Dav + "multistatus")!.Add(
+                BuildResponseElement("/calendars/user/events/",
+                    new XElement(Dav + "resourcetype", new XElement(CalDav + "calendar")),
+                    new XElement(CalDav + "calendar-description", "Calendar description"),
+                    new XElement(CalDav + "supported-calendar-component-set",
+                        new XElement(CalDav + "comp", new XAttribute("name", "VEVENT")))),
+                BuildResponseElement("/calendars/user/unknown/",
+                    new XElement(Dav + "displayname", "  "),
+                    new XElement(Dav + "resourcetype", new XElement(CalDav + "calendar"))));
+        });
+
+        var result = DavResponseParser.ParseCalendars(xml);
+
+        result.Count.ShouldBe(2);
+        result[0].Href.ShouldBe("/calendars/user/events/");
+        result[0].DisplayName.ShouldBe("events");
+        result[0].DisplayNameProvenance.ShouldBe(DisplayNameProvenance.DerivedFromHref);
+        result[0].Description.ShouldBe("Calendar description");
+        result[0].EventSupport.ShouldBe(EntityKindSupport.Advertised);
+        result[0].TodoSupport.ShouldBe(EntityKindSupport.NotAdvertised);
+        result[0].EventEvidence.Single().Value.ShouldBe("VEVENT");
+        result[1].DisplayName.ShouldBeNull();
+        result[1].DisplayNameProvenance.ShouldBe(DisplayNameProvenance.Missing);
+        result[1].EventSupport.ShouldBe(EntityKindSupport.Unknown);
+        result[1].TodoSupport.ShouldBe(EntityKindSupport.Unknown);
+        result[1].EventEvidence.ShouldBeEmpty();
+    }
+
+    [Fact]
     public void ParseTaskLists_ValidCalendarCollection_ReturnsTaskList()
     {
         // Arrange

--- a/tests/DotnetAgents.CalDav.Core.Tests.Unit/Services/CalendarServiceTests.cs
+++ b/tests/DotnetAgents.CalDav.Core.Tests.Unit/Services/CalendarServiceTests.cs
@@ -1,0 +1,238 @@
+using System.Text.Json;
+using DotnetAgents.CalDav.Core.Abstractions;
+using DotnetAgents.CalDav.Core.Configuration;
+using DotnetAgents.CalDav.Core.Models;
+using DotnetAgents.CalDav.Core.Services;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace DotnetAgents.CalDav.Core.Tests.Unit.Services;
+
+public sealed class CalendarServiceTests
+{
+    [Fact]
+    public async Task ResolveDefaultCalendarAsync_UsesIndependentEventAndTodoDefaults()
+    {
+        var client = Substitute.For<ICalendarClient>();
+        var options = Options.Create(new CalDavOptions
+        {
+            BaseUrl = "https://cal.example",
+            DefaultEventCalendarName = "Events",
+            DefaultTodoCalendarName = "To-dos"
+        });
+        var sut = new CalendarService(client, options, Substitute.For<ILogger<CalendarService>>());
+        client.GetCalendarsAsync(Arg.Any<CancellationToken>()).Returns(
+        [
+            new CalendarDescriptor
+            {
+                Href = "https://cal.example/events/",
+                DisplayName = "Events",
+                DisplayNameProvenance = DisplayNameProvenance.DavDisplayName,
+                EventSupport = EntityKindSupport.Advertised,
+                TodoSupport = EntityKindSupport.NotAdvertised
+            },
+            new CalendarDescriptor
+            {
+                Href = "https://cal.example/todos/",
+                DisplayName = "To-dos",
+                DisplayNameProvenance = DisplayNameProvenance.DavDisplayName,
+                EventSupport = EntityKindSupport.NotAdvertised,
+                TodoSupport = EntityKindSupport.Advertised
+            }
+        ]);
+
+        var eventResult = await sut.ResolveDefaultCalendarAsync(CalendarEntityKind.Event, CancellationToken.None);
+        var todoResult = await sut.ResolveDefaultCalendarAsync(CalendarEntityKind.Todo, CancellationToken.None);
+
+        eventResult.Calendar!.Href.ShouldBe("https://cal.example/events/");
+        todoResult.Calendar!.Href.ShouldBe("https://cal.example/todos/");
+    }
+
+    [Fact]
+    public async Task ResolveDefaultCalendarAsync_ResolvesAuthorizedMatchBeyondCandidateLimit()
+    {
+        var client = Substitute.For<ICalendarClient>();
+        var options = Options.Create(new CalDavOptions
+        {
+            BaseUrl = "https://cal.example",
+            DefaultTodoCalendarName = "Target"
+        });
+        var sut = new CalendarService(client, options, Substitute.For<ILogger<CalendarService>>());
+        var calendars = Enumerable.Range(0, 33)
+            .Select(index => Calendar($"https://cal.example/{index:D2}/", $"Calendar {index:D2}", EntityKindSupport.Advertised))
+            .Append(Calendar("https://cal.example/target/", "Target", EntityKindSupport.Advertised))
+            .ToArray();
+        client.GetCalendarsAsync(Arg.Any<CancellationToken>()).Returns(calendars);
+
+        var result = await sut.ResolveDefaultCalendarAsync(CalendarEntityKind.Todo, CancellationToken.None);
+
+        result.Code.ShouldBe(CalendarSelectionCode.Success);
+        result.Calendar!.Href.ShouldBe("https://cal.example/target/");
+    }
+
+    [Theory]
+    [InlineData("Work", CalendarSelectionCode.Success)]
+    [InlineData("Unknown", CalendarSelectionCode.Success)]
+    [InlineData("Missing", CalendarSelectionCode.NotFound)]
+    [InlineData("Duplicate", CalendarSelectionCode.Ambiguous)]
+    [InlineData("Private", CalendarSelectionCode.OutsideScope)]
+    [InlineData("Events", CalendarSelectionCode.UnsupportedCapability)]
+    public async Task ResolveDefaultCalendarAsync_ReturnsDeterministicTypedOutcome(
+        string configuredName,
+        CalendarSelectionCode expectedCode)
+    {
+        var client = Substitute.For<ICalendarClient>();
+        var options = Options.Create(new CalDavOptions
+        {
+            BaseUrl = "https://cal.example",
+            CalendarHrefs = "https://cal.example/work/,https://cal.example/unknown/,https://cal.example/duplicate-a/,https://cal.example/duplicate-b/,https://cal.example/events/",
+            DefaultTodoCalendarName = configuredName
+        });
+        var sut = new CalendarService(client, options, Substitute.For<ILogger<CalendarService>>());
+        client.GetCalendarsAsync(Arg.Any<CancellationToken>()).Returns(
+        [
+            Calendar("https://cal.example/work/", "Work", EntityKindSupport.Advertised),
+            Calendar("https://cal.example/unknown/", "Unknown", EntityKindSupport.Unknown),
+            Calendar("https://cal.example/duplicate-a/", "Duplicate", EntityKindSupport.Advertised),
+            Calendar("https://cal.example/duplicate-b/", " duplicate ", EntityKindSupport.Advertised),
+            Calendar("https://cal.example/private/", "Private", EntityKindSupport.Advertised),
+            Calendar("https://cal.example/events/", "Events", EntityKindSupport.NotAdvertised)
+        ]);
+
+        var result = await sut.ResolveDefaultCalendarAsync(CalendarEntityKind.Todo, CancellationToken.None);
+
+        result.Code.ShouldBe(expectedCode);
+        if (expectedCode == CalendarSelectionCode.Success && configuredName == "Work")
+            result.Calendar!.Href.ShouldBe("https://cal.example/work/");
+        if (expectedCode == CalendarSelectionCode.Ambiguous)
+            result.Candidates.Select(candidate => candidate.Href).ShouldBe(
+                ["https://cal.example/duplicate-a/", "https://cal.example/duplicate-b/"]);
+        if (expectedCode != CalendarSelectionCode.Success)
+        {
+            result.Candidates.ShouldNotBeEmpty();
+            result.Candidates.ShouldAllBe(candidate => candidate.Href != "https://cal.example/private/");
+            result.Candidates.All(candidate => candidate.DisplayName is not null).ShouldBeTrue();
+        }
+    }
+
+    [Fact]
+    public async Task GetCalendarsAsync_AppliesExactScopeAndPreservesDiscoveryEvidence()
+    {
+        var client = Substitute.For<ICalendarClient>();
+        var options = Options.Create(new CalDavOptions
+        {
+            BaseUrl = "https://cal.example",
+            CalendarHrefs = "https://cal.example/a/,https://cal.example/missing/,https://cal.example/a/,https://cal.example/missing/"
+        });
+        var sut = new CalendarService(client, options, Substitute.For<ILogger<CalendarService>>());
+        client.GetCalendarsAsync(Arg.Any<CancellationToken>()).Returns(
+        [
+            new CalendarDescriptor
+            {
+                Href = "https://cal.example/b/",
+                DisplayName = "Work",
+                DisplayNameProvenance = DisplayNameProvenance.DavDisplayName,
+                EventSupport = EntityKindSupport.Unknown,
+                TodoSupport = EntityKindSupport.NotAdvertised,
+                TodoEvidence = [new CapabilityEvidence("supported-calendar-component-set", "VEVENT")]
+            },
+            new CalendarDescriptor
+            {
+                Href = "https://cal.example/a/",
+                DisplayName = "a",
+                DisplayNameProvenance = DisplayNameProvenance.DerivedFromHref,
+                EventSupport = EntityKindSupport.Advertised,
+                TodoSupport = EntityKindSupport.Advertised,
+                EventEvidence = [new CapabilityEvidence("supported-calendar-component-set", "VEVENT,VTODO")],
+                TodoEvidence = [new CapabilityEvidence("supported-calendar-component-set", "VEVENT,VTODO")]
+            }
+        ]);
+
+        var result = await sut.GetCalendarsAsync(CancellationToken.None);
+
+        result.Items.Select(calendar => calendar.Href).ShouldBe(["https://cal.example/a/"]);
+        result.Items[0].DisplayNameProvenance.ShouldBe(DisplayNameProvenance.DerivedFromHref);
+        result.Items[0].EventSupport.ShouldBe(EntityKindSupport.Advertised);
+        result.Items[0].TodoSupport.ShouldBe(EntityKindSupport.Advertised);
+        result.Diagnostics.Select(diagnostic => diagnostic.Code)
+            .ShouldBe(["duplicate_calendar_href", "duplicate_calendar_href", "calendar_href_not_found"]);
+    }
+
+    [Fact]
+    public async Task GetCalendarsAsync_WithoutConfiguredScope_ReturnsAllUniqueCalendarsInCanonicalOrder()
+    {
+        var client = Substitute.For<ICalendarClient>();
+        var options = Options.Create(new CalDavOptions { BaseUrl = "https://cal.example" });
+        var sut = new CalendarService(client, options, Substitute.For<ILogger<CalendarService>>());
+        client.GetCalendarsAsync(Arg.Any<CancellationToken>()).Returns(
+        [
+            Calendar("https://cal.example/z/", "Z", EntityKindSupport.Advertised),
+            Calendar("https://cal.example/a/", "A", EntityKindSupport.Advertised),
+            Calendar("https://cal.example/a/", "Duplicate A", EntityKindSupport.Advertised)
+        ]);
+
+        var result = await sut.GetCalendarsAsync(CancellationToken.None);
+
+        result.Items.Select(calendar => calendar.Href).ShouldBe(
+            ["https://cal.example/a/", "https://cal.example/z/"]);
+        result.Diagnostics.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task GetCalendarsAsync_DiagnosticsDoNotExposeConfiguredHrefText()
+    {
+        const string unsafeHref = "https://user:secret@cal.example/private/";
+        var oversizedHref = $"https://cal.example/{new string('x', 10_000)}";
+        var client = Substitute.For<ICalendarClient>();
+        var options = Options.Create(new CalDavOptions
+        {
+            BaseUrl = "https://cal.example",
+            CalendarHrefs = $"{unsafeHref},{oversizedHref}"
+        });
+        var sut = new CalendarService(client, options, Substitute.For<ILogger<CalendarService>>());
+        client.GetCalendarsAsync(Arg.Any<CancellationToken>()).Returns([]);
+
+        var result = await sut.GetCalendarsAsync(CancellationToken.None);
+
+        var serializedDiagnostics = JsonSerializer.Serialize(result.Diagnostics);
+        serializedDiagnostics.ShouldNotContain(unsafeHref);
+        serializedDiagnostics.ShouldNotContain(oversizedHref);
+        result.Diagnostics.Select(diagnostic => diagnostic.Code)
+            .ShouldBe(["calendar_href_not_found", "calendar_href_not_found"]);
+    }
+
+    [Fact]
+    public async Task GetCalendarsAsync_DeduplicatesAndBoundsDiscoveredCalendars()
+    {
+        var client = Substitute.For<ICalendarClient>();
+        var options = Options.Create(new CalDavOptions
+        {
+            BaseUrl = "https://cal.example",
+            CalendarHrefs = "https://cal.example/000/"
+        });
+        var sut = new CalendarService(client, options, Substitute.For<ILogger<CalendarService>>());
+        var calendars = Enumerable.Range(0, 257)
+            .Select(index => Calendar($"https://cal.example/{index:D3}/", $"Calendar {index:D3}", EntityKindSupport.Advertised))
+            .Append(Calendar("https://cal.example/000/", "Duplicate", EntityKindSupport.Advertised))
+            .ToArray();
+        client.GetCalendarsAsync(Arg.Any<CancellationToken>()).Returns(calendars);
+
+        var exception = await Should.ThrowAsync<CalendarDiscoveryLimitException>(() =>
+            sut.GetCalendarsAsync(CancellationToken.None));
+
+        exception.CalendarCount.ShouldBe(257);
+    }
+
+    private static CalendarDescriptor Calendar(string href, string displayName, EntityKindSupport todoSupport) =>
+        new()
+        {
+            Href = href,
+            DisplayName = displayName,
+            DisplayNameProvenance = DisplayNameProvenance.DavDisplayName,
+            EventSupport = EntityKindSupport.Advertised,
+            TodoSupport = todoSupport
+        };
+}

--- a/tests/DotnetAgents.CalDav.IntegrationTests/CalendarMcpStdioIntegrationTests.cs
+++ b/tests/DotnetAgents.CalDav.IntegrationTests/CalendarMcpStdioIntegrationTests.cs
@@ -1,0 +1,94 @@
+using System.Collections.Concurrent;
+using DotnetAgents.CalDav.IntegrationTests.Fixtures;
+using ModelContextProtocol.Client;
+using ModelContextProtocol.Protocol;
+using Shouldly;
+using Xunit;
+
+namespace DotnetAgents.CalDav.IntegrationTests;
+
+/// <summary>Exercises the Calendar tracer bullet through the SDK's native stdio client.</summary>
+[Collection("RadicaleCollection")]
+public sealed class CalendarMcpStdioIntegrationTests
+{
+    private readonly RadicaleFixture _fixture;
+
+    public CalendarMcpStdioIntegrationTests(RadicaleFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact]
+    public async Task CalendarList_UsesNativeDiscoverAndReturnsStructuredContentOverStdio()
+    {
+        var stderr = new ConcurrentQueue<string>();
+        var transport = new StdioClientTransport(new StdioClientTransportOptions
+        {
+            Command = "dotnet",
+            Arguments = [GetServerAssemblyPath()],
+            WorkingDirectory = AppContext.BaseDirectory,
+            InheritEnvironmentVariables = true,
+            EnvironmentVariables = CreateEnvironment(),
+            StandardErrorLines = stderr.Enqueue
+        });
+        var options = new McpClientOptions
+        {
+            ProtocolVersion = "2026-07-28",
+            DiscoverProbeTimeout = TimeSpan.FromSeconds(10)
+        };
+
+        await using var client = await McpClient.CreateAsync(transport, options, cancellationToken: TestContext.Current.CancellationToken);
+        var listedTools = await client.ListToolsAsync(new ListToolsRequestParams(), TestContext.Current.CancellationToken);
+        var calendarTool = listedTools.Tools.Single(tool => tool.Name == "calendars.list");
+        var result = await client.CallToolAsync("calendars.list", null, cancellationToken: TestContext.Current.CancellationToken);
+
+        client.ServerInfo.ShouldNotBeNull();
+        client.NegotiatedProtocolVersion.ShouldBe("2026-07-28");
+        listedTools.Tools.Select(tool => tool.Name).ShouldBe(
+        [
+            "calendars.list",
+            "list_task_lists",
+            "show_tasks",
+            "add_task",
+            "find_tasks",
+            "complete_task_by_summary",
+            "delete_task_by_summary"
+        ]);
+        calendarTool.InputSchema.GetProperty("type").GetString().ShouldBe("object");
+        calendarTool.InputSchema.GetProperty("additionalProperties").GetBoolean().ShouldBeFalse();
+        calendarTool.OutputSchema!.Value.GetProperty("oneOf").GetArrayLength().ShouldBe(2);
+        calendarTool.Meta!["cache"]!["ttlMs"]!.GetValue<int>().ShouldBe(30000);
+        calendarTool.Meta!["cache"]!["cacheScope"]!.GetValue<string>().ShouldBe("private");
+        result.StructuredContent.ShouldNotBeNull();
+        var structured = result.StructuredContent!.Value;
+        structured.GetProperty("outcome").GetString().ShouldBe("success");
+        structured.GetProperty("pagination").GetProperty("mode").GetString().ShouldBe("non_snapshot");
+        structured.GetProperty("items").GetArrayLength().ShouldBe(1);
+        structured.GetProperty("items")[0].GetProperty("calendar").GetProperty("href").GetString()
+            .ShouldBe($"{_fixture.BaseUrl}{_fixture.TaskListHref}");
+        stderr.ShouldBeEmpty();
+    }
+
+    private Dictionary<string, string?> CreateEnvironment() => new()
+    {
+        ["CALDAV_URL"] = _fixture.BaseUrl,
+        ["CALDAV_USERNAME"] = "caldavtest",
+        ["CALDAV_PASSWORD"] = "caldavtest123",
+        ["CALDAV_CALENDAR_HREFS"] = $"{_fixture.BaseUrl}{_fixture.TaskListHref}"
+    };
+
+    private static string GetServerAssemblyPath()
+    {
+        var directory = AppContext.BaseDirectory;
+        while (directory is not null)
+        {
+            var candidate = Path.Combine(directory, "src", "DotnetAgents.CalDav.Mcp", "bin", "Release", "net10.0", "DotnetAgents.CalDav.Mcp.dll");
+            if (File.Exists(candidate))
+                return candidate;
+
+            directory = Directory.GetParent(directory)?.FullName;
+        }
+
+        throw new FileNotFoundException("Could not locate the built MCP server assembly.");
+    }
+}

--- a/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/CalDavEnvironmentMapperTests.cs
+++ b/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/CalDavEnvironmentMapperTests.cs
@@ -27,21 +27,22 @@ public class CalDavEnvironmentMapperTests
     }
 
     [Fact]
-    public void MapFromEnvironment_MapsOptionalTaskLists()
+    public void MapFromEnvironment_MapsOptionalCalendarScope()
     {
         var envVars = new Dictionary<string, string?>
         {
             ["CALDAV_URL"] = "https://caldav.example.com",
             ["CALDAV_USERNAME"] = "user",
             ["CALDAV_PASSWORD"] = "pass",
-            ["CALDAV_TASK_LISTS"] = "list1,list2",
+            ["CALDAV_CALENDAR_HREFS"] = "https://caldav.example.com/a/,https://caldav.example.com/b/",
         };
 
         var configure = CalDavEnvironmentMapper.MapFromEnvironment(key => envVars.GetValueOrDefault(key));
         var options = new CalDavOptions();
         configure(options);
 
-        options.TaskLists.ShouldBe("list1,list2");
+        options.CalendarHrefs.ShouldBe("https://caldav.example.com/a/,https://caldav.example.com/b/");
+        options.TaskLists.ShouldBeNull();
     }
 
     [Fact]
@@ -57,7 +58,7 @@ public class CalDavEnvironmentMapperTests
     }
 
     [Fact]
-    public void MapFromEnvironment_MissingTaskLists_DefaultsToNull()
+    public void MapFromEnvironment_MissingCalendarScope_DefaultsToNull()
     {
         var envVars = new Dictionary<string, string?>
         {
@@ -70,29 +71,31 @@ public class CalDavEnvironmentMapperTests
         var options = new CalDavOptions();
         configure(options);
 
-        options.TaskLists.ShouldBeNull();
+        options.CalendarHrefs.ShouldBeNull();
     }
 
     [Fact]
-    public void MapFromEnvironment_MapsDefaultTaskList()
+    public void MapFromEnvironment_MapsIndependentDefaultCalendarNames()
     {
         var envVars = new Dictionary<string, string?>
         {
             ["CALDAV_URL"] = "https://caldav.example.com",
             ["CALDAV_USERNAME"] = "user",
             ["CALDAV_PASSWORD"] = "pass",
-            ["CALDAV_DEFAULT_TASK_LIST"] = "My Tasks",
+            ["CALDAV_DEFAULT_TODO_CALENDAR_NAME"] = "My To-dos",
+            ["CALDAV_DEFAULT_EVENT_CALENDAR_NAME"] = "My Events",
         };
 
         var configure = CalDavEnvironmentMapper.MapFromEnvironment(key => envVars.GetValueOrDefault(key));
         var options = new CalDavOptions();
         configure(options);
 
-        options.DefaultTaskList.ShouldBe("My Tasks");
+        options.DefaultTodoCalendarName.ShouldBe("My To-dos");
+        options.DefaultEventCalendarName.ShouldBe("My Events");
     }
 
     [Fact]
-    public void MapFromEnvironment_MissingDefaultTaskList_DefaultsToNull()
+    public void MapFromEnvironment_MissingDefaultCalendarNames_DefaultToNull()
     {
         var envVars = new Dictionary<string, string?>
         {
@@ -105,7 +108,8 @@ public class CalDavEnvironmentMapperTests
         var options = new CalDavOptions();
         configure(options);
 
-        options.DefaultTaskList.ShouldBeNull();
+        options.DefaultTodoCalendarName.ShouldBeNull();
+        options.DefaultEventCalendarName.ShouldBeNull();
     }
 
 }

--- a/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/CalDavHostBuilderTests.cs
+++ b/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/CalDavHostBuilderTests.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using System.Text.Json.Nodes;
 using DotnetAgents.CalDav.Core.Abstractions;
 using DotnetAgents.CalDav.Core.Configuration;
 using DotnetAgents.CalDav.Mcp.Hosting;
@@ -184,35 +185,108 @@ public class CalDavHostBuilderTests
     }
 
     [Fact]
-    public void CreateBuilder_DefaultMode_RegistersOnlyChatSafeTools()
+    public void CreateBuilder_DefaultMode_RegistersCalendarDiscoveryAlongsideChatSafeLegacyTools()
     {
         // Arrange & Act
         var builder = CalDavHostBuilder.CreateBuilder();
 
-        // Assert — only TaskListTools and ChatTaskTools should be registered as tool types
         var registeredToolTypes = GetRegisteredMcpToolTypes(builder.Services);
 
-        registeredToolTypes.ShouldContain(typeof(DotnetAgents.CalDav.Mcp.Tools.TaskListTools));
-        registeredToolTypes.ShouldContain(typeof(DotnetAgents.CalDav.Mcp.Tools.ChatTaskTools));
-        registeredToolTypes.ShouldNotContain(typeof(DotnetAgents.CalDav.Mcp.Tools.TaskQueryTools),
-            "TaskQueryTools should not be registered in default (chat-safe) mode");
-        registeredToolTypes.ShouldNotContain(typeof(DotnetAgents.CalDav.Mcp.Tools.TaskMutationTools),
-            "TaskMutationTools should not be registered in default (chat-safe) mode");
+        registeredToolTypes.ShouldBe(
+        [
+            typeof(DotnetAgents.CalDav.Mcp.Tools.CalendarTools),
+            typeof(DotnetAgents.CalDav.Mcp.Tools.TaskListTools),
+            typeof(DotnetAgents.CalDav.Mcp.Tools.ChatTaskTools)
+        ]);
+
     }
 
     [Fact]
-    public void CreateBuilder_AdvancedMode_RegistersAllToolTypes()
+    public void BuildHost_AdvertisesFrozenCalendarListSchemasAndPrivateCacheHint()
     {
-        // Arrange & Act
+        var builder = CalDavHostBuilder.CreateBuilder();
+        builder.Services.ConfigureCalDav(ValidOptions);
+        using var host = builder.Build();
+
+        var options = host.Services.GetRequiredService<IOptions<ModelContextProtocol.Server.McpServerOptions>>().Value;
+        options.ToolCollection!.TryGetPrimitive("calendars.list", out var tool).ShouldBeTrue();
+
+        var inputSchema = JsonNode.Parse(tool!.ProtocolTool.InputSchema.GetRawText())!.AsObject();
+        var outputSchema = JsonNode.Parse(tool.ProtocolTool.OutputSchema!.Value.GetRawText())!.AsObject();
+        inputSchema["type"]!.GetValue<string>().ShouldBe("object");
+        inputSchema["additionalProperties"]!.GetValue<bool>().ShouldBeFalse();
+        outputSchema["oneOf"]!.AsArray().Count.ShouldBe(2);
+        outputSchema["$defs"]!.AsObject().ShouldContainKey("calendarListSuccess");
+        inputSchema["$defs"].ShouldBeNull();
+        outputSchema["$defs"]!.AsObject().ShouldNotContainKey("deleteInput");
+        tool.ProtocolTool.Meta!["cache"]!["ttlMs"]!.GetValue<int>().ShouldBe(30000);
+        tool.ProtocolTool.Meta!["cache"]!["cacheScope"]!.GetValue<string>().ShouldBe("private");
+    }
+
+    [Fact]
+    public void BuildHost_DefaultMode_ListsToolsInCanonicalWireOrder()
+    {
+        var builder = CalDavHostBuilder.CreateBuilder();
+        builder.Services.ConfigureCalDav(ValidOptions);
+        using var host = builder.Build();
+
+        var tools = host.Services.GetRequiredService<IOptions<ModelContextProtocol.Server.McpServerOptions>>().Value
+            .ToolCollection!
+            .ToArray()
+            .Select(tool => tool.ProtocolTool.Name);
+
+        tools.ShouldBe(
+        [
+            "calendars.list",
+            "list_task_lists",
+            "show_tasks",
+            "add_task",
+            "find_tasks",
+            "complete_task_by_summary",
+            "delete_task_by_summary"
+        ]);
+    }
+
+    [Fact]
+    public void CreateBuilder_AdvancedMode_KeepsLegacyAdvancedTools()
+    {
         var builder = CalDavHostBuilder.CreateBuilder(exposeAdvancedTools: true);
 
-        // Assert — all 4 tool classes should be registered
         var registeredToolTypes = GetRegisteredMcpToolTypes(builder.Services);
 
-        registeredToolTypes.ShouldContain(typeof(DotnetAgents.CalDav.Mcp.Tools.TaskListTools));
-        registeredToolTypes.ShouldContain(typeof(DotnetAgents.CalDav.Mcp.Tools.ChatTaskTools));
+        registeredToolTypes.ShouldContain(typeof(DotnetAgents.CalDav.Mcp.Tools.CalendarTools));
         registeredToolTypes.ShouldContain(typeof(DotnetAgents.CalDav.Mcp.Tools.TaskQueryTools));
         registeredToolTypes.ShouldContain(typeof(DotnetAgents.CalDav.Mcp.Tools.TaskMutationTools));
+    }
+
+    [Fact]
+    public void BuildHost_AdvancedMode_ListsRankedToolsThenOrdinalFallback()
+    {
+        var builder = CalDavHostBuilder.CreateBuilder(exposeAdvancedTools: true);
+        builder.Services.ConfigureCalDav(ValidOptions);
+        using var host = builder.Build();
+
+        var tools = host.Services.GetRequiredService<IOptions<ModelContextProtocol.Server.McpServerOptions>>().Value
+            .ToolCollection!
+            .ToArray()
+            .Select(tool => tool.ProtocolTool.Name);
+
+        tools.ShouldBe(
+        [
+            "calendars.list",
+            "list_task_lists",
+            "show_tasks",
+            "add_task",
+            "find_tasks",
+            "complete_task_by_summary",
+            "delete_task_by_summary",
+            "complete_task",
+            "create_task",
+            "delete_task",
+            "get_task",
+            "list_tasks",
+            "update_task"
+        ]);
     }
 
     private static IReadOnlyList<Type> GetRegisteredMcpToolTypes(IServiceCollection services)

--- a/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/CalendarToolsTests.cs
+++ b/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/CalendarToolsTests.cs
@@ -1,0 +1,227 @@
+using System.Net;
+using System.Text.Json;
+using System.Xml;
+using DotnetAgents.CalDav.Core.Abstractions;
+using DotnetAgents.CalDav.Core.Models;
+using DotnetAgents.CalDav.Mcp.Tools;
+using ModelContextProtocol.Protocol;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace DotnetAgents.CalDav.Mcp.Tests.Unit;
+
+public sealed class CalendarToolsTests
+{
+    [Fact]
+    public async Task ListAsync_MapsScopedDiscoveryToTheVersionedStructuredShape()
+    {
+        var service = Substitute.For<ICalendarService>();
+        var sut = new CalendarTools(service);
+        service.GetCalendarsAsync(Arg.Any<CancellationToken>()).Returns(new CalendarDiscoveryResult(
+        [
+            new CalendarDescriptor
+            {
+                Href = "https://cal.example/events/",
+                DisplayName = "Events",
+                DisplayNameProvenance = DisplayNameProvenance.DavDisplayName,
+                Color = "#AABBCCDD",
+                EventSupport = EntityKindSupport.Advertised,
+                TodoSupport = EntityKindSupport.NotAdvertised,
+                EventEvidence = [new CapabilityEvidence("supported-calendar-component-set", "VEVENT")],
+                TodoEvidence = [new CapabilityEvidence("supported-calendar-component-set", "VEVENT")]
+            }
+        ],
+        [new CalendarDiagnostic("calendar_href_not_found", "Configured Calendar href was not discovered.", CalendarDiagnosticSeverity.Warning)]));
+
+        var wireResult = await sut.ListAsync(CancellationToken.None);
+        var result = wireResult.StructuredContent!.Value.Deserialize<CalendarListResult>()!;
+
+        result.Outcome.ShouldBe("success");
+        result.Items.Single().Calendar.Href.ShouldBe("https://cal.example/events/");
+        result.Items.Single().EntityKinds.Event.State.ShouldBe("advertised");
+        result.Items.Single().EntityKinds.Todo.State.ShouldBe("not_advertised");
+        result.Items.Single().Color.ShouldBeNull();
+        result.Diagnostics.Single().Severity.ShouldBe("warning");
+        result.Pagination.Mode.ShouldBe("non_snapshot");
+        result.Pagination.NextCursor.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task ListAsync_ReturnsTypedLimitErrorWithoutPartialItems()
+    {
+        var service = Substitute.For<ICalendarService>();
+        var sut = new CalendarTools(service);
+        service.GetCalendarsAsync(Arg.Any<CancellationToken>())
+            .Returns(_ => Task.FromException<CalendarDiscoveryResult>(new CalendarDiscoveryLimitException(257)));
+
+        var result = await sut.ListAsync(CancellationToken.None);
+
+        result.IsError.ShouldBe(true);
+        var error = result.StructuredContent!.Value.Deserialize<CalendarErrorResult>()!;
+        error.Code.ShouldBe("limit_exhausted");
+        error.Limits!.CalendarCount.ShouldBe(257);
+    }
+
+    [Theory]
+    [InlineData(HttpStatusCode.Unauthorized, "upstream_unauthorized", false, "upstream", "selectionDiscoveryCapability")]
+    [InlineData(HttpStatusCode.Forbidden, "upstream_forbidden", false, "upstream", "selectionDiscoveryCapability")]
+    [InlineData(HttpStatusCode.TooManyRequests, "upstream_rate_limited", true, "upstream", "selectionDiscoveryCapability")]
+    [InlineData(HttpStatusCode.MethodNotAllowed, "unsupported_capability", false, "capabilityAndProjection", "selectionDiscoveryCapability")]
+    [InlineData(HttpStatusCode.NotImplemented, "unsupported_capability", false, "capabilityAndProjection", "selectionDiscoveryCapability")]
+    [InlineData(HttpStatusCode.RequestEntityTooLarge, "payload_too_large", false, "limitsAndAdmission", "admissionAndPayload")]
+    [InlineData(HttpStatusCode.InsufficientStorage, "upstream_unavailable", false, "upstream", "selectionDiscoveryCapability")]
+    [InlineData(HttpStatusCode.InternalServerError, "upstream_unavailable", true, "upstream", "selectionDiscoveryCapability")]
+    [InlineData(HttpStatusCode.BadGateway, "upstream_unavailable", true, "upstream", "selectionDiscoveryCapability")]
+    [InlineData(HttpStatusCode.NotFound, "upstream_protocol_error", false, "upstream", "selectionDiscoveryCapability")]
+    public async Task ListAsync_MapsUpstreamFailuresToTypedStructuredErrors(
+        HttpStatusCode statusCode,
+        string expectedCode,
+        bool expectedRetryable,
+        string expectedCategory,
+        string expectedPhase)
+    {
+        var service = Substitute.For<ICalendarService>();
+        var sut = new CalendarTools(service);
+        service.GetCalendarsAsync(Arg.Any<CancellationToken>()).Returns(_ =>
+            Task.FromException<CalendarDiscoveryResult>(new HttpRequestException("upstream", null, statusCode)));
+
+        var result = await sut.ListAsync(CancellationToken.None);
+
+        result.IsError.ShouldBe(true);
+        ((TextContentBlock)result.Content.Single()).Text.ShouldBe("Calendar discovery failed.");
+        var error = result.StructuredContent!.Value.Deserialize<CalendarErrorResult>()!;
+        error.Code.ShouldBe(expectedCode);
+        error.Category.ShouldBe(expectedCategory);
+        error.Phase.ShouldBe(expectedPhase);
+        error.Retryable.ShouldBe(expectedRetryable);
+        JsonSerializer.Serialize(error).ShouldNotContain("\"limits\":null");
+    }
+
+    [Fact]
+    public async Task ListAsync_MapsNetworkFailureWithoutStatusToRetryableUnavailable()
+    {
+        var service = Substitute.For<ICalendarService>();
+        var sut = new CalendarTools(service);
+        service.GetCalendarsAsync(Arg.Any<CancellationToken>()).Returns(_ =>
+            Task.FromException<CalendarDiscoveryResult>(new HttpRequestException("network")));
+
+        var result = await sut.ListAsync(CancellationToken.None);
+
+        result.IsError.ShouldBe(true);
+        var error = result.StructuredContent!.Value.Deserialize<CalendarErrorResult>()!;
+        error.Code.ShouldBe("upstream_unavailable");
+        error.Retryable.ShouldBe(true);
+    }
+
+    [Theory]
+    [InlineData("xml", "upstream_protocol_error", false)]
+    [InlineData("timeout", "upstream_unavailable", true)]
+    [InlineData("protocol", "upstream_protocol_error", false)]
+    public async Task ListAsync_MapsProtocolAndTimeoutFailuresToTypedStructuredErrors(
+        string failure,
+        string expectedCode,
+        bool expectedRetryable)
+    {
+        Exception exception = failure == "xml"
+            ? new XmlException("invalid XML")
+            : failure == "timeout"
+                ? new TimeoutException("timed out")
+                : new CalendarDiscoveryProtocolException("invalid DAV response");
+        var service = Substitute.For<ICalendarService>();
+        var sut = new CalendarTools(service);
+        service.GetCalendarsAsync(Arg.Any<CancellationToken>()).Returns(_ =>
+            Task.FromException<CalendarDiscoveryResult>(exception));
+
+        var result = await sut.ListAsync(CancellationToken.None);
+
+        result.IsError.ShouldBe(true);
+        var error = result.StructuredContent!.Value.Deserialize<CalendarErrorResult>()!;
+        error.Code.ShouldBe(expectedCode);
+        error.Retryable.ShouldBe(expectedRetryable);
+        error.Phase.ShouldBe("selectionDiscoveryCapability");
+    }
+
+    [Fact]
+    public async Task ListAsync_MapsUpstreamCancellationToRetryableUnavailable()
+    {
+        var service = Substitute.For<ICalendarService>();
+        var sut = new CalendarTools(service);
+        service.GetCalendarsAsync(Arg.Any<CancellationToken>()).Returns(_ =>
+            Task.FromException<CalendarDiscoveryResult>(new OperationCanceledException("timed out")));
+
+        var result = await sut.ListAsync(CancellationToken.None);
+
+        result.IsError.ShouldBe(true);
+        var error = result.StructuredContent!.Value.Deserialize<CalendarErrorResult>()!;
+        error.Code.ShouldBe("upstream_unavailable");
+        error.Retryable.ShouldBe(true);
+    }
+
+    [Fact]
+    public async Task ListAsync_MapsEveryCalendarDescriptorWireEnum()
+    {
+        var service = Substitute.For<ICalendarService>();
+        var sut = new CalendarTools(service);
+        service.GetCalendarsAsync(Arg.Any<CancellationToken>()).Returns(new CalendarDiscoveryResult(
+        [
+            new CalendarDescriptor
+            {
+                Href = "https://cal.example/derived/",
+                DisplayNameProvenance = DisplayNameProvenance.DerivedFromHref,
+                Color = "#aAbBcC",
+                EventSupport = EntityKindSupport.Unknown,
+                TodoSupport = EntityKindSupport.Advertised
+            },
+            new CalendarDescriptor
+            {
+                Href = "https://cal.example/missing/",
+                DisplayNameProvenance = DisplayNameProvenance.Missing,
+                EventSupport = EntityKindSupport.NotAdvertised,
+                TodoSupport = EntityKindSupport.Unknown
+            },
+            new CalendarDescriptor
+            {
+                Href = "https://cal.example/invalid-color/",
+                DisplayNameProvenance = DisplayNameProvenance.DavDisplayName,
+                Color = "#ZZZZZZ",
+                EventSupport = EntityKindSupport.Advertised,
+                TodoSupport = EntityKindSupport.Advertised
+            },
+            new CalendarDescriptor
+            {
+                Href = "https://cal.example/malformed-color/",
+                DisplayNameProvenance = DisplayNameProvenance.DavDisplayName,
+                Color = "AABBCC",
+                EventSupport = EntityKindSupport.Advertised,
+                TodoSupport = EntityKindSupport.Advertised
+            },
+            new CalendarDescriptor
+            {
+                Href = "https://cal.example/no-color/",
+                DisplayNameProvenance = DisplayNameProvenance.DavDisplayName,
+                EventSupport = EntityKindSupport.Advertised,
+                TodoSupport = EntityKindSupport.Advertised
+            }
+        ],
+        [
+            new CalendarDiagnostic("info", "Information.", CalendarDiagnosticSeverity.Info),
+            new CalendarDiagnostic("error", "Error.", CalendarDiagnosticSeverity.Error)
+        ]));
+
+        var result = (await sut.ListAsync(CancellationToken.None)).StructuredContent!.Value
+            .Deserialize<CalendarListResult>()!;
+
+        result.Items[0].DisplayNameProvenance.ShouldBe("derived-from-href");
+        result.Items[0].Color.ShouldBe("#aAbBcC");
+        result.Items[0].EntityKinds.Event.State.ShouldBe("unknown");
+        result.Items[0].EntityKinds.Todo.State.ShouldBe("advertised");
+        result.Items[1].DisplayNameProvenance.ShouldBe("missing");
+        result.Items[1].EntityKinds.Event.State.ShouldBe("not_advertised");
+        result.Items[1].EntityKinds.Todo.State.ShouldBe("unknown");
+        result.Items[2].Color.ShouldBeNull();
+        result.Items[3].Color.ShouldBeNull();
+        result.Items[4].Color.ShouldBeNull();
+        result.Diagnostics.Select(diagnostic => diagnostic.Severity).ShouldBe(["info", "error"]);
+    }
+}

--- a/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/McpMetadataTests.cs
+++ b/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/McpMetadataTests.cs
@@ -76,6 +76,7 @@ public class McpMetadataTests
             .ToList();
 
         envVarNames.ShouldContain("CALDAV_TASK_LISTS");
+        envVarNames.ShouldContain("CALDAV_CALENDAR_HREFS");
     }
 
     [Fact]
@@ -95,6 +96,8 @@ public class McpMetadataTests
             .ToList();
 
         envVarNames.ShouldContain("CALDAV_DEFAULT_TASK_LIST");
+        envVarNames.ShouldContain("CALDAV_DEFAULT_TODO_CALENDAR_NAME");
+        envVarNames.ShouldContain("CALDAV_DEFAULT_EVENT_CALENDAR_NAME");
     }
 
     // ─── packaging metadata ─────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #37

Stack: PR 2 for issue #35. Target base: codex/issue-36-contract-harness.

Implements scoped CalDAV Calendar discovery through the native 2026-07-28 MCP surface, including frozen #36 advertised schemas/cache metadata, independent capability/default handling, bounded typed errors, deterministic tools/list ordering, and an SDK stdio-client test.

Local verification: Release build; Core unit 167/167; MCP unit 140/140; unit coverage 95.8% line / 85.0% branch; Slopwatch clean. The Docker-backed integration fixture could not be completed locally: with Ryuk disabled, RadicaleFixture.InitializeAsync -> CreateUserPrincipalAsync timed out after 100 seconds before the test method/MCP discover/tools-list/call; the normal full run also failed starting Testcontainers ResourceReaper. CI is the decisive Docker evidence.