### PR TITLE
Read lossless Calendar Object Resource snapshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Add this MCP server to VS Code, Claude Desktop, Cursor, or any MCP client:
 | `CALDAV_PASSWORD` | Yes | Password for Basic auth |
 | `CALDAV_TASK_LISTS` | No | Comma-separated task list hrefs to expose; omit to auto-discover |
 | `CALDAV_EXPOSE_ADVANCED_TOOLS` | No | Set to `true` to expose href-based tools like `get_task`, `update_task`, `complete_task`, and `delete_task` |
+| `CALDAV_EXPOSE_EXACT_TOOLS` | No | Set to `true` to expose protected exact Calendar Object Resource tools |
 
 ## Available tools
 
@@ -53,7 +54,12 @@ Add this MCP server to VS Code, Claude Desktop, Cursor, or any MCP client:
 - `complete_task` — Mark a task complete.
 - `delete_task` — Delete a task.
 
-By default, the server exposes only the chat-safe tools: `list_task_lists`, `caldav_add_task`, `caldav_complete_task_by_summary`, and `caldav_delete_task_by_summary`. Set `CALDAV_EXPOSE_ADVANCED_TOOLS=true` to also expose the href-based advanced tools.
+### Calendar resource tools
+
+- `calendar_resources.get` — Read an authoritative semantic-or-opaque snapshot by confirmed absolute href.
+- `calendar_resources.exact_get` — Opt-in exact read through a protected MCP resource link; enable with `CALDAV_EXPOSE_EXACT_TOOLS=true`.
+
+By default, the server exposes `calendars.list` and `calendar_resources.get` alongside the legacy chat-safe tools retained during the staged migration. Set `CALDAV_EXPOSE_ADVANCED_TOOLS=true` to also expose the legacy href-based advanced tools.
 
 ## Supported servers
 

--- a/scripts/verify-coverage.sh
+++ b/scripts/verify-coverage.sh
@@ -14,8 +14,8 @@ fi
 
 echo "Using coverage file: $COBERTURA_FILE"
 
-LINE_RATE=$(grep -oP 'line-rate="[^"]*"' "$COBERTURA_FILE" | head -1 | grep -oP '[\d.]+')
-BRANCH_RATE=$(grep -oP 'branch-rate="[^"]*"' "$COBERTURA_FILE" | head -1 | grep -oP '[\d.]+')
+LINE_RATE=$(grep -m1 -oP 'line-rate="[^"]*"' "$COBERTURA_FILE" | grep -oP '[\d.]+')
+BRANCH_RATE=$(grep -m1 -oP 'branch-rate="[^"]*"' "$COBERTURA_FILE" | grep -oP '[\d.]+')
 
 if [ -z "$LINE_RATE" ] || [ -z "$BRANCH_RATE" ]; then
   echo "::error::Failed to parse coverage rates from $COBERTURA_FILE"

--- a/src/DotnetAgents.CalDav.Core/Abstractions/ICalendarClient.cs
+++ b/src/DotnetAgents.CalDav.Core/Abstractions/ICalendarClient.cs
@@ -7,4 +7,7 @@ public interface ICalendarClient
 {
     /// <summary>Discovers every Calendar collection visible to the configured account.</summary>
     Task<IReadOnlyList<CalendarDescriptor>> GetCalendarsAsync(CancellationToken cancellationToken);
+
+    /// <summary>Reads one complete Calendar Object Resource revision by canonical absolute href.</summary>
+    Task<CalendarResourceRead> GetCalendarResourceAsync(string href, CancellationToken cancellationToken);
 }

--- a/src/DotnetAgents.CalDav.Core/Abstractions/ICalendarService.cs
+++ b/src/DotnetAgents.CalDav.Core/Abstractions/ICalendarService.cs
@@ -12,4 +12,7 @@ public interface ICalendarService
     Task<CalendarSelectionResult> ResolveDefaultCalendarAsync(
         CalendarEntityKind entityKind,
         CancellationToken cancellationToken);
+
+    /// <summary>Reads one authoritative Calendar Object Resource snapshot.</summary>
+    Task<CalendarResourceRead> GetResourceAsync(string href, CancellationToken cancellationToken);
 }

--- a/src/DotnetAgents.CalDav.Core/Internal/CalDavClient.cs
+++ b/src/DotnetAgents.CalDav.Core/Internal/CalDavClient.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Globalization;
+using System.Buffers;
 using System.Net;
 using System.Net.Http.Headers;
 using System.Text;
@@ -19,6 +20,8 @@ namespace DotnetAgents.CalDav.Core.Internal;
 /// </summary>
 internal sealed class CalDavClient : ICalDavClient, ICalendarClient
 {
+    private const int MaximumCalendarResourceBytes = 4 * 1024 * 1024;
+    private static readonly UTF8Encoding StrictUtf8 = new(false, true);
     private static readonly ActivitySource ActivitySource = new("DotnetAgents.CalDav", "0.1.0");
     private static readonly HttpMethod PropFindMethod = new("PROPFIND");
     private static readonly HttpMethod ReportMethod = new("REPORT");
@@ -102,6 +105,108 @@ internal sealed class CalDavClient : ICalDavClient, ICalendarClient
             .OrderBy(calendar => calendar.Href, StringComparer.Ordinal)
             .ToArray();
     }
+
+    /// <inheritdoc />
+    public async Task<CalendarResourceRead> GetCalendarResourceAsync(string href, CancellationToken cancellationToken)
+    {
+        if (!TryValidateAbsoluteResourceHref(href, out var resourceUri))
+            return new CalendarResourceRead(CalendarResourceReadCode.InvalidInput);
+
+        using var request = new HttpRequestMessage(HttpMethod.Get, resourceUri);
+        using var response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+        if (response.StatusCode == HttpStatusCode.NotFound)
+            return new CalendarResourceRead(CalendarResourceReadCode.NotFound);
+
+        response.EnsureSuccessStatusCode();
+        var responseEntityTag = response.Headers.ETag;
+        if (responseEntityTag is null || responseEntityTag.IsWeak)
+            return new CalendarResourceRead(CalendarResourceReadCode.ConcurrencyUnavailable);
+
+        var entityTag = responseEntityTag.ToString();
+        var bounded = await ReadBoundedContentAsync(response.Content, cancellationToken);
+        if (bounded.Content is null)
+            return new CalendarResourceRead(CalendarResourceReadCode.PayloadTooLarge, ObservedByteCount: bounded.ObservedByteCount);
+        var content = bounded.Content;
+        try
+        {
+            _ = StrictUtf8.GetCharCount(content);
+        }
+        catch (DecoderFallbackException)
+        {
+            return new CalendarResourceRead(CalendarResourceReadCode.UpstreamProtocolError);
+        }
+
+        return CalendarResourceRead.Success(href, entityTag, content);
+    }
+
+    private bool TryValidateAbsoluteResourceHref(string href, out Uri resourceUri)
+    {
+        resourceUri = null!;
+        if (!Uri.TryCreate(href, UriKind.Absolute, out var candidate) || !IsSafeCanonicalUri(candidate, href))
+            return false;
+
+        var origin = new Uri(_options.Value.BaseUrl, UriKind.Absolute);
+        if (!HasSameOrigin(origin, candidate))
+            return false;
+
+        resourceUri = candidate;
+        return true;
+    }
+
+    private static bool IsSafeCanonicalUri(Uri candidate, string original) =>
+        (candidate.Scheme.Equals(Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase)
+            || candidate.Scheme.Equals(Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
+        && string.IsNullOrEmpty(candidate.UserInfo)
+        && string.IsNullOrEmpty(candidate.Fragment)
+        && string.IsNullOrEmpty(candidate.Query)
+        && !candidate.AbsolutePath.Contains("%2F", StringComparison.OrdinalIgnoreCase)
+        && !candidate.AbsolutePath.Contains("%5C", StringComparison.OrdinalIgnoreCase)
+        && string.Equals(candidate.AbsoluteUri, original, StringComparison.Ordinal);
+
+    private static bool HasSameOrigin(Uri left, Uri right) =>
+        string.Equals(left.Scheme, right.Scheme, StringComparison.OrdinalIgnoreCase)
+        && string.Equals(left.Host, right.Host, StringComparison.OrdinalIgnoreCase)
+        && left.Port == right.Port;
+
+    private static async Task<BoundedContentRead> ReadBoundedContentAsync(
+        HttpContent content,
+        CancellationToken cancellationToken)
+    {
+        if (content.Headers.ContentLength > MaximumCalendarResourceBytes)
+            return new BoundedContentRead(null, SaturateByteCount(content.Headers.ContentLength.Value));
+
+        await using var stream = await content.ReadAsStreamAsync(cancellationToken);
+        using var destination = new MemoryStream(
+            content.Headers.ContentLength is >= 0 and <= MaximumCalendarResourceBytes
+                ? (int)content.Headers.ContentLength.Value
+                : 0);
+        var buffer = ArrayPool<byte>.Shared.Rent(81920);
+        try
+        {
+            while (destination.Length <= MaximumCalendarResourceBytes)
+            {
+                var remainingPlusOne = (MaximumCalendarResourceBytes - (int)destination.Length) + 1;
+                var read = await stream.ReadAsync(
+                    buffer.AsMemory(0, Math.Min(buffer.Length, remainingPlusOne)),
+                    cancellationToken);
+                if (read == 0)
+                    return new BoundedContentRead(destination.ToArray(), (int)destination.Length);
+                if (destination.Length + read > MaximumCalendarResourceBytes)
+                    return new BoundedContentRead(null, (int)destination.Length + read);
+                await destination.WriteAsync(buffer.AsMemory(0, read), cancellationToken);
+            }
+
+            return new BoundedContentRead(null, MaximumCalendarResourceBytes + 1);
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+        }
+    }
+
+    private static int SaturateByteCount(long byteCount) => byteCount > int.MaxValue ? int.MaxValue : (int)byteCount;
+
+    private sealed record BoundedContentRead(byte[]? Content, int ObservedByteCount);
 
     /// <inheritdoc/>
     public async Task<IReadOnlyList<TaskItem>> GetTasksAsync(string taskListHref, TaskQuery query, CancellationToken cancellationToken)

--- a/src/DotnetAgents.CalDav.Core/Internal/Ical/CalendarContentDocument.cs
+++ b/src/DotnetAgents.CalDav.Core/Internal/Ical/CalendarContentDocument.cs
@@ -1,0 +1,480 @@
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Collections.Frozen;
+using DotnetAgents.CalDav.Core.Models;
+
+namespace DotnetAgents.CalDav.Core.Internal.Ical;
+
+internal sealed record CalendarContentProperty(
+    IReadOnlyList<CalendarComponentPathSegment> ComponentPath,
+    string Name,
+    IReadOnlyList<CalendarParameter> Parameters,
+    CalendarPropertyValueType ValueType,
+    string RawEncodedValue,
+    string OriginalSlice,
+    int Start,
+    int Length);
+
+internal sealed record CalendarContentComponent(
+    IReadOnlyList<CalendarComponentPathSegment> Path,
+    string BeginSlice,
+    string EndSlice,
+    int Start,
+    int Length);
+
+internal sealed partial class CalendarContentDocument
+{
+    private static readonly FrozenDictionary<string, CalendarPropertyValueType> DefaultValueTypes = CreateDefaultValueTypes();
+    private static readonly FrozenDictionary<string, CalendarPropertyValueType> ExplicitValueTypes =
+        new Dictionary<string, CalendarPropertyValueType>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["TEXT"] = CalendarPropertyValueType.Text,
+            ["URI"] = CalendarPropertyValueType.Uri,
+            ["CAL-ADDRESS"] = CalendarPropertyValueType.Uri,
+            ["DATE"] = CalendarPropertyValueType.Date,
+            ["DATE-TIME"] = CalendarPropertyValueType.DateTime,
+            ["DURATION"] = CalendarPropertyValueType.Duration,
+            ["INTEGER"] = CalendarPropertyValueType.Integer,
+            ["FLOAT"] = CalendarPropertyValueType.Float,
+            ["PERIOD"] = CalendarPropertyValueType.Period,
+            ["RECUR"] = CalendarPropertyValueType.Recur,
+            ["BINARY"] = CalendarPropertyValueType.Binary
+        }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
+    private static readonly FrozenSet<string> RegisteredPropertyNames = DefaultValueTypes.Keys
+        .Concat(["TZOFFSETFROM", "TZOFFSETTO"])
+        .ToFrozenSet(StringComparer.OrdinalIgnoreCase);
+    private static readonly UTF8Encoding StrictUtf8 = new(false, true);
+    private readonly byte[] _authoritativeUtf8;
+    private readonly string _content;
+
+    private static FrozenDictionary<string, CalendarPropertyValueType> CreateDefaultValueTypes()
+    {
+        var mappings = new Dictionary<string, CalendarPropertyValueType>(StringComparer.OrdinalIgnoreCase);
+        AddDefaultValueTypes(mappings, CalendarPropertyValueType.Uri,
+            "ATTACH", "ATTENDEE", "CALENDAR-ADDRESS", "CONCEPT", "CONFERENCE", "IMAGE", "LINK", "ORGANIZER", "SOURCE", "TZURL", "URL");
+        AddDefaultValueTypes(mappings, CalendarPropertyValueType.DateTime,
+            "ACKNOWLEDGED", "COMPLETED", "CREATED", "DTEND", "DTSTAMP", "DTSTART", "DUE", "EXDATE", "LAST-MODIFIED", "RDATE", "RECURRENCE-ID");
+        AddDefaultValueTypes(mappings, CalendarPropertyValueType.Duration, "DURATION", "REFRESH-INTERVAL", "TRIGGER");
+        AddDefaultValueTypes(mappings, CalendarPropertyValueType.Integer, "PERCENT-COMPLETE", "PRIORITY", "REPEAT", "SEQUENCE");
+        AddDefaultValueTypes(mappings, CalendarPropertyValueType.Float, "GEO");
+        AddDefaultValueTypes(mappings, CalendarPropertyValueType.Period, "FREEBUSY");
+        AddDefaultValueTypes(mappings, CalendarPropertyValueType.Recur, "EXRULE", "RRULE");
+        AddDefaultValueTypes(mappings, CalendarPropertyValueType.Text,
+            "ACTION", "CALSCALE", "CATEGORIES", "CLASS", "COLOR", "COMMENT", "CONTACT", "DESCRIPTION", "LOCATION",
+            "METHOD", "NAME", "PRODID", "PROXIMITY", "REFID", "RELATED-TO", "REQUEST-STATUS", "RESOURCES",
+            "RESOURCE-TYPE", "STATUS", "STRUCTURED-DATA", "SUMMARY", "TRANSP", "TZID", "TZNAME", "UID", "VERSION");
+        return mappings.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
+    }
+
+    private static void AddDefaultValueTypes(
+        IDictionary<string, CalendarPropertyValueType> mappings,
+        CalendarPropertyValueType valueType,
+        params string[] propertyNames)
+    {
+        foreach (var propertyName in propertyNames)
+            mappings.Add(propertyName, valueType);
+    }
+
+    private CalendarContentDocument(
+        byte[] authoritativeUtf8,
+        string content,
+        IReadOnlyList<CalendarContentProperty> properties,
+        IReadOnlyList<CalendarContentComponent> components)
+    {
+        _authoritativeUtf8 = authoritativeUtf8;
+        _content = content;
+        Properties = properties;
+        Components = components;
+    }
+
+    public IReadOnlyList<CalendarContentProperty> Properties { get; }
+
+    public IReadOnlyList<CalendarContentComponent> Components { get; }
+
+    public static CalendarContentDocument Parse(ReadOnlySpan<byte> authoritativeUtf8)
+    {
+        var bytes = authoritativeUtf8.ToArray();
+        var content = StrictUtf8.GetString(bytes);
+        var logicalLines = Unfold(ReadPhysicalLines(content));
+        var (properties, components) = ParseContent(logicalLines);
+        return new CalendarContentDocument(bytes, content, properties, components);
+    }
+
+    public byte[] Replay() => _authoritativeUtf8.ToArray();
+
+    internal static bool IsRegisteredPropertyName(string name) => RegisteredPropertyNames.Contains(name);
+
+    internal static bool IsValidRegisteredUnknownValue(CalendarContentProperty property) =>
+        property.Name is "TZOFFSETFROM" or "TZOFFSETTO"
+        && !property.Parameters.Any(parameter => parameter.Name.Equals("VALUE", StringComparison.OrdinalIgnoreCase))
+        && property.RawEncodedValue is not "-0000" and not "-000000"
+        && UtcOffsetPattern().IsMatch(property.RawEncodedValue);
+
+    [GeneratedRegex("^[+-](?:[01][0-9]|2[0-3])[0-5][0-9](?:[0-5][0-9]|60)?$", RegexOptions.CultureInvariant)]
+    private static partial Regex UtcOffsetPattern();
+
+    public byte[] ReplayForTypedValidation()
+    {
+        var componentRemovals = Components.Where(component => !IsTypedValidationComponent(component.Path[^1].Name))
+            .Select(component => new ContentRange(component.Start, component.Length));
+        var propertyRemovals = Properties.Where(property => !IsTypedValidationProperty(property))
+            .Select(property => new ContentRange(property.Start, property.Length));
+        var removals = componentRemovals.Concat(propertyRemovals)
+            .OrderBy(range => range.Start)
+            .ThenByDescending(range => range.Length)
+            .ToArray();
+        var validation = new StringBuilder(_content.Length);
+        var position = 0;
+        foreach (var removal in removals)
+        {
+            if (removal.Start < position)
+                continue;
+            validation.Append(_content, position, removal.Start - position);
+            position = removal.Start + removal.Length;
+        }
+        validation.Append(_content, position, _content.Length - position);
+        return StrictUtf8.GetBytes(validation.ToString());
+    }
+
+    public byte[] ReplaceSinglePropertyValue(
+        IReadOnlyList<CalendarComponentPathSegment> componentPath,
+        string propertyName,
+        string rawEncodedValue)
+    {
+        if (rawEncodedValue.Contains('\r') || rawEncodedValue.Contains('\n'))
+            throw new ArgumentException("A replacement value cannot contain a physical line break.", nameof(rawEncodedValue));
+        var matches = Properties.Where(property => property.Name.Equals(propertyName, StringComparison.OrdinalIgnoreCase)
+            && PathsEqual(property.ComponentPath, componentPath)).ToArray();
+        if (matches.Length != 1)
+            throw new InvalidOperationException("The addressed property must occur exactly once.");
+
+        var property = matches[0];
+        var colon = FindPhysicalUnquoted(property.OriginalSlice, ':');
+        var ending = property.OriginalSlice.EndsWith("\r\n", StringComparison.Ordinal) ? "\r\n"
+            : property.OriginalSlice.EndsWith('\n') ? "\n" : string.Empty;
+        var edited = new StringBuilder(_content.Length - property.Length + colon + rawEncodedValue.Length + ending.Length + 1);
+        edited.Append(_content, 0, property.Start);
+        edited.Append(property.OriginalSlice, 0, colon + 1);
+        edited.Append(rawEncodedValue);
+        edited.Append(ending);
+        edited.Append(_content, property.Start + property.Length, _content.Length - property.Start - property.Length);
+        return StrictUtf8.GetBytes(edited.ToString());
+    }
+
+    private static (IReadOnlyList<CalendarContentProperty> Properties, IReadOnlyList<CalendarContentComponent> Components)
+        ParseContent(IReadOnlyList<LogicalLine> lines)
+    {
+        var properties = new List<CalendarContentProperty>();
+        var components = new List<CalendarContentComponent>();
+        var stack = new Stack<ComponentFrame>();
+        var rootOccurrences = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var line in lines)
+        {
+            var colon = FindUnquoted(line.Unfolded, ':');
+            if (colon <= 0)
+                throw new FormatException("An iCalendar content line is malformed.");
+
+            var header = line.Unfolded[..colon];
+            var value = line.Unfolded[(colon + 1)..];
+            if (header.Equals("BEGIN", StringComparison.OrdinalIgnoreCase))
+            {
+                PushComponent(stack, rootOccurrences, value, line.OriginalSlice, line.Start);
+                continue;
+            }
+
+            if (header.Equals("END", StringComparison.OrdinalIgnoreCase))
+            {
+                PopComponent(stack, components, value, line.OriginalSlice, line.Start);
+                continue;
+            }
+
+            if (stack.Count == 0)
+                throw new FormatException("An iCalendar property appears outside a component.");
+
+            var headerParts = SplitUnquoted(header, ';');
+            var name = GetPropertyName(headerParts[0]);
+
+            var parameters = headerParts.Skip(1).Select(ParseParameter).ToArray();
+            properties.Add(new CalendarContentProperty(
+                stack.Reverse().Select(frame => new CalendarComponentPathSegment(frame.Name, frame.Occurrence)).ToArray(),
+                name,
+                parameters,
+                GetValueType(name, parameters),
+                value,
+                line.OriginalSlice,
+                line.Start,
+                line.OriginalSlice.Length));
+        }
+
+        if (stack.Count != 0)
+            throw new FormatException("An iCalendar component is not closed.");
+
+        return (properties, components);
+    }
+
+    private static void PushComponent(
+        Stack<ComponentFrame> stack,
+        Dictionary<string, int> rootOccurrences,
+        string rawName,
+        string beginSlice,
+        int beginStart)
+    {
+        var name = rawName.Trim().ToUpperInvariant();
+        if (!IsName(name))
+            throw new FormatException("An iCalendar component name is malformed.");
+
+        var occurrences = stack.TryPeek(out var parent) ? parent.ChildOccurrences : rootOccurrences;
+        occurrences.TryGetValue(name, out var occurrence);
+        occurrences[name] = occurrence + 1;
+        var path = stack.Reverse()
+            .Select(frame => new CalendarComponentPathSegment(frame.Name, frame.Occurrence))
+            .Append(new CalendarComponentPathSegment(name, occurrence))
+            .ToArray();
+        stack.Push(new ComponentFrame(name, occurrence, path, beginSlice, beginStart));
+    }
+
+    private static void PopComponent(
+        Stack<ComponentFrame> stack,
+        List<CalendarContentComponent> components,
+        string rawName,
+        string endSlice,
+        int endStart)
+    {
+        if (!stack.TryPop(out var component)
+            || !string.Equals(component.Name, rawName.Trim(), StringComparison.OrdinalIgnoreCase))
+        {
+            throw new FormatException("An iCalendar component boundary is mismatched.");
+        }
+
+        components.Add(new CalendarContentComponent(
+            component.Path,
+            component.BeginSlice,
+            endSlice,
+            component.BeginStart,
+            endStart + endSlice.Length - component.BeginStart));
+    }
+
+    private static CalendarParameter ParseParameter(string text)
+    {
+        var equals = FindUnquoted(text, '=');
+        if (equals <= 0)
+            throw new FormatException("An iCalendar parameter is malformed.");
+
+        var name = text[..equals];
+        if (!IsName(name))
+            throw new FormatException("An iCalendar parameter name is malformed.");
+
+        var values = SplitUnquoted(text[(equals + 1)..], ',')
+            .Select(DecodeParameterValue)
+            .ToArray();
+        if (values.Length == 0)
+            throw new FormatException("An iCalendar parameter has no value.");
+        return new CalendarParameter(name, values);
+    }
+
+    private static string DecodeParameterValue(string value)
+    {
+        var unquoted = value.Length >= 2 && value[0] == '"' && value[^1] == '"'
+            ? value[1..^1]
+            : value;
+        var decoded = new StringBuilder(unquoted.Length);
+        for (var index = 0; index < unquoted.Length; index++)
+        {
+            if (unquoted[index] != '^' || index + 1 >= unquoted.Length)
+            {
+                decoded.Append(unquoted[index]);
+                continue;
+            }
+
+            var escaped = unquoted[index + 1];
+            if (escaped == '^')
+                decoded.Append('^');
+            else if (escaped is 'n' or 'N')
+                decoded.Append('\n');
+            else if (escaped == '\'')
+                decoded.Append('"');
+            else
+            {
+                decoded.Append('^');
+                continue;
+            }
+
+            index++;
+        }
+
+        return decoded.ToString();
+    }
+
+    private static CalendarPropertyValueType GetValueType(
+        string propertyName,
+        IReadOnlyList<CalendarParameter> parameters)
+    {
+        var explicitType = parameters
+            .Where(parameter => parameter.Name.Equals("VALUE", StringComparison.OrdinalIgnoreCase))
+            .SelectMany(parameter => parameter.Values)
+            .LastOrDefault();
+        return explicitType is null
+            ? GetDefaultValueType(propertyName)
+            : ParseValueType(explicitType);
+    }
+
+    internal static CalendarPropertyValueType GetDefaultValueType(string propertyName) =>
+        DefaultValueTypes.TryGetValue(propertyName, out var valueType) ? valueType : CalendarPropertyValueType.Unknown;
+
+    private static CalendarPropertyValueType ParseValueType(string value) =>
+        ExplicitValueTypes.TryGetValue(value, out var valueType) ? valueType : CalendarPropertyValueType.Unknown;
+
+    private static IReadOnlyList<PhysicalLine> ReadPhysicalLines(string content)
+    {
+        var lines = new List<PhysicalLine>();
+        var start = 0;
+        for (var index = 0; index < content.Length; index++)
+        {
+            if (content[index] == '\r')
+            {
+                if (index + 1 >= content.Length || content[index + 1] != '\n')
+                    throw new FormatException("An iCalendar line ending is malformed.");
+                lines.Add(new PhysicalLine(content[start..index], content[start..(index + 2)], start));
+                start = ++index + 1;
+            }
+            else if (content[index] == '\n')
+            {
+                lines.Add(new PhysicalLine(content[start..index], content[start..(index + 1)], start));
+                start = index + 1;
+            }
+        }
+
+        if (start < content.Length)
+            lines.Add(new PhysicalLine(content[start..], content[start..], start));
+        return lines;
+    }
+
+    private static IReadOnlyList<LogicalLine> Unfold(IReadOnlyList<PhysicalLine> physicalLines)
+    {
+        var logicalLines = new List<LogicalLine>();
+        foreach (var line in physicalLines)
+        {
+            if (line.Content.Length > 0 && line.Content[0] is ' ' or '\t')
+            {
+                if (logicalLines.Count == 0)
+                    throw new FormatException("An iCalendar fold has no preceding line.");
+                var previous = logicalLines[^1];
+                logicalLines[^1] = previous with
+                {
+                    Unfolded = previous.Unfolded + line.Content[1..],
+                    OriginalSlice = previous.OriginalSlice + line.OriginalSlice
+                };
+            }
+            else if (line.Content.Length > 0)
+            {
+                logicalLines.Add(new LogicalLine(line.Content, line.OriginalSlice, line.Start));
+            }
+        }
+
+        return logicalLines;
+    }
+
+    private static string[] SplitUnquoted(string text, char separator)
+    {
+        var parts = new List<string>();
+        var start = 0;
+        var quoted = false;
+        for (var index = 0; index < text.Length; index++)
+        {
+            if (text[index] == '"')
+                quoted = !quoted;
+            else if (text[index] == separator && !quoted)
+            {
+                parts.Add(text[start..index]);
+                start = index + 1;
+            }
+        }
+
+        if (quoted)
+            throw new FormatException("An iCalendar quoted parameter is not closed.");
+        parts.Add(text[start..]);
+        return parts.ToArray();
+    }
+
+    private static int FindUnquoted(string text, char value)
+    {
+        var quoted = false;
+        for (var index = 0; index < text.Length; index++)
+        {
+            if (text[index] == '"')
+                quoted = !quoted;
+            else if (text[index] == value && !quoted)
+                return index;
+        }
+
+        return -1;
+    }
+
+    private static bool IsName(string value) =>
+        value.Length > 0 && value.All(character => char.IsAsciiLetterOrDigit(character) || character == '-');
+
+    private static string GetPropertyName(string value)
+    {
+        var parts = value.Split('.');
+        if (parts.Length is < 1 or > 2 || parts.Any(part => !IsName(part)))
+            throw new FormatException("An iCalendar property name is malformed.");
+        return parts[^1];
+    }
+
+    private static bool IsTypedValidationComponent(string name) => name is
+        "VCALENDAR" or "VEVENT" or "VTODO" or "VTIMEZONE" or "STANDARD" or "DAYLIGHT" or "VALARM";
+
+    private static bool IsTypedValidationProperty(CalendarContentProperty property) =>
+        IsRegisteredPropertyName(property.Name);
+
+    private static int FindPhysicalUnquoted(string slice, char value)
+    {
+        var quoted = false;
+        for (var index = 0; index < slice.Length; index++)
+        {
+            var foldLength = GetFoldMarkerLength(slice, index);
+            if (foldLength > 0)
+            {
+                index += foldLength - 1;
+                continue;
+            }
+            if (slice[index] == '"')
+                quoted = !quoted;
+            else if (slice[index] == value && !quoted)
+                return index;
+        }
+
+        throw new FormatException("An iCalendar content line is malformed.");
+    }
+
+    private static int GetFoldMarkerLength(string slice, int index)
+    {
+        if (slice[index] == '\r' && index + 2 < slice.Length && slice[index + 1] == '\n')
+            return slice[index + 2] is ' ' or '\t' ? 3 : 0;
+        if (slice[index] == '\n' && index + 1 < slice.Length)
+            return slice[index + 1] is ' ' or '\t' ? 2 : 0;
+        return 0;
+    }
+
+    private static bool PathsEqual(
+        IReadOnlyList<CalendarComponentPathSegment> left,
+        IReadOnlyList<CalendarComponentPathSegment> right) => left.Count == right.Count
+        && left.Zip(right).All(pair => pair.First == pair.Second);
+
+    private sealed record ComponentFrame(
+        string Name,
+        int Occurrence,
+        IReadOnlyList<CalendarComponentPathSegment> Path,
+        string BeginSlice,
+        int BeginStart)
+    {
+        public Dictionary<string, int> ChildOccurrences { get; } = new(StringComparer.OrdinalIgnoreCase);
+    }
+
+    private sealed record PhysicalLine(string Content, string OriginalSlice, int Start);
+
+    private sealed record LogicalLine(string Unfolded, string OriginalSlice, int Start);
+
+    private sealed record ContentRange(int Start, int Length);
+}

--- a/src/DotnetAgents.CalDav.Core/Internal/Ical/CalendarResourceProjector.cs
+++ b/src/DotnetAgents.CalDav.Core/Internal/Ical/CalendarResourceProjector.cs
@@ -1,0 +1,396 @@
+using System.Globalization;
+using System.Text;
+using DotnetAgents.CalDav.Core.Models;
+using Ical.Net.Serialization;
+using IcalCalendar = Ical.Net.Calendar;
+
+namespace DotnetAgents.CalDav.Core.Internal.Ical;
+
+internal sealed record CalendarProjectionResult(
+    CalendarResourceProjection Projection,
+    IReadOnlyList<CalendarProperty> Properties,
+    IReadOnlyList<CalendarResourceDiagnostic> Diagnostics);
+
+internal static class CalendarResourceProjector
+{
+    private static readonly HashSet<string> SingletonProperties = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "UID", "RECURRENCE-ID", "SUMMARY", "DESCRIPTION", "DTSTART", "DTEND", "DUE", "DURATION",
+        "LOCATION", "STATUS", "TRANSP", "CLASS", "PRIORITY", "URL", "COMPLETED", "DTSTAMP",
+        "CREATED", "LAST-MODIFIED", "GEO", "ORGANIZER", "PERCENT-COMPLETE", "SEQUENCE", "RRULE"
+    };
+
+    public static CalendarProjectionResult Project(ReadOnlySpan<byte> authoritativeUtf8)
+    {
+        try
+        {
+            var document = CalendarContentDocument.Parse(authoritativeUtf8);
+            return ProjectDocument(document);
+        }
+        catch (Exception exception) when (exception is FormatException or DecoderFallbackException)
+        {
+            return Opaque([], "invalid_calendar_data");
+        }
+    }
+
+    private static CalendarProjectionResult ProjectDocument(CalendarContentDocument document)
+    {
+        var properties = document.Properties.Select(ToPublicProperty).ToArray();
+        try
+        {
+            var diagnostic = ValidateComponents(document.Components);
+            if (diagnostic is not null)
+                return Opaque(properties, diagnostic);
+            diagnostic = ValidateCalendarProperties(document.Properties);
+            if (diagnostic is not null)
+                return Opaque(properties, diagnostic);
+
+            var entities = GetEntityComponents(document);
+            diagnostic = ValidateEntityComponents(entities);
+            if (diagnostic is not null)
+                return Opaque(properties, diagnostic);
+
+            if (!IcalNetCorroborates(document.ReplayForTypedValidation(), entities[0].Kind, entities.Count))
+                return Opaque(properties, "typed_projection_invalid");
+
+            var master = entities.Single(entity => entity.RecurrenceIdentity is null);
+            var projection = new CalendarResourceProjection(
+                master.Kind,
+                master.Uid,
+                DecodeText(GetOptionalValue(master.Properties, "SUMMARY")));
+            return new CalendarProjectionResult(projection, properties, []);
+        }
+        catch (Exception exception) when (exception is FormatException or InvalidOperationException)
+        {
+            return Opaque(properties, "typed_projection_invalid");
+        }
+    }
+
+    private static IReadOnlyList<EntityComponent> GetEntityComponents(CalendarContentDocument document) => document.Components
+        .Where(component => IsEntityComponent(component.Path[^1].Name))
+        .Select(component => CreateEntity(component, document.Properties))
+        .ToArray();
+
+    private static EntityComponent CreateEntity(
+        CalendarContentComponent component,
+        IReadOnlyList<CalendarContentProperty> properties)
+    {
+        var owned = properties.Where(property => PathsEqual(property.ComponentPath, component.Path)).ToArray();
+        var recurrenceProperty = GetProperty(owned, "RECURRENCE-ID");
+        return new EntityComponent(
+            component.Path[^1].Name.Equals("VEVENT", StringComparison.OrdinalIgnoreCase)
+                ? CalendarResourceProjectionKind.Event
+                : CalendarResourceProjectionKind.Todo,
+            DecodeText(GetRequiredValue(owned, "UID")),
+            recurrenceProperty is null ? null : GetTemporalIdentity(recurrenceProperty),
+            owned);
+    }
+
+    private static string? ValidateComponents(IReadOnlyList<CalendarContentComponent> components)
+    {
+        var roots = components.Where(component => component.Path.Count == 1).ToArray();
+        if (roots.Length != 1 || !roots[0].Path[0].Name.Equals("VCALENDAR", StringComparison.OrdinalIgnoreCase))
+            return "calendar_component_cardinality";
+
+        if (components.Any(component => !HasValidKnownTopology(component.Path)))
+            return "known_component_topology_invalid";
+
+        var unsupported = components.Any(component => component.Path[^1].Name is "VJOURNAL" or "VFREEBUSY");
+        return unsupported ? "unsupported_entity_component" : null;
+    }
+
+    private static bool HasValidKnownTopology(IReadOnlyList<CalendarComponentPathSegment> path) => path[^1].Name switch
+    {
+        "VCALENDAR" => path.Count == 1,
+        "VEVENT" or "VTODO" or "VTIMEZONE" => path.Count == 2 && path[0].Name == "VCALENDAR",
+        "STANDARD" or "DAYLIGHT" => path.Count == 3 && path[1].Name == "VTIMEZONE",
+        "VALARM" => path.Count == 3 && path[1].Name is "VEVENT" or "VTODO",
+        _ => true
+    };
+
+    private static bool IsEntityComponent(string name) =>
+        name.Equals("VEVENT", StringComparison.OrdinalIgnoreCase)
+        || name.Equals("VTODO", StringComparison.OrdinalIgnoreCase);
+
+    private static string? ValidateEntityComponents(IReadOnlyList<EntityComponent> entities)
+    {
+        var basicError = ValidateBasicEntityShape(entities);
+        if (basicError is not null)
+            return basicError;
+
+        var masters = entities.Where(entity => entity.RecurrenceIdentity is null).ToArray();
+        if (masters.Length != 1)
+            return "entity_master_cardinality";
+        if (entities.Any(entity => !string.Equals(entity.Uid, masters[0].Uid, StringComparison.Ordinal)))
+            return "recurrence_override_uid_mismatch";
+        if (entities.Where(entity => entity.RecurrenceIdentity is not null)
+            .GroupBy(entity => entity.RecurrenceIdentity, StringComparer.Ordinal).Any(group => group.Count() > 1))
+            return "recurrence_identity_duplicate";
+
+        var recurrenceError = ValidateRecurrenceFamily(entities, masters[0]);
+        if (recurrenceError is not null)
+            return recurrenceError;
+        return HasRecurrenceDefinition(masters[0]) || entities.Count == 1
+            ? null
+            : "recurrence_override_without_recurrence_set";
+    }
+
+    private static string? ValidateBasicEntityShape(IReadOnlyList<EntityComponent> entities)
+    {
+        if (entities.Count == 0)
+            return "entity_master_missing";
+        if (entities.Select(entity => entity.Kind).Distinct().Count() != 1)
+            return "mixed_entity_kinds";
+        if (entities.Any(entity => entity.Uid is null))
+            return "entity_uid_invalid";
+        if (entities.Any(entity => GetRequiredValue(entity.Properties, "DTSTAMP") is null))
+            return "entity_dtstamp_invalid";
+        if (entities.Any(entity => HasAmbiguousValueParameters(entity.Properties)))
+            return "property_parameter_cardinality";
+        if (entities.Any(HasMutuallyExclusiveEndProperties))
+            return "entity_temporal_cardinality";
+        return entities.Any(entity => HasRepeatedSingleton(entity.Properties))
+            ? "singleton_property_repeated"
+            : null;
+    }
+
+    private static string? ValidateRecurrenceFamily(
+        IReadOnlyList<EntityComponent> entities,
+        EntityComponent master)
+    {
+        var start = GetProperty(master.Properties, "DTSTART");
+        if (start is null)
+            return master.Kind == CalendarResourceProjectionKind.Event ? "entity_start_invalid" : null;
+
+        var startFamily = GetTemporalFamily(start);
+        return entities.Where(entity => entity.RecurrenceIdentity is not null)
+            .Select(entity => GetProperty(entity.Properties, "RECURRENCE-ID"))
+            .Any(property => property is null || GetTemporalFamily(property) != startFamily)
+                ? "recurrence_identity_family_mismatch"
+                : null;
+    }
+
+    private static bool HasRecurrenceDefinition(EntityComponent entity) => entity.Properties.Any(property =>
+        property.Name.Equals("RRULE", StringComparison.OrdinalIgnoreCase)
+        || property.Name.Equals("RDATE", StringComparison.OrdinalIgnoreCase));
+
+    private static string? ValidateCalendarProperties(IReadOnlyList<CalendarContentProperty> properties)
+    {
+        if (properties.Any(HasInvalidRegisteredValueType))
+            return "registered_property_value_invalid";
+        if (properties.Any(HasInvalidKnownValue))
+            return "typed_projection_invalid";
+
+        var rootProperties = properties.Where(property => property.ComponentPath.Count == 1).ToArray();
+        return GetRequiredValue(rootProperties, "VERSION") is null
+            || GetRequiredValue(rootProperties, "PRODID") is null
+                ? "calendar_required_property_invalid"
+                : null;
+    }
+
+    private static bool HasInvalidRegisteredValueType(CalendarContentProperty property)
+    {
+        if (property.Name is "TZOFFSETFROM" or "TZOFFSETTO")
+            return !CalendarContentDocument.IsValidRegisteredUnknownValue(property);
+        if (!CalendarContentDocument.IsRegisteredPropertyName(property.Name))
+            return false;
+        return property.ValueType == CalendarPropertyValueType.Unknown
+            || HasIncompatibleValueOverride(property);
+    }
+
+    private static bool HasIncompatibleValueOverride(CalendarContentProperty property)
+    {
+        var overrides = property.Parameters
+            .Where(parameter => parameter.Name.Equals("VALUE", StringComparison.OrdinalIgnoreCase))
+            .SelectMany(parameter => parameter.Values)
+            .ToArray();
+        if (overrides.Length == 0)
+            return false;
+        if (overrides.Length != 1)
+            return true;
+        return !AllowsValueType(property.Name, property.ValueType);
+    }
+
+    private static bool AllowsValueType(string propertyName, CalendarPropertyValueType valueType) => propertyName switch
+    {
+        "ATTACH" or "IMAGE" => valueType is CalendarPropertyValueType.Uri or CalendarPropertyValueType.Binary,
+        "DTSTART" or "DTEND" or "DUE" or "EXDATE" or "RECURRENCE-ID" =>
+            valueType is CalendarPropertyValueType.Date or CalendarPropertyValueType.DateTime,
+        "RDATE" => valueType is CalendarPropertyValueType.Date or CalendarPropertyValueType.DateTime or CalendarPropertyValueType.Period,
+        "TRIGGER" => valueType is CalendarPropertyValueType.Duration or CalendarPropertyValueType.DateTime,
+        "STRUCTURED-DATA" => valueType is CalendarPropertyValueType.Text or CalendarPropertyValueType.Uri or CalendarPropertyValueType.Binary,
+        _ => valueType == CalendarContentDocument.GetDefaultValueType(propertyName)
+    };
+
+    private static bool HasInvalidKnownValue(CalendarContentProperty property) => property.Name switch
+    {
+        "URL" or "ATTENDEE" or "ORGANIZER" => !Uri.TryCreate(property.RawEncodedValue, UriKind.Absolute, out _),
+        "ATTACH" when property.ValueType == CalendarPropertyValueType.Uri =>
+            !Uri.TryCreate(property.RawEncodedValue, UriKind.Absolute, out _),
+        "ATTACH" when property.ValueType == CalendarPropertyValueType.Binary => !IsBase64(property.RawEncodedValue),
+        _ => false
+    };
+
+    private static bool IsBase64(string value)
+    {
+        var decoded = new byte[(value.Length * 3 / 4) + 3];
+        return Convert.TryFromBase64String(value, decoded, out _);
+    }
+
+    private static bool HasMutuallyExclusiveEndProperties(EntityComponent entity)
+    {
+        var hasDuration = GetProperty(entity.Properties, "DURATION") is not null;
+        if (!hasDuration)
+            return false;
+        var endName = entity.Kind == CalendarResourceProjectionKind.Event ? "DTEND" : "DUE";
+        return GetProperty(entity.Properties, endName) is not null;
+    }
+
+    private static bool HasRepeatedSingleton(IReadOnlyList<CalendarContentProperty> properties) => properties
+        .Where(property => SingletonProperties.Contains(property.Name))
+        .GroupBy(property => property.Name, StringComparer.OrdinalIgnoreCase)
+        .Any(group => group.Count() > 1);
+
+    private static bool HasAmbiguousValueParameters(IReadOnlyList<CalendarContentProperty> properties) => properties.Any(property =>
+        CountParameterValues(property, "VALUE") > 1 || CountParameterValues(property, "TZID") > 1);
+
+    private static int CountParameterValues(CalendarContentProperty property, string name) => property.Parameters
+        .Where(parameter => parameter.Name.Equals(name, StringComparison.OrdinalIgnoreCase))
+        .Sum(parameter => parameter.Values.Count);
+
+    private static bool IcalNetCorroborates(
+        ReadOnlySpan<byte> authoritativeUtf8,
+        CalendarResourceProjectionKind kind,
+        int entityCount)
+    {
+        try
+        {
+            var calendar = IcalCalendar.Load(new UTF8Encoding(false, true).GetString(authoritativeUtf8));
+            if (calendar is null)
+                return false;
+            var entityCountsMatch = kind == CalendarResourceProjectionKind.Event
+                ? calendar.Events.Count == entityCount && calendar.Todos.Count == 0
+                : calendar.Todos.Count == entityCount && calendar.Events.Count == 0;
+            if (!entityCountsMatch)
+                return false;
+            var roundTrip = new CalendarSerializer().SerializeToString(calendar);
+            return roundTrip is not null && HasAllRegisteredOccurrences(
+                CalendarContentDocument.Parse(authoritativeUtf8),
+                CalendarContentDocument.Parse(Encoding.UTF8.GetBytes(roundTrip)));
+        }
+        catch (Exception exception) when (exception is ArgumentException
+            or InvalidOperationException
+            or System.Runtime.Serialization.SerializationException)
+        {
+            return false;
+        }
+    }
+
+    private static bool HasAllRegisteredOccurrences(
+        CalendarContentDocument source,
+        CalendarContentDocument roundTrip)
+    {
+        var sourceCounts = GetRegisteredOccurrenceCounts(source.Properties);
+        var roundTripCounts = GetRegisteredOccurrenceCounts(roundTrip.Properties);
+        return sourceCounts.All(sourceCount => roundTripCounts.GetValueOrDefault(sourceCount.Key) >= sourceCount.Value);
+    }
+
+    private static IReadOnlyDictionary<string, int> GetRegisteredOccurrenceCounts(
+        IReadOnlyList<CalendarContentProperty> properties) => properties
+        .Where(property => CalendarContentDocument.IsRegisteredPropertyName(property.Name))
+        .GroupBy(property => $"{string.Join('/', property.ComponentPath.Select(segment => segment.Name))}|{property.Name}", StringComparer.OrdinalIgnoreCase)
+        .ToDictionary(group => group.Key, group => group.Count(), StringComparer.OrdinalIgnoreCase);
+
+    private static CalendarContentProperty? GetProperty(
+        IEnumerable<CalendarContentProperty> properties,
+        string name) => properties.FirstOrDefault(property => property.Name.Equals(name, StringComparison.OrdinalIgnoreCase));
+
+    private static string? GetRequiredValue(
+        IEnumerable<CalendarContentProperty> properties,
+        string name)
+    {
+        var values = properties.Where(property => property.Name.Equals(name, StringComparison.OrdinalIgnoreCase))
+            .Select(property => property.RawEncodedValue)
+            .ToArray();
+        return values.Length == 1 && values[0].Length > 0 ? values[0] : null;
+    }
+
+    private static string? GetOptionalValue(IEnumerable<CalendarContentProperty> properties, string name) =>
+        GetProperty(properties, name)?.RawEncodedValue;
+
+    private static string GetTemporalIdentity(CalendarContentProperty property)
+    {
+        var family = GetTemporalFamily(property);
+        if (family.StartsWith("utc", StringComparison.Ordinal))
+        {
+            var parsed = DateTimeOffset.ParseExact(
+                property.RawEncodedValue,
+                "yyyyMMdd'T'HHmmss'Z'",
+                CultureInfo.InvariantCulture,
+                DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal);
+            return $"{family}|{parsed:O}";
+        }
+
+        return $"{family}|{property.RawEncodedValue}";
+    }
+
+    private static string GetTemporalFamily(CalendarContentProperty property)
+    {
+        if (property.ValueType == CalendarPropertyValueType.Date)
+            return "date";
+        if (property.RawEncodedValue.EndsWith('Z'))
+            return "utc-date-time";
+        var timeZone = property.Parameters
+            .Where(parameter => parameter.Name.Equals("TZID", StringComparison.OrdinalIgnoreCase))
+            .SelectMany(parameter => parameter.Values)
+            .SingleOrDefault();
+        return timeZone is null ? "floating-date-time" : $"zoned-date-time:{timeZone}";
+    }
+
+    private static string? DecodeText(string? value)
+    {
+        if (value is null)
+            return null;
+        var decoded = new StringBuilder(value.Length);
+        for (var index = 0; index < value.Length; index++)
+        {
+            if (value[index] != '\\' || index + 1 >= value.Length)
+            {
+                decoded.Append(value[index]);
+                continue;
+            }
+
+            var escaped = value[++index];
+            decoded.Append(escaped is 'n' or 'N' ? '\n' : escaped);
+        }
+
+        return decoded.ToString();
+    }
+
+    private static bool PathsEqual(
+        IReadOnlyList<CalendarComponentPathSegment> left,
+        IReadOnlyList<CalendarComponentPathSegment> right) => left.Count == right.Count
+        && left.Zip(right).All(pair => pair.First.Occurrence == pair.Second.Occurrence
+            && pair.First.Name.Equals(pair.Second.Name, StringComparison.OrdinalIgnoreCase));
+
+    private static CalendarProperty ToPublicProperty(CalendarContentProperty property) => new(
+        property.ComponentPath,
+        property.Name,
+        property.Parameters,
+        property.ValueType,
+        property.RawEncodedValue,
+        property.OriginalSlice);
+
+    private static CalendarProjectionResult Opaque(
+        IReadOnlyList<CalendarProperty> properties,
+        string code) => new(
+        new CalendarResourceProjection(CalendarResourceProjectionKind.Opaque, null, null),
+        properties,
+        [new CalendarResourceDiagnostic(code, "The Calendar Object Resource is readable but cannot be projected safely.", CalendarResourceDiagnosticSeverity.Error)]);
+
+    private sealed record EntityComponent(
+        CalendarResourceProjectionKind Kind,
+        string? Uid,
+        string? RecurrenceIdentity,
+        IReadOnlyList<CalendarContentProperty> Properties);
+}

--- a/src/DotnetAgents.CalDav.Core/Internal/Xml/DavResponseParser.cs
+++ b/src/DotnetAgents.CalDav.Core/Internal/Xml/DavResponseParser.cs
@@ -1,3 +1,4 @@
+using System.Xml;
 using System.Xml.Linq;
 using DotnetAgents.CalDav.Core.Models;
 
@@ -8,6 +9,8 @@ namespace DotnetAgents.CalDav.Core.Internal.Xml;
 /// </summary>
 internal static class DavResponseParser
 {
+    private const long MaxXmlCharacters = 4L * 1024 * 1024;
+    private const int MaxXmlDepth = 64;
     private static readonly XNamespace Dav = "DAV:";
     private static readonly XNamespace CalDav = "urn:ietf:params:xml:ns:caldav";
     private static readonly XNamespace AppleCs = "http://apple.com/ns/ical/";
@@ -15,7 +18,7 @@ internal static class DavResponseParser
     /// <summary>Parses a multistatus XML body into a list of <see cref="TaskList"/> records.</summary>
     public static IReadOnlyList<TaskList> ParseTaskLists(string multistatusXml)
     {
-        var doc = XDocument.Parse(multistatusXml);
+        var doc = ParseDocument(multistatusXml);
         return doc.Descendants(Dav + "response")
             .Select(TryParseTaskList)
             .OfType<TaskList>()
@@ -25,7 +28,7 @@ internal static class DavResponseParser
     /// <summary>Parses every discovered Calendar collection with independent component evidence.</summary>
     public static IReadOnlyList<CalendarDescriptor> ParseCalendars(string multistatusXml)
     {
-        var doc = XDocument.Parse(multistatusXml);
+        var doc = ParseDocument(multistatusXml);
         return doc.Descendants(Dav + "response")
             .Select(TryParseCalendar)
             .OfType<CalendarDescriptor>()
@@ -35,7 +38,7 @@ internal static class DavResponseParser
     /// <summary>Parses a multistatus response to extract the calendar-home-set URL.</summary>
     public static string? ParseCalendarHomeSet(string multistatusXml)
     {
-        var doc = XDocument.Parse(multistatusXml);
+        var doc = ParseDocument(multistatusXml);
         return doc.Descendants(CalDav + "calendar-home-set")
             .Descendants(Dav + "href")
             .FirstOrDefault()?.Value?.Trim();
@@ -44,7 +47,7 @@ internal static class DavResponseParser
     /// <summary>Parses a multistatus response to extract the current-user-principal URL.</summary>
     public static string? ParseCurrentUserPrincipal(string multistatusXml)
     {
-        var doc = XDocument.Parse(multistatusXml);
+        var doc = ParseDocument(multistatusXml);
         return doc.Descendants(Dav + "current-user-principal")
             .Descendants(Dav + "href")
             .FirstOrDefault()?.Value?.Trim();
@@ -55,7 +58,7 @@ internal static class DavResponseParser
     /// </summary>
     public static IReadOnlyList<(string Href, string? ETag, string ICalData)> ParseCalendarData(string multistatusXml)
     {
-        var doc = XDocument.Parse(multistatusXml);
+        var doc = ParseDocument(multistatusXml);
         return doc.Descendants(Dav + "response")
             .Select(TryParseCalendarDataResponse)
             .Where(entry => entry.HasValue)
@@ -84,6 +87,23 @@ internal static class DavResponseParser
             Color = GetPropValue(response, AppleCs + "calendar-color"),
             SupportedComponents = supportedComponents
         };
+    }
+
+    private static XDocument ParseDocument(string xml)
+    {
+        var settings = new XmlReaderSettings
+        {
+            DtdProcessing = DtdProcessing.Prohibit,
+            XmlResolver = null,
+            MaxCharactersInDocument = MaxXmlCharacters,
+            MaxCharactersFromEntities = 0
+        };
+        using var textReader = new StringReader(xml);
+        using var xmlReader = XmlReader.Create(textReader, settings);
+        var document = XDocument.Load(xmlReader, LoadOptions.PreserveWhitespace);
+        if (document.Descendants().Any(element => element.Ancestors().Count() > MaxXmlDepth))
+            throw new XmlException("The WebDAV response exceeds the safe XML depth limit.");
+        return document;
     }
 
     private static CalendarDescriptor? TryParseCalendar(XElement response)

--- a/src/DotnetAgents.CalDav.Core/Models/CalendarResourceSnapshot.cs
+++ b/src/DotnetAgents.CalDav.Core/Models/CalendarResourceSnapshot.cs
@@ -1,0 +1,99 @@
+namespace DotnetAgents.CalDav.Core.Models;
+
+/// <summary>Outcome of an authoritative Calendar Object Resource read.</summary>
+public enum CalendarResourceReadCode
+{
+    Success,
+    NotFound,
+    InvalidInput,
+    OutsideScope,
+    ConcurrencyUnavailable,
+    PayloadTooLarge,
+    UpstreamProtocolError
+}
+
+/// <summary>Closed semantic projection kind for a Calendar Object Resource.</summary>
+public enum CalendarResourceProjectionKind
+{
+    Event,
+    Todo,
+    Opaque
+}
+
+/// <summary>Safe diagnostic severity for a Calendar Object Resource projection.</summary>
+public enum CalendarResourceDiagnosticSeverity
+{
+    Info,
+    Warning,
+    Error
+}
+
+/// <summary>A content-free diagnostic safe to expose to MCP clients.</summary>
+public sealed record CalendarResourceDiagnostic(
+    string Code,
+    string Message,
+    CalendarResourceDiagnosticSeverity Severity);
+
+/// <summary>Lossless content-line value classification.</summary>
+public enum CalendarPropertyValueType
+{
+    Text,
+    Uri,
+    Date,
+    DateTime,
+    Duration,
+    Integer,
+    Float,
+    Period,
+    Recur,
+    Binary,
+    Unknown
+}
+
+/// <summary>One component in the path that owns a content line.</summary>
+public sealed record CalendarComponentPathSegment(string Name, int Occurrence);
+
+/// <summary>One parameter occurrence; duplicate names remain separate occurrences.</summary>
+public sealed record CalendarParameter(string Name, IReadOnlyList<string> Values);
+
+/// <summary>A lossless indexed iCalendar property.</summary>
+public sealed record CalendarProperty(
+    IReadOnlyList<CalendarComponentPathSegment> ComponentPath,
+    string Name,
+    IReadOnlyList<CalendarParameter> Parameters,
+    CalendarPropertyValueType ValueType,
+    string RawEncodedValue,
+    string OriginalSlice);
+
+/// <summary>Minimal typed Event, To-do, or opaque projection over authoritative content.</summary>
+public sealed record CalendarResourceProjection(
+    CalendarResourceProjectionKind Kind,
+    string? EntityUid,
+    string? Summary);
+
+/// <summary>An immutable, revision-coherent Calendar Object Resource snapshot.</summary>
+public sealed record CalendarResourceSnapshot(
+    string CalendarHref,
+    string ResourceHref,
+    string EntityTag,
+    ReadOnlyMemory<byte> AuthoritativeUtf8,
+    IReadOnlyList<CalendarProperty> CalendarProperties,
+    CalendarResourceProjection Projection,
+    IReadOnlyList<CalendarResourceDiagnostic> Diagnostics)
+{
+    /// <summary>Whether this snapshot may be used as the base of a semantic mutation.</summary>
+    public bool SemanticMutationAvailable => Projection.Kind != CalendarResourceProjectionKind.Opaque;
+}
+
+/// <summary>Read transport/result envelope used across the Calendar Service boundary.</summary>
+public sealed record CalendarResourceRead(
+    CalendarResourceReadCode Code,
+    string? ResourceHref = null,
+    string? EntityTag = null,
+    ReadOnlyMemory<byte> AuthoritativeUtf8 = default,
+    CalendarResourceSnapshot? Snapshot = null,
+    int? ObservedByteCount = null)
+{
+    public static CalendarResourceRead Success(string resourceHref, string entityTag, ReadOnlyMemory<byte> authoritativeUtf8) =>
+        new(CalendarResourceReadCode.Success, resourceHref, entityTag, authoritativeUtf8);
+}

--- a/src/DotnetAgents.CalDav.Core/Services/CalendarService.cs
+++ b/src/DotnetAgents.CalDav.Core/Services/CalendarService.cs
@@ -1,5 +1,6 @@
 using DotnetAgents.CalDav.Core.Abstractions;
 using DotnetAgents.CalDav.Core.Configuration;
+using DotnetAgents.CalDav.Core.Internal.Ical;
 using DotnetAgents.CalDav.Core.Models;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -62,6 +63,93 @@ internal sealed class CalendarService : ICalendarService
             ? CalendarSelectionResult.Success(matchingScoped[0])
             : CalendarSelectionResult.Failure(CalendarSelectionCode.UnsupportedCapability, matchingScoped);
     }
+
+    /// <inheritdoc />
+    public async Task<CalendarResourceRead> GetResourceAsync(string href, CancellationToken cancellationToken)
+    {
+        if (!TryGetCanonicalResourceUri(href, out var resourceUri))
+            return new CalendarResourceRead(CalendarResourceReadCode.InvalidInput);
+
+        var configuredScope = ParseScope(_options.Value.CalendarHrefs);
+        if (configuredScope.Count > 0 && !configuredScope.Any(calendarHref => IsDirectResourceOf(resourceUri, calendarHref)))
+            return new CalendarResourceRead(CalendarResourceReadCode.OutsideScope);
+
+        var calendars = ApplyScope(await _calendarClient.GetCalendarsAsync(cancellationToken)).Items;
+        var calendar = calendars
+            .Where(candidate => IsDirectResourceOf(resourceUri, candidate.Href))
+            .OrderByDescending(candidate => candidate.Href.Length)
+            .FirstOrDefault();
+        if (calendar is null)
+            return new CalendarResourceRead(CalendarResourceReadCode.OutsideScope);
+
+        var read = await _calendarClient.GetCalendarResourceAsync(href, cancellationToken);
+        if (read.Code != CalendarResourceReadCode.Success)
+            return read;
+
+        var projection = CalendarResourceProjector.Project(read.AuthoritativeUtf8.Span);
+        var snapshot = new CalendarResourceSnapshot(
+            calendar.Href,
+            read.ResourceHref!,
+            read.EntityTag!,
+            read.AuthoritativeUtf8,
+            projection.Properties,
+            projection.Projection,
+            projection.Diagnostics);
+        return read with { Snapshot = snapshot };
+    }
+
+    private bool TryGetCanonicalResourceUri(string href, out Uri resourceUri)
+    {
+        resourceUri = null!;
+        if (!Uri.TryCreate(href, UriKind.Absolute, out var candidate)
+            || (!candidate.Scheme.Equals(Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase)
+                && !candidate.Scheme.Equals(Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
+            || !string.IsNullOrEmpty(candidate.UserInfo)
+            || !string.IsNullOrEmpty(candidate.Fragment)
+            || !string.IsNullOrEmpty(candidate.Query)
+            || HasEncodedPathSeparator(candidate)
+            || !string.Equals(candidate.AbsoluteUri, href, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        var origin = new Uri(_options.Value.BaseUrl, UriKind.Absolute);
+        if (!HasSameOrigin(origin, candidate))
+            return false;
+
+        resourceUri = candidate;
+        return true;
+    }
+
+    private static bool IsDirectResourceOf(Uri resourceUri, string calendarHref)
+    {
+        if (!Uri.TryCreate(calendarHref, UriKind.Absolute, out var calendarUri)
+            || !HasSameOrigin(calendarUri, resourceUri)
+            || !string.IsNullOrEmpty(calendarUri.UserInfo)
+            || !string.IsNullOrEmpty(calendarUri.Fragment)
+            || !string.IsNullOrEmpty(calendarUri.Query))
+        {
+            return false;
+        }
+
+        var calendarPath = calendarUri.AbsolutePath.EndsWith('/')
+            ? calendarUri.AbsolutePath
+            : calendarUri.AbsolutePath + '/';
+        if (!resourceUri.AbsolutePath.StartsWith(calendarPath, StringComparison.Ordinal))
+            return false;
+
+        var relativePath = resourceUri.AbsolutePath[calendarPath.Length..];
+        return relativePath.Length > 0 && !relativePath.Contains('/');
+    }
+
+    private static bool HasSameOrigin(Uri left, Uri right) =>
+        string.Equals(left.Scheme, right.Scheme, StringComparison.OrdinalIgnoreCase)
+        && string.Equals(left.Host, right.Host, StringComparison.OrdinalIgnoreCase)
+        && left.Port == right.Port;
+
+    private static bool HasEncodedPathSeparator(Uri uri) =>
+        uri.AbsolutePath.Contains("%2F", StringComparison.OrdinalIgnoreCase)
+        || uri.AbsolutePath.Contains("%5C", StringComparison.OrdinalIgnoreCase);
 
     private CalendarDiscoveryResult ApplyScope(IReadOnlyList<CalendarDescriptor> discovered)
     {

--- a/src/DotnetAgents.CalDav.Mcp/.mcp/server.json
+++ b/src/DotnetAgents.CalDav.Mcp/.mcp/server.json
@@ -59,6 +59,11 @@
           "name": "CALDAV_EXPOSE_ADVANCED_TOOLS",
           "description": "Set to true to expose advanced href-based tools alongside the chat-safe surface (optional)",
           "isRequired": false
+        },
+        {
+          "name": "CALDAV_EXPOSE_EXACT_TOOLS",
+          "description": "Set to true to expose protected exact Calendar Object Resource tools (optional)",
+          "isRequired": false
         }
       ]
     }

--- a/src/DotnetAgents.CalDav.Mcp/Hosting/CalDavHostBuilder.cs
+++ b/src/DotnetAgents.CalDav.Mcp/Hosting/CalDavHostBuilder.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using ModelContextProtocol.Protocol;
 
 namespace DotnetAgents.CalDav.Mcp.Hosting;
 
@@ -20,7 +21,8 @@ public sealed class CalDavHostBuilder
     /// before calling <see cref="HostApplicationBuilder.Build"/>.
     /// </summary>
     /// <param name="exposeAdvancedTools">Whether to retain the existing legacy href-based tool surface.</param>
-    public static HostApplicationBuilder CreateBuilder(bool exposeAdvancedTools = false)
+    /// <param name="exposeExactTools">Whether to expose protected exact resource reads.</param>
+    public static HostApplicationBuilder CreateBuilder(bool exposeAdvancedTools = false, bool exposeExactTools = false)
     {
         var builder = Host.CreateApplicationBuilder();
 
@@ -29,6 +31,7 @@ public sealed class CalDavHostBuilder
         var mcpBuilder = builder.Services.AddMcpServer(options => options.ProtocolVersion = "2026-07-28")
             .WithStdioServerTransport()
             .WithTools<CalendarTools>()
+            .WithTools<CalendarResourceTools>()
             .WithTools<TaskListTools>()
             .WithTools<ChatTaskTools>();
 
@@ -37,6 +40,21 @@ public sealed class CalDavHostBuilder
             mcpBuilder
                 .WithTools<TaskQueryTools>()
                 .WithTools<TaskMutationTools>();
+        }
+
+        if (exposeExactTools)
+        {
+            mcpBuilder
+                .WithTools<ExactCalendarResourceTools>()
+                .WithListResourcesHandler((_, _) => ValueTask.FromResult(ExactCalendarResourceHandler.List()))
+                .WithReadResourceHandler(async (request, cancellationToken) =>
+                {
+                    var service = request.Services!.GetRequiredService<DotnetAgents.CalDav.Core.Abstractions.ICalendarService>();
+                    return await ExactCalendarResourceHandler.ReadAsync(
+                        request.Params!.Uri,
+                        service,
+                        cancellationToken).ConfigureAwait(false);
+                });
         }
 
         builder.Services.PostConfigure<ModelContextProtocol.Server.McpServerOptions>(ConfigureCalendarToolContract);
@@ -49,15 +67,26 @@ public sealed class CalDavHostBuilder
 
     private static void ConfigureCalendarToolContract(ModelContextProtocol.Server.McpServerOptions options)
     {
-        if (options.ToolCollection is null || !options.ToolCollection.TryGetPrimitive("calendars.list", out var tool))
+        if (options.ToolCollection is null)
             return;
 
         options.ToolCollection = new OrderedToolCollection(options.ToolCollection.ToArray());
-        tool.ProtocolTool.InputSchema = CalendarToolContract.GetInputSchema();
-        tool.ProtocolTool.OutputSchema = CalendarToolContract.GetOutputSchema();
+        ConfigureTool(options.ToolCollection, "calendars.list");
+        ConfigureTool(options.ToolCollection, "calendar_resources.get");
+        ConfigureTool(options.ToolCollection, "calendar_resources.exact_get");
+    }
+
+    private static void ConfigureTool(
+        ModelContextProtocol.Server.McpServerPrimitiveCollection<ModelContextProtocol.Server.McpServerTool> tools,
+        string toolName)
+    {
+        if (!tools.TryGetPrimitive(toolName, out var tool))
+            return;
+        tool.ProtocolTool.InputSchema = CalendarToolContract.GetInputSchema(toolName);
+        tool.ProtocolTool.OutputSchema = CalendarToolContract.GetOutputSchema(toolName);
         tool.ProtocolTool.Meta = new System.Text.Json.Nodes.JsonObject
         {
-            ["cache"] = CalendarToolContract.GetCacheMetadata()
+            ["cache"] = CalendarToolContract.GetCacheMetadata(toolName)
         };
     }
 }

--- a/src/DotnetAgents.CalDav.Mcp/Hosting/CalDavMcpRunner.cs
+++ b/src/DotnetAgents.CalDav.Mcp/Hosting/CalDavMcpRunner.cs
@@ -56,13 +56,20 @@ public sealed class CalDavMcpRunner
         return string.Equals(getEnv("CALDAV_EXPOSE_ADVANCED_TOOLS"), "true", StringComparison.OrdinalIgnoreCase);
     }
 
+    internal static bool ShouldExposeExactTools(Func<string, string?>? envProvider = null)
+    {
+        var getEnv = envProvider ?? Environment.GetEnvironmentVariable;
+        return string.Equals(getEnv("CALDAV_EXPOSE_EXACT_TOOLS"), "true", StringComparison.OrdinalIgnoreCase);
+    }
+
     [ExcludeFromCodeCoverage]
     private static async Task<int> RunHostAsync(Action<CalDavOptions> configure, CancellationToken cancellationToken)
     {
         try
         {
             var exposeAdvancedTools = ShouldExposeAdvancedTools();
-            var builder = CalDavHostBuilder.CreateBuilder(exposeAdvancedTools);
+            var exposeExactTools = ShouldExposeExactTools();
+            var builder = CalDavHostBuilder.CreateBuilder(exposeAdvancedTools, exposeExactTools);
             builder.Services.ConfigureCalDav(configure);
             using var host = builder.Build();
             await host.RunAsync(cancellationToken).ConfigureAwait(false);

--- a/src/DotnetAgents.CalDav.Mcp/Hosting/CalendarToolContract.cs
+++ b/src/DotnetAgents.CalDav.Mcp/Hosting/CalendarToolContract.cs
@@ -10,15 +10,15 @@ internal static class CalendarToolContract
     private const string ResourceName = "DotnetAgents.CalDav.Mcp.CalendarToolCatalog.json";
     private static readonly JsonObject Catalog = LoadCatalog();
 
-    public static JsonElement GetInputSchema() => GetSchema("inputSchema");
+    public static JsonElement GetInputSchema(string toolName = "calendars.list") => GetSchema(toolName, "inputSchema");
 
-    public static JsonElement GetOutputSchema() => GetSchema("outputSchema");
+    public static JsonElement GetOutputSchema(string toolName = "calendars.list") => GetSchema(toolName, "outputSchema");
 
-    public static JsonObject GetCacheMetadata() => FindCalendarTool()["cache"]!.DeepClone().AsObject();
+    public static JsonObject GetCacheMetadata(string toolName = "calendars.list") => FindTool(toolName)["cache"]!.DeepClone().AsObject();
 
-    private static JsonElement GetSchema(string schemaProperty)
+    private static JsonElement GetSchema(string toolName, string schemaProperty)
     {
-        var reference = FindCalendarTool()[schemaProperty]!["$ref"]!.GetValue<string>();
+        var reference = FindTool(toolName)[schemaProperty]!["$ref"]!.GetValue<string>();
         var definitionName = reference.Split('/').Last();
         var schema = Catalog["$defs"]![definitionName]!.DeepClone().AsObject();
         var definitions = GetReferencedDefinitions(schema);
@@ -66,9 +66,9 @@ internal static class CalendarToolContract
         return direct.Concat(obj.Where(property => property.Key != "$ref").SelectMany(property => GetDefinitionReferences(property.Value)));
     }
 
-    private static JsonObject FindCalendarTool() => Catalog["tools"]!.AsArray()
+    private static JsonObject FindTool(string toolName) => Catalog["tools"]!.AsArray()
         .Select(item => item!.AsObject())
-        .Single(tool => tool["name"]!.GetValue<string>() == "calendars.list");
+        .Single(tool => tool["name"]!.GetValue<string>() == toolName);
 
     private static JsonObject LoadCatalog()
     {

--- a/src/DotnetAgents.CalDav.Mcp/Hosting/ExactCalendarResourceHandler.cs
+++ b/src/DotnetAgents.CalDav.Mcp/Hosting/ExactCalendarResourceHandler.cs
@@ -1,0 +1,47 @@
+using System.Text;
+using DotnetAgents.CalDav.Core.Abstractions;
+using DotnetAgents.CalDav.Core.Models;
+using DotnetAgents.CalDav.Mcp.Tools;
+using ModelContextProtocol.Protocol;
+
+namespace DotnetAgents.CalDav.Mcp.Hosting;
+
+internal static class ExactCalendarResourceHandler
+{
+    public static ListResourcesResult List() => new()
+    {
+        Resources = [],
+        TimeToLive = TimeSpan.Zero,
+        CacheScope = CacheScope.Private
+    };
+
+    public static async Task<ReadResourceResult> ReadAsync(
+        string uri,
+        ICalendarService calendarService,
+        CancellationToken cancellationToken)
+    {
+        if (!ExactCalendarResourceLink.TryParse(uri, out var href, out var expectedEntityTag))
+            throw new InvalidOperationException("The protected Calendar resource link is invalid.");
+
+        var read = await calendarService.GetResourceAsync(href, cancellationToken);
+        if (read.Code != CalendarResourceReadCode.Success || read.Snapshot is null)
+            throw new InvalidOperationException("The protected Calendar resource is unavailable.");
+        if (!string.Equals(read.Snapshot.EntityTag, expectedEntityTag, StringComparison.Ordinal))
+            throw new InvalidOperationException("The protected Calendar resource revision has changed.");
+
+        return new ReadResourceResult
+        {
+            Contents =
+            [
+                new TextResourceContents
+                {
+                    Uri = uri,
+                    MimeType = "text/calendar; charset=utf-8",
+                    Text = new UTF8Encoding(false, true).GetString(read.Snapshot.AuthoritativeUtf8.Span)
+                }
+            ],
+            TimeToLive = TimeSpan.Zero,
+            CacheScope = CacheScope.Private
+        };
+    }
+}

--- a/src/DotnetAgents.CalDav.Mcp/Hosting/OrderedToolCollection.cs
+++ b/src/DotnetAgents.CalDav.Mcp/Hosting/OrderedToolCollection.cs
@@ -8,12 +8,14 @@ internal sealed class OrderedToolCollection : McpServerPrimitiveCollection<McpSe
     private static readonly IReadOnlyDictionary<string, int> Ranks = new Dictionary<string, int>(StringComparer.Ordinal)
     {
         ["calendars.list"] = 0,
-        ["list_task_lists"] = 1,
-        ["show_tasks"] = 2,
-        ["add_task"] = 3,
-        ["find_tasks"] = 4,
-        ["complete_task_by_summary"] = 5,
-        ["delete_task_by_summary"] = 6
+        ["calendar_resources.get"] = 1,
+        ["calendar_resources.exact_get"] = 2,
+        ["list_task_lists"] = 3,
+        ["show_tasks"] = 4,
+        ["add_task"] = 5,
+        ["find_tasks"] = 6,
+        ["complete_task_by_summary"] = 7,
+        ["delete_task_by_summary"] = 8
     };
 
     public OrderedToolCollection(IEnumerable<McpServerTool> tools)

--- a/src/DotnetAgents.CalDav.Mcp/Tools/CalendarResourceTools.cs
+++ b/src/DotnetAgents.CalDav.Mcp/Tools/CalendarResourceTools.cs
@@ -1,0 +1,292 @@
+using System.ComponentModel;
+using System.Net;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Xml;
+using DotnetAgents.CalDav.Core.Abstractions;
+using DotnetAgents.CalDav.Core.Models;
+using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
+
+namespace DotnetAgents.CalDav.Mcp.Tools;
+
+/// <summary>Authoritative Calendar Object Resource semantic reads.</summary>
+[McpServerToolType]
+public sealed class CalendarResourceTools
+{
+    private const int MaxStructuredResultBytes = 4 * 1024 * 1024;
+    private readonly ICalendarService _calendarService;
+
+    public CalendarResourceTools(ICalendarService calendarService)
+    {
+        _calendarService = calendarService;
+    }
+
+    /// <summary>Reads one complete, revision-coherent Calendar Object Resource snapshot.</summary>
+    [McpServerTool(
+        Name = "calendar_resources.get",
+        ReadOnly = true,
+        Destructive = false,
+        Idempotent = true,
+        OpenWorld = true,
+        UseStructuredContent = true,
+        OutputSchemaType = typeof(CalendarResourceSuccessResult)),
+     Description("Read one semantic Calendar Object Resource by an explicitly confirmed absolute href.")]
+    public async Task<CallToolResult> GetAsync(
+        [Description("Canonical absolute Calendar Object Resource href.")] string href,
+        CancellationToken cancellationToken)
+    {
+        return await ExecuteReadAsync(
+            _calendarService,
+            href,
+            snapshot => CreateBoundedSuccess(CalendarResourceSuccessResult.FromSnapshot(snapshot)),
+            cancellationToken);
+    }
+
+    internal static async Task<CallToolResult> ExecuteReadAsync(
+        ICalendarService calendarService,
+        string href,
+        Func<CalendarResourceSnapshot, CallToolResult> createSuccess,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var read = await calendarService.GetResourceAsync(href, cancellationToken);
+            if (read.Code != CalendarResourceReadCode.Success || read.Snapshot is null)
+                return CreateError(read.Code, read.ObservedByteCount);
+
+            return createSuccess(read.Snapshot);
+        }
+        catch (HttpRequestException exception)
+        {
+            return CreateHttpError(exception.StatusCode);
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            return CreateHttpError(null);
+        }
+        catch (TimeoutException)
+        {
+            return CreateHttpError(null);
+        }
+        catch (XmlException)
+        {
+            return CreateDiscoveryProtocolError();
+        }
+        catch (CalendarDiscoveryProtocolException)
+        {
+            return CreateDiscoveryProtocolError();
+        }
+        catch (CalendarDiscoveryLimitException exception)
+        {
+            return Error(
+                "limit_exhausted",
+                "limitsAndAdmission",
+                "Calendar discovery exceeded the safe item limit.",
+                false,
+                "admissionAndPayload",
+                calendarCount: exception.CalendarCount);
+        }
+    }
+
+    internal static CallToolResult CreateSuccess(object content, params ContentBlock[] additionalContent) => new()
+    {
+        IsError = false,
+        StructuredContent = JsonSerializer.SerializeToElement(content),
+        Content = [new TextContentBlock { Text = "Calendar Object Resource read completed." }, .. additionalContent]
+    };
+
+    private static CallToolResult CreateBoundedSuccess(CalendarResourceSuccessResult content)
+    {
+        var structured = JsonSerializer.SerializeToElement(content);
+        var candidate = new CallToolResult
+        {
+            IsError = false,
+            StructuredContent = structured,
+            Content = [new TextContentBlock { Text = "Calendar Object Resource read completed." }]
+        };
+        var byteCount = JsonSerializer.SerializeToUtf8Bytes(candidate).Length;
+        return byteCount > MaxStructuredResultBytes
+            ? Error("payload_too_large", "limitsAndAdmission", "The structured Calendar snapshot exceeds the safe payload limit.", false, "admissionAndPayload", byteCount)
+            : candidate;
+    }
+
+    internal static CallToolResult CreateError(CalendarResourceReadCode code, int? observedByteCount = null) => code switch
+    {
+        CalendarResourceReadCode.InvalidInput => Error("invalid_input", "input", "The resource href is invalid.", false, "originScopeAuthorization"),
+        CalendarResourceReadCode.OutsideScope => Error("outside_scope", "selection", "The resource is outside the configured Calendar Scope.", false, "originScopeAuthorization"),
+        CalendarResourceReadCode.NotFound => Error("not_found", "selection", "The Calendar Object Resource was not found.", false, "targetRevision"),
+        CalendarResourceReadCode.ConcurrencyUnavailable => Error("concurrency_unavailable", "state", "The server did not return a strong Entity Tag.", false, "targetRevision"),
+        CalendarResourceReadCode.PayloadTooLarge => Error("payload_too_large", "limitsAndAdmission", "The Calendar Object Resource exceeds the safe payload limit.", false, "admissionAndPayload", observedByteCount),
+        _ => Error("upstream_protocol_error", "upstream", "The Calendar Object Resource response was invalid.", false, "execution")
+    };
+
+    private static CallToolResult CreateHttpError(HttpStatusCode? statusCode) => statusCode switch
+    {
+        HttpStatusCode.Unauthorized => Error("upstream_unauthorized", "upstream", "The Calendar Object Resource read was not authorized.", false, "execution"),
+        HttpStatusCode.Forbidden => Error("upstream_forbidden", "upstream", "The Calendar Object Resource read was forbidden.", false, "execution"),
+        HttpStatusCode.NotFound => CreateDiscoveryProtocolError(),
+        HttpStatusCode.RequestEntityTooLarge => CreateError(CalendarResourceReadCode.PayloadTooLarge),
+        HttpStatusCode.TooManyRequests => Error("upstream_rate_limited", "upstream", "The Calendar Object Resource read is rate limited.", true, "execution"),
+        HttpStatusCode.MethodNotAllowed or HttpStatusCode.NotImplemented => Error("unsupported_capability", "capabilityAndProjection", "The server does not support direct resource reads.", false, "selectionDiscoveryCapability"),
+        HttpStatusCode.InsufficientStorage => Error("upstream_unavailable", "upstream", "The Calendar Object Resource read is unavailable.", false, "execution"),
+        null => Error("upstream_unavailable", "upstream", "The Calendar Object Resource read is unavailable.", true, "execution"),
+        >= HttpStatusCode.InternalServerError => Error("upstream_unavailable", "upstream", "The Calendar Object Resource read is unavailable.", true, "execution"),
+        _ => CreateError(CalendarResourceReadCode.UpstreamProtocolError)
+    };
+
+    private static CallToolResult CreateDiscoveryProtocolError() => Error(
+        "upstream_protocol_error",
+        "upstream",
+        "Calendar discovery returned an invalid response.",
+        false,
+        "selectionDiscoveryCapability");
+
+    private static CallToolResult Error(
+        string code,
+        string category,
+        string message,
+        bool retryable,
+        string phase,
+        int? byteCount = null,
+        int? calendarCount = null) => new()
+        {
+            IsError = true,
+            StructuredContent = JsonSerializer.SerializeToElement(new CalendarResourceErrorResult(
+                code,
+                category,
+                message,
+                retryable,
+                phase,
+                byteCount is null && calendarCount is null
+                    ? null
+                    : new CalendarResourceExecutionLimits(byteCount, calendarCount))),
+            Content = [new TextContentBlock { Text = "Calendar Object Resource read failed." }]
+        };
+}
+
+/// <summary>Structured success outcome for a direct resource read.</summary>
+public sealed record CalendarResourceSuccessResult(
+    [property: JsonPropertyName("outcome")] string Outcome,
+    [property: JsonPropertyName("snapshot")] CalendarSnapshotResult Snapshot)
+{
+    internal static CalendarResourceSuccessResult FromSnapshot(CalendarResourceSnapshot snapshot) =>
+        new("success", CalendarSnapshotResult.FromSnapshot(snapshot));
+}
+
+/// <summary>Frozen MCP snapshot representation.</summary>
+public sealed record CalendarSnapshotResult(
+    [property: JsonPropertyName("calendar")] CalendarHref Calendar,
+    [property: JsonPropertyName("resourceRevision")] CalendarResourceRevisionResult ResourceRevision,
+    [property: JsonPropertyName("authoritativePayload")] CalendarAuthoritativePayloadResult AuthoritativePayload,
+    [property: JsonPropertyName("calendarProperties")] IReadOnlyList<CalendarPropertyResult> CalendarProperties,
+    [property: JsonPropertyName("projection")] object Projection,
+    [property: JsonPropertyName("diagnostics")] IReadOnlyList<CalendarDiagnosticResult> Diagnostics,
+    [property: JsonPropertyName("entityRevision"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] CalendarEntityRevisionResult? EntityRevision)
+{
+    internal static CalendarSnapshotResult FromSnapshot(CalendarResourceSnapshot snapshot) => new(
+        new CalendarHref(snapshot.CalendarHref),
+        new CalendarResourceRevisionResult(snapshot.ResourceHref, snapshot.EntityTag),
+        new CalendarAuthoritativePayloadResult("base64", Convert.ToBase64String(snapshot.AuthoritativeUtf8.Span)),
+        snapshot.CalendarProperties.Select(CalendarPropertyResult.FromProperty).ToArray(),
+        CreateProjection(snapshot),
+        snapshot.Diagnostics.Select(CalendarDiagnosticResult.FromResourceDiagnostic).ToArray(),
+        CreateEntityRevision(snapshot));
+
+    private static object CreateProjection(CalendarResourceSnapshot snapshot) => snapshot.Projection.Kind switch
+    {
+        CalendarResourceProjectionKind.Event => new CalendarEventProjectionResult(
+            "event",
+            snapshot.Projection.EntityUid!,
+            new CalendarEventFieldsResult(snapshot.Projection.Summary)),
+        CalendarResourceProjectionKind.Todo => new CalendarTodoProjectionResult(
+            "todo",
+            snapshot.Projection.EntityUid!,
+            new CalendarTodoFieldsResult(snapshot.Projection.Summary)),
+        _ => new CalendarOpaqueProjectionResult("opaque", snapshot.CalendarProperties.Select(CalendarPropertyResult.FromProperty).ToArray())
+    };
+
+    private static CalendarEntityRevisionResult? CreateEntityRevision(CalendarResourceSnapshot snapshot) =>
+        snapshot.SemanticMutationAvailable
+            ? new CalendarEntityRevisionResult(
+                snapshot.ResourceHref,
+                snapshot.Projection.EntityUid!,
+                snapshot.Projection.Kind == CalendarResourceProjectionKind.Event ? "event" : "todo",
+                snapshot.EntityTag)
+            : null;
+}
+
+public sealed record CalendarResourceRevisionResult(
+    [property: JsonPropertyName("href")] string Href,
+    [property: JsonPropertyName("entityTag")] string EntityTag);
+
+public sealed record CalendarAuthoritativePayloadResult(
+    [property: JsonPropertyName("encoding")] string Encoding,
+    [property: JsonPropertyName("base64Utf8")] string Base64Utf8);
+
+public sealed record CalendarEntityRevisionResult(
+    [property: JsonPropertyName("href")] string Href,
+    [property: JsonPropertyName("entityUid")] string EntityUid,
+    [property: JsonPropertyName("entityKind")] string EntityKind,
+    [property: JsonPropertyName("entityTag")] string EntityTag);
+
+public sealed record CalendarEventProjectionResult(
+    [property: JsonPropertyName("kind")] string Kind,
+    [property: JsonPropertyName("uid")] string Uid,
+    [property: JsonPropertyName("fields")] CalendarEventFieldsResult Fields);
+
+public sealed record CalendarTodoProjectionResult(
+    [property: JsonPropertyName("kind")] string Kind,
+    [property: JsonPropertyName("uid")] string Uid,
+    [property: JsonPropertyName("fields")] CalendarTodoFieldsResult Fields);
+
+public sealed record CalendarOpaqueProjectionResult(
+    [property: JsonPropertyName("kind")] string Kind,
+    [property: JsonPropertyName("properties")] IReadOnlyList<CalendarPropertyResult> Properties);
+
+public sealed record CalendarEventFieldsResult(
+    [property: JsonPropertyName("summary"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] string? Summary);
+
+public sealed record CalendarTodoFieldsResult(
+    [property: JsonPropertyName("summary"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] string? Summary);
+
+public sealed record CalendarPropertyResult(
+    [property: JsonPropertyName("componentPath")] IReadOnlyList<CalendarComponentPathResult> ComponentPath,
+    [property: JsonPropertyName("name")] string Name,
+    [property: JsonPropertyName("parameters")] IReadOnlyList<CalendarParameterResult> Parameters,
+    [property: JsonPropertyName("valueType")] string ValueType,
+    [property: JsonPropertyName("rawEncodedValue")] string RawEncodedValue,
+    [property: JsonPropertyName("originalSlice")] string OriginalSlice)
+{
+    internal static CalendarPropertyResult FromProperty(CalendarProperty property) => new(
+        property.ComponentPath.Select(item => new CalendarComponentPathResult(item.Name, item.Occurrence)).ToArray(),
+        property.Name,
+        property.Parameters.Select(item => new CalendarParameterResult(item.Name, item.Values)).ToArray(),
+        property.ValueType switch
+        {
+            CalendarPropertyValueType.DateTime => "date-time",
+            _ => property.ValueType.ToString().ToLowerInvariant()
+        },
+        property.RawEncodedValue,
+        property.OriginalSlice);
+}
+
+public sealed record CalendarComponentPathResult(
+    [property: JsonPropertyName("name")] string Name,
+    [property: JsonPropertyName("occurrence")] int Occurrence);
+
+public sealed record CalendarParameterResult(
+    [property: JsonPropertyName("name")] string Name,
+    [property: JsonPropertyName("values")] IReadOnlyList<string> Values);
+
+public sealed record CalendarResourceErrorResult(
+    [property: JsonPropertyName("code")] string Code,
+    [property: JsonPropertyName("category")] string Category,
+    [property: JsonPropertyName("message")] string Message,
+    [property: JsonPropertyName("retryable")] bool Retryable,
+    [property: JsonPropertyName("phase")] string Phase,
+    [property: JsonPropertyName("limits"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] CalendarResourceExecutionLimits? Limits = null);
+
+public sealed record CalendarResourceExecutionLimits(
+    [property: JsonPropertyName("byteCount"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] int? ByteCount = null,
+    [property: JsonPropertyName("calendarCount"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] int? CalendarCount = null);

--- a/src/DotnetAgents.CalDav.Mcp/Tools/CalendarTools.cs
+++ b/src/DotnetAgents.CalDav.Mcp/Tools/CalendarTools.cs
@@ -190,6 +190,17 @@ public sealed record CalendarDiagnosticResult(
             CalendarDiagnosticSeverity.Error => "error",
             _ => throw new ArgumentOutOfRangeException(nameof(diagnostic), diagnostic.Severity, null)
         });
+
+    internal static CalendarDiagnosticResult FromResourceDiagnostic(CalendarResourceDiagnostic diagnostic) => new(
+        diagnostic.Code,
+        diagnostic.Message,
+        diagnostic.Severity switch
+        {
+            CalendarResourceDiagnosticSeverity.Info => "info",
+            CalendarResourceDiagnosticSeverity.Warning => "warning",
+            CalendarResourceDiagnosticSeverity.Error => "error",
+            _ => throw new ArgumentOutOfRangeException(nameof(diagnostic), diagnostic.Severity, null)
+        });
 }
 
 /// <summary>List pagination deliberately has no snapshot continuity guarantee.</summary>

--- a/src/DotnetAgents.CalDav.Mcp/Tools/ExactCalendarResourceTools.cs
+++ b/src/DotnetAgents.CalDav.Mcp/Tools/ExactCalendarResourceTools.cs
@@ -1,0 +1,148 @@
+using System.ComponentModel;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json.Serialization;
+using DotnetAgents.CalDav.Core.Abstractions;
+using DotnetAgents.CalDav.Core.Models;
+using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
+
+namespace DotnetAgents.CalDav.Mcp.Tools;
+
+/// <summary>Opt-in exact Calendar Object Resource access through protected MCP resource links.</summary>
+[McpServerToolType]
+public sealed class ExactCalendarResourceTools
+{
+    private readonly ICalendarService _calendarService;
+
+    public ExactCalendarResourceTools(ICalendarService calendarService)
+    {
+        _calendarService = calendarService;
+    }
+
+    [McpServerTool(
+        Name = "calendar_resources.exact_get",
+        ReadOnly = true,
+        Destructive = false,
+        Idempotent = true,
+        OpenWorld = true,
+        UseStructuredContent = true,
+        OutputSchemaType = typeof(CalendarExactGetSuccessResult)),
+     Description("Read one confirmed absolute href through a protected MCP resource link.")]
+    public async Task<CallToolResult> GetAsync(
+        [Description("Canonical absolute Calendar Object Resource href.")] string href,
+        CancellationToken cancellationToken)
+    {
+        return await CalendarResourceTools.ExecuteReadAsync(
+            _calendarService,
+            href,
+            CreateSuccess,
+            cancellationToken);
+    }
+
+    private static CallToolResult CreateSuccess(CalendarResourceSnapshot snapshot)
+    {
+        var link = ExactCalendarResourceLink.Create(snapshot);
+        return CalendarResourceTools.CreateSuccess(
+            new CalendarExactGetSuccessResult("success", new CalendarExactResourceLinkResult("resource_link", link.Uri, link.Name)),
+            link);
+    }
+}
+
+public sealed record CalendarExactGetSuccessResult(
+    [property: JsonPropertyName("outcome")] string Outcome,
+    [property: JsonPropertyName("resourceLink")] CalendarExactResourceLinkResult ResourceLink);
+
+public sealed record CalendarExactResourceLinkResult(
+    [property: JsonPropertyName("type")] string Type,
+    [property: JsonPropertyName("uri")] string Uri,
+    [property: JsonPropertyName("name")] string Name);
+
+internal static class ExactCalendarResourceLink
+{
+    private const string Scheme = "caldav-exact";
+
+    public static ResourceLinkBlock Create(CalendarResourceSnapshot snapshot)
+    {
+        var uri = $"{Scheme}://snapshot/{Encode(snapshot.ResourceHref)}?etag={Encode(snapshot.EntityTag)}";
+        return new ResourceLinkBlock
+        {
+            Uri = uri,
+            Name = "Calendar Object Resource exact snapshot",
+            Description = "Exact UTF-8 content from the bound strong Entity Tag revision.",
+            MimeType = "text/calendar; charset=utf-8",
+            Size = snapshot.AuthoritativeUtf8.Length
+        };
+    }
+
+    public static bool TryParse(string uri, out string href, out string entityTag)
+    {
+        href = string.Empty;
+        entityTag = string.Empty;
+        if (!Uri.TryCreate(uri, UriKind.Absolute, out var parsed) || !HasProtectedShape(parsed, uri))
+            return false;
+
+        var etagPrefix = "?etag=";
+        if (!parsed.Query.StartsWith(etagPrefix, StringComparison.Ordinal))
+            return false;
+        var encodedEntityTag = parsed.Query[etagPrefix.Length..];
+        if (encodedEntityTag.Length == 0 || encodedEntityTag.Contains('&'))
+            return false;
+        return TryDecodeBinding(parsed.AbsolutePath[1..], encodedEntityTag, out href, out entityTag);
+    }
+
+    private static bool HasProtectedShape(Uri parsed, string original) =>
+        parsed.Scheme.Equals(Scheme, StringComparison.Ordinal)
+        && parsed.Host.Equals("snapshot", StringComparison.Ordinal)
+        && string.IsNullOrEmpty(parsed.UserInfo)
+        && parsed.IsDefaultPort
+        && string.IsNullOrEmpty(parsed.Fragment)
+        && parsed.AbsolutePath.Length > 1
+        && !parsed.AbsolutePath[1..].Contains('/')
+        && string.Equals(parsed.AbsoluteUri, original, StringComparison.Ordinal);
+
+    private static bool TryDecodeBinding(
+        string encodedHref,
+        string encodedEntityTag,
+        out string href,
+        out string entityTag)
+    {
+        href = string.Empty;
+        entityTag = string.Empty;
+        if (!TryDecode(encodedHref, out href) || !TryDecode(encodedEntityTag, out entityTag))
+            return false;
+        return IsCanonicalResourceHref(href)
+            && EntityTagHeaderValue.TryParse(entityTag, out var parsedEntityTag)
+            && parsedEntityTag is { IsWeak: false };
+    }
+
+    private static string Encode(string value) => Convert.ToBase64String(Encoding.UTF8.GetBytes(value))
+        .TrimEnd('=')
+        .Replace('+', '-')
+        .Replace('/', '_');
+
+    private static bool TryDecode(string value, out string decoded)
+    {
+        decoded = string.Empty;
+        try
+        {
+            var base64 = value.Replace('-', '+').Replace('_', '/');
+            base64 = base64.PadRight((base64.Length + 3) / 4 * 4, '=');
+            decoded = new UTF8Encoding(false, true).GetString(Convert.FromBase64String(base64));
+            return string.Equals(Encode(decoded), value, StringComparison.Ordinal);
+        }
+        catch (Exception exception) when (exception is FormatException or DecoderFallbackException)
+        {
+            return false;
+        }
+    }
+
+    private static bool IsCanonicalResourceHref(string href) =>
+        Uri.TryCreate(href, UriKind.Absolute, out var parsed)
+        && (parsed.Scheme.Equals(Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase)
+            || parsed.Scheme.Equals(Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
+        && string.IsNullOrEmpty(parsed.UserInfo)
+        && string.IsNullOrEmpty(parsed.Query)
+        && string.IsNullOrEmpty(parsed.Fragment)
+        && string.Equals(parsed.AbsoluteUri, href, StringComparison.Ordinal);
+}

--- a/tests/DotnetAgents.CalDav.Core.Tests.Unit/Internal/CalDavClientTests.cs
+++ b/tests/DotnetAgents.CalDav.Core.Tests.Unit/Internal/CalDavClientTests.cs
@@ -15,6 +15,128 @@ namespace DotnetAgents.CalDav.Core.Tests.Unit.Internal;
 
 public class CalDavClientTests
 {
+    [Theory]
+    [InlineData(null)]
+    [InlineData("W/\"weak-revision\"")]
+    public async Task GetCalendarResourceAsync_ReturnsConcurrencyUnavailableForMissingOrWeakEntityTag(string? entityTag)
+    {
+        var handler = new StubHttpMessageHandler(_ =>
+        {
+            var response = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("BEGIN:VCALENDAR\r\nEND:VCALENDAR\r\n", Encoding.UTF8, "text/calendar")
+            };
+            if (entityTag is not null)
+                response.Headers.ETag = EntityTagHeaderValue.Parse(entityTag);
+            return response;
+        });
+        var sut = CreateSut(handler);
+
+        var result = await sut.GetCalendarResourceAsync(
+            "https://example.com/calendars/user/events/a.ics",
+            CancellationToken.None);
+
+        result.Code.ShouldBe(CalendarResourceReadCode.ConcurrencyUnavailable);
+        result.EntityTag.ShouldBeNull();
+        result.AuthoritativeUtf8.IsEmpty.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task GetCalendarResourceAsync_RejectsInvalidUtf8WithoutReturningAResource()
+    {
+        var handler = new StubHttpMessageHandler(_ => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Headers = { ETag = new EntityTagHeaderValue("\"revision-1\"") },
+            Content = new ByteArrayContent([0x43, 0xC3, 0x28])
+        });
+        var sut = CreateSut(handler);
+
+        var result = await sut.GetCalendarResourceAsync(
+            "https://example.com/calendars/user/events/a.ics",
+            CancellationToken.None);
+
+        result.Code.ShouldBe(CalendarResourceReadCode.UpstreamProtocolError);
+        result.EntityTag.ShouldBeNull();
+        result.AuthoritativeUtf8.IsEmpty.ShouldBeTrue();
+        result.Snapshot.ShouldBeNull();
+    }
+
+    [Theory]
+    [InlineData((4 * 1024 * 1024) - 1, CalendarResourceReadCode.Success)]
+    [InlineData(4 * 1024 * 1024, CalendarResourceReadCode.Success)]
+    [InlineData((4 * 1024 * 1024) + 1, CalendarResourceReadCode.PayloadTooLarge)]
+    public async Task GetCalendarResourceAsync_EnforcesDecompressedUtf8LimitPlusOne(
+        int byteCount,
+        CalendarResourceReadCode expectedCode)
+    {
+        var payload = Enumerable.Repeat((byte)'A', byteCount).ToArray();
+        var handler = new StubHttpMessageHandler(_ => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Headers = { ETag = new EntityTagHeaderValue("\"revision-1\"") },
+            Content = new ByteArrayContent(payload)
+        });
+        var sut = CreateSut(handler);
+
+        var result = await sut.GetCalendarResourceAsync(
+            "https://example.com/calendars/user/events/a.ics",
+            CancellationToken.None);
+
+        result.Code.ShouldBe(expectedCode);
+        if (expectedCode == CalendarResourceReadCode.Success)
+            result.AuthoritativeUtf8.Length.ShouldBe(byteCount);
+        else
+        {
+            result.AuthoritativeUtf8.IsEmpty.ShouldBeTrue();
+            result.Snapshot.ShouldBeNull();
+            result.ObservedByteCount.ShouldBe(byteCount);
+        }
+    }
+
+    [Fact]
+    public async Task GetCalendarResourceAsync_StopsUnknownLengthStreamAtLimitPlusOne()
+    {
+        var stream = new CountingNonSeekableStream(new byte[(4 * 1024 * 1024) + 128]);
+        var handler = new StubHttpMessageHandler(_ => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Headers = { ETag = new EntityTagHeaderValue("\"revision-1\"") },
+            Content = new StreamContent(stream)
+        });
+        var sut = CreateSut(handler);
+
+        var result = await sut.GetCalendarResourceAsync(
+            "https://example.com/calendars/user/events/a.ics",
+            CancellationToken.None);
+
+        result.Code.ShouldBe(CalendarResourceReadCode.PayloadTooLarge);
+        result.ObservedByteCount.ShouldBe((4 * 1024 * 1024) + 1);
+        result.AuthoritativeUtf8.IsEmpty.ShouldBeTrue();
+        result.Snapshot.ShouldBeNull();
+        stream.BytesRead.ShouldBe((4 * 1024 * 1024) + 1);
+    }
+
+    [Theory]
+    [InlineData("https://other.example/calendars/user/events/a.ics")]
+    [InlineData("https://user:secret@example.com/calendars/user/events/a.ics")]
+    [InlineData("https://example.com/calendars/user/events/a.ics#fragment")]
+    [InlineData("https://example.com/calendars/user/events%2Fprivate/a.ics")]
+    [InlineData("https://example.com/calendars/user/events%5cprivate/a.ics")]
+    [InlineData("/calendars/user/events/a.ics")]
+    public async Task GetCalendarResourceAsync_RejectsUnsafeHrefWithoutSendingRequest(string href)
+    {
+        var requestCount = 0;
+        var handler = new StubHttpMessageHandler(_ =>
+        {
+            requestCount++;
+            return new HttpResponseMessage(HttpStatusCode.OK);
+        });
+        var sut = CreateSut(handler);
+
+        var result = await sut.GetCalendarResourceAsync(href, CancellationToken.None);
+
+        result.Code.ShouldBe(CalendarResourceReadCode.InvalidInput);
+        requestCount.ShouldBe(0);
+    }
+
     #region CreateTaskAsync Tests
 
     [Fact]
@@ -1836,6 +1958,34 @@ public class CalDavClientTests
         {
             return Task.FromResult(handler(request));
         }
+    }
+
+    private sealed class CountingNonSeekableStream(byte[] content) : Stream
+    {
+        private readonly MemoryStream _inner = new(content);
+
+        public int BytesRead { get; private set; }
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => throw new NotSupportedException();
+        public override long Position { get => throw new NotSupportedException(); set => throw new NotSupportedException(); }
+        public override void Flush() { }
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            var read = _inner.Read(buffer, offset, count);
+            BytesRead += read;
+            return read;
+        }
+        public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            var read = _inner.Read(buffer.Span);
+            BytesRead += read;
+            return ValueTask.FromResult(read);
+        }
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
     }
 
     /// <summary>

--- a/tests/DotnetAgents.CalDav.Core.Tests.Unit/Internal/Ical/CalendarContentDocumentTests.cs
+++ b/tests/DotnetAgents.CalDav.Core.Tests.Unit/Internal/Ical/CalendarContentDocumentTests.cs
@@ -1,0 +1,511 @@
+using System.Text;
+using DotnetAgents.CalDav.Core.Internal.Ical;
+using DotnetAgents.CalDav.Core.Models;
+using Shouldly;
+using Xunit;
+
+namespace DotnetAgents.CalDav.Core.Tests.Unit.Internal.Ical;
+
+public sealed class CalendarContentDocumentTests
+{
+    [Fact]
+    public void Parse_PreservesFoldedSlicesUnknownValuesAndRepeatedParameterOccurrences()
+    {
+        const string content = "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Example//EN\r\nBEGIN:VEVENT\r\nUID:u1\r\nDTSTAMP:20260815T120000Z\r\nDTSTART:20260816T090000Z\r\nDESCRIPTION:Ol\u00e1 \ud83c\udf0d and a long value\r\n continued exactly\r\n\r\nX-LINK;X-LABEL=One,one;X-LABEL=TWO;VALUE=URI:https://example.test/a,b;c\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n";
+        var bytes = Encoding.UTF8.GetBytes(content);
+
+        var document = CalendarContentDocument.Parse(bytes);
+        var property = document.Properties.Single(item => item.Name == "X-LINK");
+
+        document.Replay().ShouldBe(bytes);
+        property.ComponentPath.Select(item => (item.Name, item.Occurrence)).ShouldBe(
+            [("VCALENDAR", 0), ("VEVENT", 0)]);
+        property.Parameters.Select(item => (item.Name, string.Join('|', item.Values))).ShouldBe(
+            [("X-LABEL", "One|one"), ("X-LABEL", "TWO"), ("VALUE", "URI")]);
+        property.ValueType.ShouldBe(CalendarPropertyValueType.Uri);
+        property.RawEncodedValue.ShouldBe("https://example.test/a,b;c");
+        property.OriginalSlice.ShouldBe("X-LINK;X-LABEL=One,one;X-LABEL=TWO;VALUE=URI:https://example.test/a,b;c\r\n");
+        document.Properties.Single(item => item.Name == "DESCRIPTION").OriginalSlice.ShouldContain("\r\n continued exactly\r\n");
+    }
+
+    [Fact]
+    public void Parse_DecodesRfc6868ParameterEscapesInOnePass()
+    {
+        const string content = "BEGIN:VCALENDAR\r\nX-PROP;X-P=^^n,^n,^',^^:value\r\nEND:VCALENDAR\r\n";
+
+        var document = CalendarContentDocument.Parse(Encoding.UTF8.GetBytes(content));
+
+        document.Properties.Single().Parameters.Single().Values.ShouldBe(["^n", "\n", "\"", "^"]);
+    }
+
+    [Theory]
+    [InlineData(CalendarPropertyValueType.Uri, "ATTACH,ATTENDEE,CALENDAR-ADDRESS,CONCEPT,CONFERENCE,IMAGE,LINK,ORGANIZER,SOURCE,TZURL,URL")]
+    [InlineData(CalendarPropertyValueType.DateTime, "ACKNOWLEDGED,COMPLETED,CREATED,DTEND,DTSTAMP,DTSTART,DUE,EXDATE,LAST-MODIFIED,RDATE,RECURRENCE-ID")]
+    [InlineData(CalendarPropertyValueType.Duration, "DURATION,REFRESH-INTERVAL,TRIGGER")]
+    [InlineData(CalendarPropertyValueType.Integer, "PERCENT-COMPLETE,PRIORITY,REPEAT,SEQUENCE")]
+    [InlineData(CalendarPropertyValueType.Float, "GEO")]
+    [InlineData(CalendarPropertyValueType.Period, "FREEBUSY")]
+    [InlineData(CalendarPropertyValueType.Recur, "EXRULE,RRULE")]
+    [InlineData(CalendarPropertyValueType.Text, "ACTION,CALSCALE,CATEGORIES,CLASS,COLOR,COMMENT,CONTACT,DESCRIPTION,LOCATION,METHOD,NAME,PRODID,PROXIMITY,REFID,RELATED-TO,REQUEST-STATUS,RESOURCES,RESOURCE-TYPE,STATUS,STRUCTURED-DATA,SUMMARY,TRANSP,TZID,TZNAME,UID,VERSION")]
+    public void GetDefaultValueType_ExhaustivelyClassifiesRegisteredFrozenValues(
+        CalendarPropertyValueType expected,
+        string propertyNames)
+    {
+        foreach (var propertyName in propertyNames.Split(','))
+        {
+            CalendarContentDocument.IsRegisteredPropertyName(propertyName).ShouldBeTrue();
+            CalendarContentDocument.GetDefaultValueType(propertyName).ShouldBe(expected);
+        }
+    }
+
+    [Theory]
+    [InlineData("TEXT", CalendarPropertyValueType.Text)]
+    [InlineData("URI", CalendarPropertyValueType.Uri)]
+    [InlineData("CAL-ADDRESS", CalendarPropertyValueType.Uri)]
+    [InlineData("DATE", CalendarPropertyValueType.Date)]
+    [InlineData("DATE-TIME", CalendarPropertyValueType.DateTime)]
+    [InlineData("DURATION", CalendarPropertyValueType.Duration)]
+    [InlineData("INTEGER", CalendarPropertyValueType.Integer)]
+    [InlineData("FLOAT", CalendarPropertyValueType.Float)]
+    [InlineData("PERIOD", CalendarPropertyValueType.Period)]
+    [InlineData("RECUR", CalendarPropertyValueType.Recur)]
+    [InlineData("BINARY", CalendarPropertyValueType.Binary)]
+    [InlineData("X-UNKNOWN", CalendarPropertyValueType.Unknown)]
+    public void Parse_ClassifiesEveryFrozenExplicitValueType(
+        string explicitValue,
+        CalendarPropertyValueType expected)
+    {
+        var content = $"BEGIN:VCALENDAR\r\nX-PROP;VALUE={explicitValue}:value\r\nEND:VCALENDAR\r\n";
+
+        var property = CalendarContentDocument.Parse(Encoding.UTF8.GetBytes(content)).Properties.Single();
+
+        property.ValueType.ShouldBe(expected);
+    }
+
+    [Theory]
+    [InlineData("TZOFFSETFROM")]
+    [InlineData("TZOFFSETTO")]
+    public void GetDefaultValueType_KeepsUtcOffsetsRegisteredButFrozenUnknown(string propertyName)
+    {
+        CalendarContentDocument.IsRegisteredPropertyName(propertyName).ShouldBeTrue();
+        CalendarContentDocument.GetDefaultValueType(propertyName).ShouldBe(CalendarPropertyValueType.Unknown);
+    }
+
+    [Theory]
+    [InlineData("BEGIN:VCALENDAR\rEND:VCALENDAR\r\n")]
+    [InlineData(" SUMMARY:value\r\n")]
+    [InlineData("BEGIN:VCALENDAR\r\nMALFORMED\r\nEND:VCALENDAR\r\n")]
+    [InlineData("X-PROP:value\r\n")]
+    [InlineData("BEGIN:VCALENDAR\r\n")]
+    [InlineData("BEGIN:X_BAD\r\nEND:X_BAD\r\n")]
+    [InlineData("END:VCALENDAR\r\n")]
+    [InlineData("BEGIN:VCALENDAR\r\nEND:VEVENT\r\n")]
+    [InlineData("BEGIN:VCALENDAR\r\nX-PROP;PARAM:value\r\nEND:VCALENDAR\r\n")]
+    [InlineData("BEGIN:VCALENDAR\r\nX-PROP;BAD_PARAM=value:value\r\nEND:VCALENDAR\r\n")]
+    [InlineData("BEGIN:VCALENDAR\r\nA.B.C:value\r\nEND:VCALENDAR\r\n")]
+    [InlineData("BEGIN:VCALENDAR\r\nBAD_NAME:value\r\nEND:VCALENDAR\r\n")]
+    public void Parse_RejectsMalformedContentLineStructure(string content)
+    {
+        Should.Throw<FormatException>(() => CalendarContentDocument.Parse(Encoding.UTF8.GetBytes(content)));
+    }
+
+    [Theory]
+    [InlineData("new\rvalue")]
+    [InlineData("new\nvalue")]
+    public void ReplaceSinglePropertyValue_RejectsPhysicalLineBreaks(string replacement)
+    {
+        const string content = "BEGIN:VCALENDAR\r\nSUMMARY:old\r\nEND:VCALENDAR\r\n";
+        var document = CalendarContentDocument.Parse(Encoding.UTF8.GetBytes(content));
+
+        Should.Throw<ArgumentException>(() =>
+            document.ReplaceSinglePropertyValue(document.Components.Single().Path, "SUMMARY", replacement));
+    }
+
+    [Theory]
+    [InlineData("DESCRIPTION:other\r\n")]
+    [InlineData("SUMMARY:one\r\nSUMMARY:two\r\n")]
+    public void ReplaceSinglePropertyValue_RequiresExactlyOneAddressedOccurrence(string properties)
+    {
+        var content = $"BEGIN:VCALENDAR\r\n{properties}END:VCALENDAR\r\n";
+        var document = CalendarContentDocument.Parse(Encoding.UTF8.GetBytes(content));
+
+        Should.Throw<InvalidOperationException>(() =>
+            document.ReplaceSinglePropertyValue(document.Components.Single().Path, "SUMMARY", "new"));
+    }
+
+    [Fact]
+    public void ReplaceSinglePropertyValue_PreservesLfFoldedHeaderPrefix()
+    {
+        const string content = "BEGIN:VCALENDAR\nSUMMARY;X-LABEL=first\n continued:old\nEND:VCALENDAR\n";
+        var document = CalendarContentDocument.Parse(Encoding.UTF8.GetBytes(content));
+
+        var edited = document.ReplaceSinglePropertyValue(document.Components.Single().Path, "SUMMARY", "new");
+
+        Encoding.UTF8.GetString(edited).ShouldBe("BEGIN:VCALENDAR\nSUMMARY;X-LABEL=first\n continued:new\nEND:VCALENDAR\n");
+    }
+
+    [Fact]
+    public void Project_TreatsUnsupportedRootEntityComponentAsOpaqueEvenWhenItIsEmpty()
+    {
+        const string content = "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Example//EN\r\nBEGIN:vevent\r\nUID:u1\r\nDTSTAMP:20260815T120000Z\r\nDTSTART:20260816T090000Z\r\nEND:vevent\r\nBEGIN:VJOURNAL\r\nEND:VJOURNAL\r\nEND:VCALENDAR\r\n";
+
+        var result = CalendarResourceProjector.Project(Encoding.UTF8.GetBytes(content));
+
+        result.Projection.Kind.ShouldBe(CalendarResourceProjectionKind.Opaque);
+        result.Diagnostics.Select(item => item.Code).ShouldBe(["unsupported_entity_component"]);
+    }
+
+    [Fact]
+    public void Project_TreatsAnEmptyAdditionalEntityAsOpaque()
+    {
+        const string content = "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Example//EN\r\nBEGIN:VEVENT\r\nUID:u1\r\nDTSTAMP:20260815T120000Z\r\nDTSTART:20260816T090000Z\r\nEND:VEVENT\r\nBEGIN:VEVENT\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n";
+
+        var result = CalendarResourceProjector.Project(Encoding.UTF8.GetBytes(content));
+
+        result.Projection.Kind.ShouldBe(CalendarResourceProjectionKind.Opaque);
+        result.Diagnostics.Select(item => item.Code).ShouldBe(["entity_uid_invalid"]);
+    }
+
+    [Fact]
+    public void Project_TreatsRepeatedSingletonPropertyAsOpaque()
+    {
+        const string content = "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Example//EN\r\nBEGIN:VEVENT\r\nUID:u1\r\nDTSTAMP:20260815T120000Z\r\nDTSTART:20260816T090000Z\r\nSUMMARY:one\r\nSUMMARY:two\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n";
+
+        var result = CalendarResourceProjector.Project(Encoding.UTF8.GetBytes(content));
+
+        result.Projection.Kind.ShouldBe(CalendarResourceProjectionKind.Opaque);
+        result.Diagnostics.Select(item => item.Code).ShouldBe(["singleton_property_repeated"]);
+    }
+
+    [Fact]
+    public void Project_DecodesTextEscapesInOnePass()
+    {
+        const string content = "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Example//EN\r\nBEGIN:VEVENT\r\nUID:u1\r\nDTSTAMP:20260815T120000Z\r\nDTSTART:20260816T090000Z\r\nSUMMARY:literal\\\\n and newline\\n\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n";
+
+        var result = CalendarResourceProjector.Project(Encoding.UTF8.GetBytes(content));
+
+        result.Projection.Kind.ShouldBe(CalendarResourceProjectionKind.Event);
+        result.Projection.Summary.ShouldBe("literal\\n and newline\n");
+    }
+
+    [Fact]
+    public void ReplaceSinglePropertyValue_ChangesOnlyTheAddressedSlice()
+    {
+        const string content = "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Example//EN\r\nX-ROOT;X-P=one,two:keep\r\nBEGIN:VEVENT\r\nUID:u1\r\nDTSTAMP:20260815T120000Z\r\nDTSTART:20260816T090000Z\r\nSUMMARY;X-LABEL=\"quoted:\r\n parameter\":old and\r\n folded\r\nATTACH;VALUE=URI:https://example.test/inert\r\nBEGIN:VALARM\r\nACTION:DISPLAY\r\nDESCRIPTION:keep nested\r\nTRIGGER:-PT15M\r\nEND:VALARM\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n";
+        var document = CalendarContentDocument.Parse(Encoding.UTF8.GetBytes(content));
+        var path = document.Components.Single(component => component.Path.Count == 2).Path;
+
+        var edited = document.ReplaceSinglePropertyValue(path, "SUMMARY", "new\\, exact");
+
+        Encoding.UTF8.GetString(edited).ShouldBe(content.Replace("parameter\":old and\r\n folded\r\n", "parameter\":new\\, exact\r\n", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void ReplaceSinglePropertyValue_PreservesNamedNestedAndUnknownCorpusByteForByte()
+    {
+        const string content = "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Example//EN\r\nBEGIN:VTIMEZONE\r\nTZID:America/New_York\r\nBEGIN:STANDARD\r\nDTSTART:19701101T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=11;BYDAY=1SU\r\nTZOFFSETFROM:-0400\r\nTZOFFSETTO:-0500\r\nTZNAME:EST\r\nEND:STANDARD\r\nEND:VTIMEZONE\r\nBEGIN:X-SUPPORT\r\nX-META:kept\r\nEND:X-SUPPORT\r\nBEGIN:VEVENT\r\nUID:u1\r\nDTSTAMP:20260815T120000Z\r\nDTSTART;TZID=America/New_York:20260816T090000\r\nSUMMARY:old\r\nX-REPEAT:first\r\nX-REPEAT:second\r\nITEM1.X-UNKNOWN;X-P=one;X-P=two,three:keep exactly\r\nBEGIN:X-NESTED\r\nX-VALUE:untouched\r\nEND:X-NESTED\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n";
+        var document = CalendarContentDocument.Parse(Encoding.UTF8.GetBytes(content));
+        var eventPath = document.Components.Single(component => component.Path.Count == 2 && component.Path[1].Name == "VEVENT").Path;
+
+        var projection = CalendarResourceProjector.Project(Encoding.UTF8.GetBytes(content));
+        projection.Projection.Kind.ShouldBe(
+            CalendarResourceProjectionKind.Event,
+            string.Join(',', projection.Diagnostics.Select(diagnostic => diagnostic.Code)));
+
+        var edited = document.ReplaceSinglePropertyValue(eventPath, "SUMMARY", "new");
+
+        Encoding.UTF8.GetString(edited).ShouldBe(content.Replace("SUMMARY:old\r\n", "SUMMARY:new\r\n", StringComparison.Ordinal));
+        document.Properties.Single(property => property.Name == "X-UNKNOWN").Parameters.Count.ShouldBe(2);
+        document.Properties.Count(property => property.Name == "X-REPEAT").ShouldBe(2);
+        document.Components.ShouldContain(component => component.Path.Select(part => part.Name).SequenceEqual(new[] { "VCALENDAR", "VTIMEZONE", "STANDARD" }));
+        document.Components.ShouldContain(component => component.Path.Select(part => part.Name).SequenceEqual(new[] { "VCALENDAR", "VEVENT", "X-NESTED" }));
+    }
+
+    [Fact]
+    public void Project_PermitsUnknownRootSupportingComponentAlongsideEvent()
+    {
+        const string content = "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Example//EN\r\nBEGIN:X-SUPPORT\r\nX-META:kept\r\nEND:X-SUPPORT\r\nBEGIN:VEVENT\r\nUID:u1\r\nDTSTAMP:20260815T120000Z\r\nDTSTART:20260816T090000Z\r\nSUMMARY:projectable\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n";
+
+        var result = CalendarResourceProjector.Project(Encoding.UTF8.GetBytes(content));
+
+        result.Projection.Kind.ShouldBe(CalendarResourceProjectionKind.Event);
+        result.Properties.Single(property => property.Name == "X-META").RawEncodedValue.ShouldBe("kept");
+    }
+
+    [Fact]
+    public void Project_RejectsEntityComponentNestedUnderUnknownComponent()
+    {
+        const string content = "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Example//EN\r\nBEGIN:VEVENT\r\nUID:u1\r\nDTSTAMP:20260815T120000Z\r\nDTSTART:20260816T090000Z\r\nEND:VEVENT\r\nBEGIN:X-SUPPORT\r\nBEGIN:VTODO\r\nUID:u2\r\nEND:VTODO\r\nEND:X-SUPPORT\r\nEND:VCALENDAR\r\n";
+
+        var result = CalendarResourceProjector.Project(Encoding.UTF8.GetBytes(content));
+
+        result.Projection.Kind.ShouldBe(CalendarResourceProjectionKind.Opaque);
+        result.Diagnostics.Select(item => item.Code).ShouldBe(["known_component_topology_invalid"]);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("BEGIN:X-ROOT\r\nEND:X-ROOT\r\n")]
+    [InlineData("BEGIN:VCALENDAR\r\nEND:VCALENDAR\r\nBEGIN:VCALENDAR\r\nEND:VCALENDAR\r\n")]
+    public void Project_RejectsInvalidCalendarRootCardinality(string content)
+    {
+        var result = CalendarResourceProjector.Project(Encoding.UTF8.GetBytes(content));
+
+        result.Diagnostics.Select(item => item.Code).ShouldBe(["calendar_component_cardinality"]);
+    }
+
+    [Fact]
+    public void Project_RejectsMixedDirectEntityKinds()
+    {
+        const string content = "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Example//EN\r\nBEGIN:VEVENT\r\nUID:u1\r\nDTSTAMP:20260815T120000Z\r\nDTSTART:20260816T090000Z\r\nEND:VEVENT\r\nBEGIN:VTODO\r\nUID:u1\r\nDTSTAMP:20260815T120000Z\r\nEND:VTODO\r\nEND:VCALENDAR\r\n";
+
+        var result = CalendarResourceProjector.Project(Encoding.UTF8.GetBytes(content));
+
+        result.Diagnostics.Select(item => item.Code).ShouldBe(["mixed_entity_kinds"]);
+    }
+
+    [Fact]
+    public void Project_RejectsEventWithoutStart()
+    {
+        const string content = "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Example//EN\r\nBEGIN:VEVENT\r\nUID:u1\r\nDTSTAMP:20260815T120000Z\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n";
+
+        var result = CalendarResourceProjector.Project(Encoding.UTF8.GetBytes(content));
+
+        result.Diagnostics.Select(item => item.Code).ShouldBe(["entity_start_invalid"]);
+    }
+
+    [Fact]
+    public void Project_PermitsTodoWithoutStart()
+    {
+        const string content = "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Example//EN\r\nBEGIN:VTODO\r\nUID:u1\r\nDTSTAMP:20260815T120000Z\r\nEND:VTODO\r\nEND:VCALENDAR\r\n";
+
+        CalendarResourceProjector.Project(Encoding.UTF8.GetBytes(content)).Projection.Kind
+            .ShouldBe(CalendarResourceProjectionKind.Todo);
+    }
+
+    [Fact]
+    public void Project_RejectsTwoMasterEntities()
+    {
+        const string content = "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Example//EN\r\nBEGIN:VEVENT\r\nUID:u1\r\nDTSTAMP:20260815T120000Z\r\nDTSTART:20260816T090000Z\r\nEND:VEVENT\r\nBEGIN:VEVENT\r\nUID:u1\r\nDTSTAMP:20260815T120000Z\r\nDTSTART:20260817T090000Z\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n";
+
+        var result = CalendarResourceProjector.Project(Encoding.UTF8.GetBytes(content));
+
+        result.Diagnostics.Select(item => item.Code).ShouldBe(["entity_master_cardinality"]);
+    }
+
+    [Theory]
+    [InlineData("u2", "RRULE:FREQ=DAILY;COUNT=2", "recurrence_override_uid_mismatch")]
+    [InlineData("u1", "", "recurrence_override_without_recurrence_set")]
+    public void Project_RejectsInvalidRecurrenceOverrideSet(string overrideUid, string recurrence, string diagnostic)
+    {
+        var content = $"BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Example//EN\r\nBEGIN:VEVENT\r\nUID:u1\r\nDTSTAMP:20260815T120000Z\r\nDTSTART:20260816T090000Z\r\n{recurrence}\r\nEND:VEVENT\r\nBEGIN:VEVENT\r\nUID:{overrideUid}\r\nDTSTAMP:20260815T120000Z\r\nRECURRENCE-ID:20260817T090000Z\r\nDTSTART:20260817T100000Z\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n";
+
+        var result = CalendarResourceProjector.Project(Encoding.UTF8.GetBytes(content));
+
+        result.Diagnostics.Select(item => item.Code).ShouldBe([diagnostic]);
+    }
+
+    [Theory]
+    [InlineData("BEGIN:VCALENDAR\r\nEND:VCALENDAR")]
+    [InlineData("BEGIN:VTIMEZONE\r\nTZID:Nested\r\nEND:VTIMEZONE")]
+    [InlineData("BEGIN:STANDARD\r\nDTSTART:19700101T000000\r\nTZOFFSETFROM:+0000\r\nTZOFFSETTO:+0000\r\nEND:STANDARD")]
+    [InlineData("BEGIN:VALARM\r\nACTION:DISPLAY\r\nTRIGGER:-PT5M\r\nEND:VALARM")]
+    public void Project_RejectsKnownComponentInIllegalTopology(string illegalComponent)
+    {
+        var content = $"BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Example//EN\r\nBEGIN:X-SUPPORT\r\n{illegalComponent}\r\nEND:X-SUPPORT\r\nBEGIN:VEVENT\r\nUID:u1\r\nDTSTAMP:20260815T120000Z\r\nDTSTART:20260816T090000Z\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n";
+
+        var result = CalendarResourceProjector.Project(Encoding.UTF8.GetBytes(content));
+
+        result.Projection.Kind.ShouldBe(CalendarResourceProjectionKind.Opaque);
+        result.Diagnostics.Select(item => item.Code).ShouldBe(["known_component_topology_invalid"]);
+    }
+
+    [Fact]
+    public void Project_RejectsInvalidValueTypeOnRegisteredProperty()
+    {
+        const string content = "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Example//EN\r\nBEGIN:VEVENT\r\nUID:u1\r\nDTSTAMP:20260815T120000Z\r\nDTSTART:20260816T090000Z\r\nRRULE;VALUE=X-BOGUS:FREQ=DAILY\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n";
+
+        var result = CalendarResourceProjector.Project(Encoding.UTF8.GetBytes(content));
+
+        result.Projection.Kind.ShouldBe(CalendarResourceProjectionKind.Opaque);
+        result.Properties.Single(property => property.Name == "RRULE").RawEncodedValue.ShouldBe("FREQ=DAILY");
+        result.Diagnostics.Select(item => item.Code).ShouldBe(["registered_property_value_invalid"]);
+    }
+
+    [Theory]
+    [InlineData("RRULE;VALUE=TEXT:FREQ=DAILY")]
+    [InlineData("URL;VALUE=TEXT:https://example.test/event")]
+    [InlineData("DTSTAMP;VALUE=DATE:20260815")]
+    public void Project_RejectsRecognizedButIncompatibleValueOverrides(string property)
+    {
+        var content = $"BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Example//EN\r\nBEGIN:VEVENT\r\nUID:u1\r\nDTSTAMP:20260815T120000Z\r\nDTSTART:20260816T090000Z\r\n{property}\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n";
+
+        var result = CalendarResourceProjector.Project(Encoding.UTF8.GetBytes(content));
+
+        result.Projection.Kind.ShouldBe(CalendarResourceProjectionKind.Opaque);
+        result.Diagnostics.Select(item => item.Code).ShouldBe(["registered_property_value_invalid"]);
+    }
+
+    [Fact]
+    public void Project_PermitsLegitimateDateAlternate()
+    {
+        const string content = "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Example//EN\r\nBEGIN:VEVENT\r\nUID:u1\r\nDTSTAMP:20260815T120000Z\r\nDTSTART;VALUE=DATE:20260816\r\nDTEND;VALUE=DATE:20260817\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n";
+
+        var result = CalendarResourceProjector.Project(Encoding.UTF8.GetBytes(content));
+
+        result.Projection.Kind.ShouldBe(CalendarResourceProjectionKind.Event);
+        result.Properties.Single(property => property.Name == "DTSTART").ValueType.ShouldBe(CalendarPropertyValueType.Date);
+    }
+
+    [Theory]
+    [InlineData("BEGIN:VALARM\r\nACTION:DISPLAY\r\nDESCRIPTION:alarm\r\nTRIGGER:NOT-A-DURATION\r\nEND:VALARM")]
+    [InlineData("URL:not a uri")]
+    [InlineData("ATTACH;ENCODING=BASE64;VALUE=BINARY:not-base64!")]
+    [InlineData("ATTENDEE:not a uri")]
+    public void Project_RejectsRegisteredPropertyDroppedByIcalNet(string probe)
+    {
+        var content = $"BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Example//EN\r\nBEGIN:VEVENT\r\nUID:u1\r\nDTSTAMP:20260815T120000Z\r\nDTSTART:20260816T090000Z\r\n{probe}\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n";
+
+        var result = CalendarResourceProjector.Project(Encoding.UTF8.GetBytes(content));
+
+        result.Projection.Kind.ShouldBe(CalendarResourceProjectionKind.Opaque);
+        result.Diagnostics.Select(item => item.Code).ShouldBe(["typed_projection_invalid"]);
+    }
+
+    [Fact]
+    public void Project_RejectsMissingRequiredCalendarProperty()
+    {
+        const string content = "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nBEGIN:VEVENT\r\nUID:u1\r\nDTSTAMP:20260815T120000Z\r\nDTSTART:20260816T090000Z\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n";
+
+        var result = CalendarResourceProjector.Project(Encoding.UTF8.GetBytes(content));
+
+        result.Diagnostics.Select(item => item.Code).ShouldBe(["calendar_required_property_invalid"]);
+    }
+
+    [Fact]
+    public void Project_RejectsEntityWithoutDtstamp()
+    {
+        const string content = "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Example//EN\r\nBEGIN:VEVENT\r\nUID:u1\r\nDTSTART:20260816T090000Z\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n";
+
+        var result = CalendarResourceProjector.Project(Encoding.UTF8.GetBytes(content));
+
+        result.Diagnostics.Select(item => item.Code).ShouldBe(["entity_dtstamp_invalid"]);
+    }
+
+    [Theory]
+    [InlineData("VEVENT", "DTEND:20260816T100000Z")]
+    [InlineData("VTODO", "DUE:20260816T100000Z")]
+    public void Project_RejectsMutuallyExclusiveEndAndDuration(string component, string endProperty)
+    {
+        var content = $"BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Example//EN\r\nBEGIN:{component}\r\nUID:u1\r\nDTSTAMP:20260815T120000Z\r\nDTSTART:20260816T090000Z\r\n{endProperty}\r\nDURATION:PT1H\r\nEND:{component}\r\nEND:VCALENDAR\r\n";
+
+        var result = CalendarResourceProjector.Project(Encoding.UTF8.GetBytes(content));
+
+        result.Diagnostics.Select(item => item.Code).ShouldBe(["entity_temporal_cardinality"]);
+    }
+
+    [Theory]
+    [InlineData("VEVENT", "CREATED:20260815T100000Z")]
+    [InlineData("VEVENT", "LAST-MODIFIED:20260815T110000Z")]
+    [InlineData("VEVENT", "GEO:37.386013;-122.082932")]
+    [InlineData("VEVENT", "ORGANIZER:mailto:organizer@example.test")]
+    [InlineData("VTODO", "PERCENT-COMPLETE:50")]
+    [InlineData("VEVENT", "SEQUENCE:1")]
+    [InlineData("VEVENT", "RRULE:FREQ=DAILY")]
+    public void Project_RejectsRepeatedRegisteredEntitySingletons(string component, string property)
+    {
+        var content = $"BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Example//EN\r\nBEGIN:{component}\r\nUID:u1\r\nDTSTAMP:20260815T120000Z\r\nDTSTART:20260816T090000Z\r\n{property}\r\n{property}\r\nEND:{component}\r\nEND:VCALENDAR\r\n";
+
+        var result = CalendarResourceProjector.Project(Encoding.UTF8.GetBytes(content));
+
+        result.Projection.Kind.ShouldBe(CalendarResourceProjectionKind.Opaque);
+        result.Diagnostics.Select(item => item.Code).ShouldBe(["singleton_property_repeated"]);
+    }
+
+    [Theory]
+    [InlineData("+0000")]
+    [InlineData("-0400")]
+    [InlineData("+053045")]
+    [InlineData("-053045")]
+    public void Project_PreservesValidUtcOffsetsAsUnknownFrozenValues(string offset)
+    {
+        var content = $"BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Example//EN\r\nBEGIN:VTIMEZONE\r\nTZID:Custom\r\nBEGIN:STANDARD\r\nDTSTART:19700101T000000\r\nTZOFFSETFROM:{offset}\r\nTZOFFSETTO:+0000\r\nEND:STANDARD\r\nEND:VTIMEZONE\r\nBEGIN:VEVENT\r\nUID:u1\r\nDTSTAMP:20260815T120000Z\r\nDTSTART;TZID=Custom:20260816T090000\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n";
+
+        var result = CalendarResourceProjector.Project(Encoding.UTF8.GetBytes(content));
+
+        result.Projection.Kind.ShouldBe(CalendarResourceProjectionKind.Event);
+        result.Properties.Single(property => property.Name == "TZOFFSETFROM").ValueType.ShouldBe(CalendarPropertyValueType.Unknown);
+    }
+
+    [Theory]
+    [InlineData("-0000")]
+    [InlineData("-000000")]
+    [InlineData("+2400")]
+    [InlineData("+0061")]
+    [InlineData("+010061")]
+    public void Project_RejectsInvalidUtcOffsets(string offset)
+    {
+        var content = $"BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Example//EN\r\nBEGIN:VTIMEZONE\r\nTZID:Custom\r\nBEGIN:STANDARD\r\nDTSTART:19700101T000000\r\nTZOFFSETFROM:{offset}\r\nTZOFFSETTO:+0000\r\nEND:STANDARD\r\nEND:VTIMEZONE\r\nBEGIN:VEVENT\r\nUID:u1\r\nDTSTAMP:20260815T120000Z\r\nDTSTART;TZID=Custom:20260816T090000\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n";
+
+        var result = CalendarResourceProjector.Project(Encoding.UTF8.GetBytes(content));
+
+        result.Projection.Kind.ShouldBe(CalendarResourceProjectionKind.Opaque);
+        result.Diagnostics.Select(item => item.Code).ShouldBe(["registered_property_value_invalid"]);
+    }
+
+    [Fact]
+    public void Project_RejectsUtcOffsetDeclaredAsFrozenTextValue()
+    {
+        const string content = "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Example//EN\r\nBEGIN:VTIMEZONE\r\nTZID:Custom\r\nBEGIN:STANDARD\r\nDTSTART:19700101T000000\r\nTZOFFSETFROM;VALUE=TEXT:+0100\r\nTZOFFSETTO:+0000\r\nEND:STANDARD\r\nEND:VTIMEZONE\r\nBEGIN:VEVENT\r\nUID:u1\r\nDTSTAMP:20260815T120000Z\r\nDTSTART;TZID=Custom:20260816T090000\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n";
+
+        var result = CalendarResourceProjector.Project(Encoding.UTF8.GetBytes(content));
+
+        result.Projection.Kind.ShouldBe(CalendarResourceProjectionKind.Opaque);
+        result.Diagnostics.Select(item => item.Code).ShouldBe(["registered_property_value_invalid"]);
+    }
+
+    [Fact]
+    public void Project_RejectsSemanticallyDuplicateRecurrenceIdentities()
+    {
+        const string content = "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Example//EN\r\nBEGIN:VTIMEZONE\r\nTZID:America/New_York\r\nEND:VTIMEZONE\r\nBEGIN:VEVENT\r\nUID:u1\r\nDTSTAMP:20260815T120000Z\r\nDTSTART;TZID=America/New_York:20260816T090000\r\nRRULE:FREQ=DAILY;COUNT=3\r\nEND:VEVENT\r\nBEGIN:VEVENT\r\nUID:u1\r\nDTSTAMP:20260815T120000Z\r\nRECURRENCE-ID;TZID=America/New_York:20260817T090000\r\nDTSTART;TZID=America/New_York:20260817T100000\r\nEND:VEVENT\r\nBEGIN:VEVENT\r\nUID:u1\r\nDTSTAMP:20260815T120000Z\r\nRECURRENCE-ID;TZID=\"America/New_York\":20260817T090000\r\nDTSTART;TZID=America/New_York:20260817T110000\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n";
+
+        var result = CalendarResourceProjector.Project(Encoding.UTF8.GetBytes(content));
+
+        result.Projection.Kind.ShouldBe(CalendarResourceProjectionKind.Opaque);
+        result.Diagnostics.Select(item => item.Code).ShouldBe(["recurrence_identity_duplicate"]);
+    }
+
+    [Fact]
+    public void Project_RejectsRecurrenceIdentityWithDifferentTemporalFamily()
+    {
+        const string content = "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Example//EN\r\nBEGIN:VEVENT\r\nUID:u1\r\nDTSTAMP:20260815T120000Z\r\nDTSTART;VALUE=DATE:20260816\r\nRRULE:FREQ=DAILY;COUNT=2\r\nEND:VEVENT\r\nBEGIN:VEVENT\r\nUID:u1\r\nDTSTAMP:20260815T120000Z\r\nRECURRENCE-ID:20260817T090000Z\r\nDTSTART:20260817T100000Z\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n";
+
+        var result = CalendarResourceProjector.Project(Encoding.UTF8.GetBytes(content));
+
+        result.Projection.Kind.ShouldBe(CalendarResourceProjectionKind.Opaque);
+        result.Diagnostics.Select(item => item.Code).ShouldBe(["recurrence_identity_family_mismatch"]);
+    }
+
+    [Fact]
+    public void Project_PreservesLosslessPropertiesWhenTypedParsingFails()
+    {
+        const string content = "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Example//EN\r\nBEGIN:VEVENT\r\nUID:u1\r\nDTSTAMP:20260815T120000Z\r\nDTSTART:20260816T090000Z\r\nRRULE:not-a-rule\r\nX-KEEP:still readable\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n";
+
+        var result = CalendarResourceProjector.Project(Encoding.UTF8.GetBytes(content));
+
+        result.Projection.Kind.ShouldBe(CalendarResourceProjectionKind.Opaque);
+        result.Properties.Single(property => property.Name == "X-KEEP").RawEncodedValue.ShouldBe("still readable");
+        result.Diagnostics.Select(item => item.Code).ShouldBe(["typed_projection_invalid"]);
+    }
+
+    [Fact]
+    public void Project_RejectsAmbiguousTemporalParametersWithoutThrowing()
+    {
+        const string content = "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Example//EN\r\nBEGIN:VEVENT\r\nUID:u1\r\nDTSTAMP:20260815T120000Z\r\nDTSTART;TZID=A;TZID=B:20260816T090000\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n";
+
+        var result = CalendarResourceProjector.Project(Encoding.UTF8.GetBytes(content));
+
+        result.Projection.Kind.ShouldBe(CalendarResourceProjectionKind.Opaque);
+        result.Diagnostics.Select(item => item.Code).ShouldBe(["property_parameter_cardinality"]);
+    }
+}

--- a/tests/DotnetAgents.CalDav.Core.Tests.Unit/Internal/Xml/DavResponseParserTests.cs
+++ b/tests/DotnetAgents.CalDav.Core.Tests.Unit/Internal/Xml/DavResponseParserTests.cs
@@ -8,6 +8,30 @@ namespace DotnetAgents.CalDav.Core.Tests.Unit.Internal.Xml;
 
 public class DavResponseParserTests
 {
+    [Fact]
+    public void ParseCalendars_RejectsDtdAndEntityDeclarations()
+    {
+        const string xml = "<!DOCTYPE multistatus [<!ENTITY xxe SYSTEM 'file:///etc/passwd'>]><multistatus xmlns='DAV:'>&xxe;</multistatus>";
+
+        Should.Throw<System.Xml.XmlException>(() => DavResponseParser.ParseCalendars(xml));
+    }
+
+    [Fact]
+    public void ParseCalendars_RejectsExcessiveElementDepth()
+    {
+        var xml = "<multistatus xmlns='DAV:'>" + string.Concat(Enumerable.Repeat("<x>", 65))
+            + string.Concat(Enumerable.Repeat("</x>", 65)) + "</multistatus>";
+
+        Should.Throw<System.Xml.XmlException>(() => DavResponseParser.ParseCalendars(xml));
+    }
+
+    [Fact]
+    public void ParseCalendars_RejectsExcessiveCharacterCount()
+    {
+        var xml = "<multistatus xmlns='DAV:'><x>" + new string('a', 4 * 1024 * 1024) + "</x></multistatus>";
+
+        Should.Throw<System.Xml.XmlException>(() => DavResponseParser.ParseCalendars(xml));
+    }
     private static readonly XNamespace Dav = "DAV:";
     private static readonly XNamespace CalDav = "urn:ietf:params:xml:ns:caldav";
     private static readonly XNamespace AppleCs = "http://apple.com/ns/ical/";

--- a/tests/DotnetAgents.CalDav.Core.Tests.Unit/Services/CalendarServiceTests.cs
+++ b/tests/DotnetAgents.CalDav.Core.Tests.Unit/Services/CalendarServiceTests.cs
@@ -14,6 +14,113 @@ namespace DotnetAgents.CalDav.Core.Tests.Unit.Services;
 public sealed class CalendarServiceTests
 {
     [Fact]
+    public async Task GetResourceAsync_ReturnsOneRevisionCoherentEventSnapshot()
+    {
+        const string calendarHref = "https://cal.example/events/";
+        const string resourceHref = "https://cal.example/events/standup.ics";
+        const string content = "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Example//EN\r\nBEGIN:VEVENT\r\nUID:event-1\r\nDTSTAMP:20260815T120000Z\r\nDTSTART:20260816T090000Z\r\nSUMMARY:Standup\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n";
+        var client = Substitute.For<ICalendarClient>();
+        var options = Options.Create(new CalDavOptions
+        {
+            BaseUrl = "https://cal.example",
+            CalendarHrefs = calendarHref
+        });
+        var sut = new CalendarService(client, options, Substitute.For<ILogger<CalendarService>>());
+        client.GetCalendarsAsync(Arg.Any<CancellationToken>()).Returns(
+            [Calendar(calendarHref, "Events", EntityKindSupport.NotAdvertised)]);
+        client.GetCalendarResourceAsync(resourceHref, Arg.Any<CancellationToken>()).Returns(
+            CalendarResourceRead.Success(resourceHref, "\"revision-1\"", System.Text.Encoding.UTF8.GetBytes(content)));
+
+        var result = await sut.GetResourceAsync(resourceHref, CancellationToken.None);
+
+        result.Code.ShouldBe(CalendarResourceReadCode.Success);
+        result.Snapshot!.CalendarHref.ShouldBe(calendarHref);
+        result.Snapshot.ResourceHref.ShouldBe(resourceHref);
+        result.Snapshot.EntityTag.ShouldBe("\"revision-1\"");
+        result.Snapshot.AuthoritativeUtf8.ToArray().ShouldBe(System.Text.Encoding.UTF8.GetBytes(content));
+        result.Snapshot.Projection.Kind.ShouldBe(CalendarResourceProjectionKind.Event);
+        result.Snapshot.Projection.EntityUid.ShouldBe("event-1");
+        result.Snapshot.Projection.Summary.ShouldBe("Standup");
+    }
+
+    [Fact]
+    public async Task GetResourceAsync_ReturnsMixedEntityKindsAsOpaqueWithSafeDiagnostic()
+    {
+        const string calendarHref = "https://cal.example/mixed/";
+        const string resourceHref = "https://cal.example/mixed/mixed.ics";
+        const string content = "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Example//EN\r\nBEGIN:VEVENT\r\nUID:event-1\r\nDTSTAMP:20260815T120000Z\r\nDTSTART:20260816T090000Z\r\nEND:VEVENT\r\nBEGIN:VTODO\r\nUID:todo-1\r\nDTSTAMP:20260815T120000Z\r\nEND:VTODO\r\nEND:VCALENDAR\r\n";
+        var client = Substitute.For<ICalendarClient>();
+        var options = Options.Create(new CalDavOptions { BaseUrl = "https://cal.example", CalendarHrefs = calendarHref });
+        var sut = new CalendarService(client, options, Substitute.For<ILogger<CalendarService>>());
+        client.GetCalendarsAsync(Arg.Any<CancellationToken>()).Returns(
+            [Calendar(calendarHref, "Mixed", EntityKindSupport.Advertised)]);
+        client.GetCalendarResourceAsync(resourceHref, Arg.Any<CancellationToken>()).Returns(
+            CalendarResourceRead.Success(resourceHref, "\"revision-1\"", System.Text.Encoding.UTF8.GetBytes(content)));
+
+        var result = await sut.GetResourceAsync(resourceHref, CancellationToken.None);
+
+        result.Code.ShouldBe(CalendarResourceReadCode.Success);
+        result.Snapshot!.Projection.Kind.ShouldBe(CalendarResourceProjectionKind.Opaque);
+        result.Snapshot.Projection.EntityUid.ShouldBeNull();
+        result.Snapshot.SemanticMutationAvailable.ShouldBeFalse();
+        result.Snapshot.Diagnostics.Select(item => item.Code).ShouldBe(["mixed_entity_kinds"]);
+        JsonSerializer.Serialize(result.Snapshot.Diagnostics).ShouldNotContain("event-1");
+        JsonSerializer.Serialize(result.Snapshot.Diagnostics).ShouldNotContain("todo-1");
+    }
+
+    [Fact]
+    public async Task GetResourceAsync_TreatsContentUrisAsInertData()
+    {
+        const string calendarHref = "https://cal.example/events/";
+        const string resourceHref = "https://cal.example/events/inert.ics";
+        const string content = "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Example//EN\r\nBEGIN:VEVENT\r\nUID:event-1\r\nDTSTAMP:20260815T120000Z\r\nDTSTART:20260816T090000Z\r\nURL:https://attacker.invalid/url\r\nATTACH;VALUE=URI:https://attacker.invalid/attachment\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n";
+        var client = Substitute.For<ICalendarClient>();
+        var sut = new CalendarService(
+            client,
+            Options.Create(new CalDavOptions { BaseUrl = "https://cal.example", CalendarHrefs = calendarHref }),
+            Substitute.For<ILogger<CalendarService>>());
+        client.GetCalendarsAsync(Arg.Any<CancellationToken>()).Returns(
+            [Calendar(calendarHref, "Events", EntityKindSupport.NotAdvertised)]);
+        client.GetCalendarResourceAsync(resourceHref, Arg.Any<CancellationToken>()).Returns(
+            CalendarResourceRead.Success(resourceHref, "\"revision-1\"", System.Text.Encoding.UTF8.GetBytes(content)));
+
+        var result = await sut.GetResourceAsync(resourceHref, CancellationToken.None);
+
+        result.Code.ShouldBe(CalendarResourceReadCode.Success);
+        result.Snapshot!.CalendarProperties.Single(property => property.Name == "ATTACH").RawEncodedValue
+            .ShouldBe("https://attacker.invalid/attachment");
+        await client.Received(1).GetCalendarsAsync(Arg.Any<CancellationToken>());
+        await client.Received(1).GetCalendarResourceAsync(resourceHref, Arg.Any<CancellationToken>());
+    }
+
+    [Theory]
+    [InlineData("https://other.example/events/a.ics", CalendarResourceReadCode.InvalidInput)]
+    [InlineData("https://user:secret@cal.example/events/a.ics", CalendarResourceReadCode.InvalidInput)]
+    [InlineData("https://cal.example/events/a.ics#fragment", CalendarResourceReadCode.InvalidInput)]
+    [InlineData("/events/a.ics", CalendarResourceReadCode.InvalidInput)]
+    [InlineData("https://cal.example/events%2Fprivate/a.ics", CalendarResourceReadCode.InvalidInput)]
+    [InlineData("https://cal.example/events%5cprivate/a.ics", CalendarResourceReadCode.InvalidInput)]
+    [InlineData("https://cal.example/private/a.ics", CalendarResourceReadCode.OutsideScope)]
+    public async Task GetResourceAsync_RejectsInvalidOrOutOfScopeHrefBeforeNetwork(
+        string href,
+        CalendarResourceReadCode expectedCode)
+    {
+        var client = Substitute.For<ICalendarClient>();
+        var options = Options.Create(new CalDavOptions
+        {
+            BaseUrl = "https://cal.example",
+            CalendarHrefs = "https://cal.example/events/"
+        });
+        var sut = new CalendarService(client, options, Substitute.For<ILogger<CalendarService>>());
+
+        var result = await sut.GetResourceAsync(href, CancellationToken.None);
+
+        result.Code.ShouldBe(expectedCode);
+        await client.DidNotReceive().GetCalendarsAsync(Arg.Any<CancellationToken>());
+        await client.DidNotReceive().GetCalendarResourceAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public async Task ResolveDefaultCalendarAsync_UsesIndependentEventAndTodoDefaults()
     {
         var client = Substitute.For<ICalendarClient>();

--- a/tests/DotnetAgents.CalDav.IntegrationTests/CalendarMcpStdioIntegrationTests.cs
+++ b/tests/DotnetAgents.CalDav.IntegrationTests/CalendarMcpStdioIntegrationTests.cs
@@ -1,4 +1,6 @@
 using System.Collections.Concurrent;
+using System.Net.Http.Headers;
+using System.Text;
 using DotnetAgents.CalDav.IntegrationTests.Fixtures;
 using ModelContextProtocol.Client;
 using ModelContextProtocol.Protocol;
@@ -47,6 +49,7 @@ public sealed class CalendarMcpStdioIntegrationTests
         listedTools.Tools.Select(tool => tool.Name).ShouldBe(
         [
             "calendars.list",
+            "calendar_resources.get",
             "list_task_lists",
             "show_tasks",
             "add_task",
@@ -54,6 +57,7 @@ public sealed class CalendarMcpStdioIntegrationTests
             "complete_task_by_summary",
             "delete_task_by_summary"
         ]);
+        listedTools.Tools.ShouldNotContain(tool => tool.Name == "calendar_resources.exact_get");
         calendarTool.InputSchema.GetProperty("type").GetString().ShouldBe("object");
         calendarTool.InputSchema.GetProperty("additionalProperties").GetBoolean().ShouldBeFalse();
         calendarTool.OutputSchema!.Value.GetProperty("oneOf").GetArrayLength().ShouldBe(2);
@@ -67,6 +71,122 @@ public sealed class CalendarMcpStdioIntegrationTests
         structured.GetProperty("items")[0].GetProperty("calendar").GetProperty("href").GetString()
             .ShouldBe($"{_fixture.BaseUrl}{_fixture.TaskListHref}");
         stderr.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task CalendarResourceGet_ReturnsTheSameStrongRevisionAndExactUtf8Payload()
+    {
+        const string content = "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Integration//EN\r\nBEGIN:VTODO\r\nUID:resource-read-1\r\nDTSTAMP:20260815T120000Z\r\nSUMMARY:Lossless integration\r\nX-UNKNOWN;X-P=one,two:kept\r\nEND:VTODO\r\nEND:VCALENDAR\r\n";
+        var href = await PutResourceAsync("resource-read-1.ics", content);
+        var observed = await GetResourceAsync(href);
+        var stderr = new ConcurrentQueue<string>();
+        await using var client = await CreateClientAsync(stderr, exposeExact: false);
+
+        var result = await client.CallToolAsync(
+            "calendar_resources.get",
+            new Dictionary<string, object?> { ["href"] = href },
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        var snapshot = result.StructuredContent!.Value.GetProperty("snapshot");
+        snapshot.GetProperty("resourceRevision").GetProperty("href").GetString().ShouldBe(href);
+        snapshot.GetProperty("resourceRevision").GetProperty("entityTag").GetString().ShouldBe(observed.EntityTag);
+        Convert.FromBase64String(snapshot.GetProperty("authoritativePayload").GetProperty("base64Utf8").GetString()!)
+            .ShouldBe(observed.Utf8);
+        snapshot.GetProperty("projection").GetProperty("kind").GetString().ShouldBe("todo");
+        result.Content.OfType<TextContentBlock>().Single().Text.ShouldNotContain("BEGIN:VCALENDAR");
+        stderr.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task ExactGet_UsesProtectedNativeResourceReadWhileListRemainsEmpty()
+    {
+        const string content = "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Integration//EN\r\nBEGIN:VTODO\r\nUID:exact-read-1\r\nDTSTAMP:20260815T120000Z\r\nSUMMARY:Exact integration\r\nEND:VTODO\r\nEND:VCALENDAR\r\n";
+        var href = await PutResourceAsync("exact-read-1.ics", content);
+        var observed = await GetResourceAsync(href);
+        var stderr = new ConcurrentQueue<string>();
+        await using var client = await CreateClientAsync(stderr, exposeExact: true);
+
+        var tools = await client.ListToolsAsync(new ListToolsRequestParams(), TestContext.Current.CancellationToken);
+        var listed = await client.ListResourcesAsync(new ListResourcesRequestParams(), TestContext.Current.CancellationToken);
+        var toolResult = await client.CallToolAsync(
+            "calendar_resources.exact_get",
+            new Dictionary<string, object?> { ["href"] = href },
+            cancellationToken: TestContext.Current.CancellationToken);
+        var link = toolResult.Content.OfType<ResourceLinkBlock>().Single();
+        var read = await client.ReadResourceAsync(link.Uri, cancellationToken: TestContext.Current.CancellationToken);
+
+        tools.Tools.Select(tool => tool.Name).ShouldBe(
+        [
+            "calendars.list",
+            "calendar_resources.get",
+            "calendar_resources.exact_get",
+            "list_task_lists",
+            "show_tasks",
+            "add_task",
+            "find_tasks",
+            "complete_task_by_summary",
+            "delete_task_by_summary"
+        ]);
+        listed.Resources.ShouldBeEmpty();
+        read.Contents.ShouldHaveSingleItem().ShouldBeOfType<TextResourceContents>().Text
+            .ShouldBe(Encoding.UTF8.GetString(observed.Utf8));
+
+        await PutResourceAsync("exact-read-1.ics", content.Replace("Exact integration", "Changed revision", StringComparison.Ordinal));
+        await Should.ThrowAsync<ModelContextProtocol.McpException>(() =>
+            client.ReadResourceAsync(link.Uri, cancellationToken: TestContext.Current.CancellationToken).AsTask());
+        stderr.ShouldBeEmpty();
+    }
+
+    private async Task<McpClient> CreateClientAsync(ConcurrentQueue<string> stderr, bool exposeExact)
+    {
+        var environment = CreateEnvironment();
+        environment["CALDAV_EXPOSE_EXACT_TOOLS"] = exposeExact ? "true" : "false";
+        var transport = new StdioClientTransport(new StdioClientTransportOptions
+        {
+            Command = "dotnet",
+            Arguments = [GetServerAssemblyPath()],
+            WorkingDirectory = AppContext.BaseDirectory,
+            InheritEnvironmentVariables = true,
+            EnvironmentVariables = environment,
+            StandardErrorLines = stderr.Enqueue
+        });
+        return await McpClient.CreateAsync(
+            transport,
+            new McpClientOptions { ProtocolVersion = "2026-07-28", DiscoverProbeTimeout = TimeSpan.FromSeconds(10) },
+            cancellationToken: TestContext.Current.CancellationToken);
+    }
+
+    private async Task<string> PutResourceAsync(string name, string content)
+    {
+        using var client = CreateAuthenticatedClient();
+        var href = $"{_fixture.TaskListHref}{name}";
+        using var response = await client.PutAsync(
+            href,
+            new StringContent(content, Encoding.UTF8, "text/calendar"),
+            TestContext.Current.CancellationToken);
+        response.EnsureSuccessStatusCode();
+        return $"{_fixture.BaseUrl}{href}";
+    }
+
+    private async Task<ObservedResource> GetResourceAsync(string href)
+    {
+        using var client = CreateAuthenticatedClient();
+        using var response = await client.GetAsync(href, TestContext.Current.CancellationToken);
+        response.EnsureSuccessStatusCode();
+        response.Headers.ETag.ShouldNotBeNull();
+        response.Headers.ETag!.IsWeak.ShouldBeFalse();
+        return new ObservedResource(
+            response.Headers.ETag.ToString(),
+            await response.Content.ReadAsByteArrayAsync(TestContext.Current.CancellationToken));
+    }
+
+    private HttpClient CreateAuthenticatedClient()
+    {
+        var client = new HttpClient { BaseAddress = new Uri(_fixture.BaseUrl) };
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(
+            "Basic",
+            Convert.ToBase64String(Encoding.UTF8.GetBytes("caldavtest:caldavtest123")));
+        return client;
     }
 
     private Dictionary<string, string?> CreateEnvironment() => new()
@@ -91,4 +211,6 @@ public sealed class CalendarMcpStdioIntegrationTests
 
         throw new FileNotFoundException("Could not locate the built MCP server assembly.");
     }
+
+    private sealed record ObservedResource(string EntityTag, byte[] Utf8);
 }

--- a/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/CalDavHostBuilderTests.cs
+++ b/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/CalDavHostBuilderTests.cs
@@ -195,10 +195,29 @@ public class CalDavHostBuilderTests
         registeredToolTypes.ShouldBe(
         [
             typeof(DotnetAgents.CalDav.Mcp.Tools.CalendarTools),
+            typeof(DotnetAgents.CalDav.Mcp.Tools.CalendarResourceTools),
             typeof(DotnetAgents.CalDav.Mcp.Tools.TaskListTools),
             typeof(DotnetAgents.CalDav.Mcp.Tools.ChatTaskTools)
         ]);
 
+    }
+
+    [Fact]
+    public void BuildHost_AdvertisesFrozenResourceOutcomeSchemaAndPrivateNoCacheHint()
+    {
+        var builder = CalDavHostBuilder.CreateBuilder();
+        builder.Services.ConfigureCalDav(ValidOptions);
+        using var host = builder.Build();
+
+        var options = host.Services.GetRequiredService<IOptions<ModelContextProtocol.Server.McpServerOptions>>().Value;
+        options.ToolCollection!.TryGetPrimitive("calendar_resources.get", out var tool).ShouldBeTrue();
+        var outputSchema = JsonNode.Parse(tool!.ProtocolTool.OutputSchema!.Value.GetRawText())!.AsObject();
+
+        outputSchema["oneOf"]!.AsArray().Count.ShouldBe(2);
+        outputSchema["$defs"]!.AsObject().ShouldContainKey("resourceSuccess");
+        outputSchema["$defs"]!.AsObject().ShouldContainKey("errorOutcome");
+        tool.ProtocolTool.Meta!["cache"]!["ttlMs"]!.GetValue<int>().ShouldBe(0);
+        tool.ProtocolTool.Meta!["cache"]!["cacheScope"]!.GetValue<string>().ShouldBe("private");
     }
 
     [Fact]
@@ -238,6 +257,7 @@ public class CalDavHostBuilderTests
         tools.ShouldBe(
         [
             "calendars.list",
+            "calendar_resources.get",
             "list_task_lists",
             "show_tasks",
             "add_task",
@@ -274,6 +294,7 @@ public class CalDavHostBuilderTests
         tools.ShouldBe(
         [
             "calendars.list",
+            "calendar_resources.get",
             "list_task_lists",
             "show_tasks",
             "add_task",
@@ -287,6 +308,40 @@ public class CalDavHostBuilderTests
             "list_tasks",
             "update_task"
         ]);
+    }
+
+    [Fact]
+    public void CreateBuilder_ExactMode_RegistersExactToolIndependently()
+    {
+        var defaultBuilder = CalDavHostBuilder.CreateBuilder();
+        var exactBuilder = CalDavHostBuilder.CreateBuilder(exposeExactTools: true);
+
+        GetRegisteredMcpToolTypes(defaultBuilder.Services)
+            .ShouldNotContain(typeof(DotnetAgents.CalDav.Mcp.Tools.ExactCalendarResourceTools));
+        GetRegisteredMcpToolTypes(exactBuilder.Services)
+            .ShouldContain(typeof(DotnetAgents.CalDav.Mcp.Tools.ExactCalendarResourceTools));
+    }
+
+    [Fact]
+    public void BuildHost_ExactMode_AdvertisesFrozenClosedContractAndPrivateNoCacheHint()
+    {
+        var builder = CalDavHostBuilder.CreateBuilder(exposeExactTools: true);
+        builder.Services.ConfigureCalDav(ValidOptions);
+        using var host = builder.Build();
+        var options = host.Services.GetRequiredService<IOptions<ModelContextProtocol.Server.McpServerOptions>>().Value;
+        options.ToolCollection!.TryGetPrimitive("calendar_resources.exact_get", out var tool).ShouldBeTrue();
+
+        var inputSchema = JsonNode.Parse(tool!.ProtocolTool.InputSchema.GetRawText())!.AsObject();
+        var outputSchema = JsonNode.Parse(tool.ProtocolTool.OutputSchema!.Value.GetRawText())!.AsObject();
+        inputSchema["additionalProperties"]!.GetValue<bool>().ShouldBeFalse();
+        inputSchema["required"]!.AsArray().Select(item => item!.GetValue<string>()).ShouldBe(["href"]);
+        outputSchema["oneOf"]!.AsArray().Count.ShouldBe(2);
+        outputSchema["$defs"]!.AsObject().ShouldContainKey("exactGetSuccess");
+        outputSchema["$defs"]!.AsObject().ShouldContainKey("errorOutcome");
+        tool.ProtocolTool.Meta!["cache"]!["ttlMs"]!.GetValue<int>().ShouldBe(0);
+        tool.ProtocolTool.Meta!["cache"]!["cacheScope"]!.GetValue<string>().ShouldBe("private");
+        tool.ProtocolTool.Annotations!.ReadOnlyHint.ShouldBe(true);
+        tool.ProtocolTool.Annotations.OpenWorldHint.ShouldBe(true);
     }
 
     private static IReadOnlyList<Type> GetRegisteredMcpToolTypes(IServiceCollection services)

--- a/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/CalDavMcpRunnerTests.cs
+++ b/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/CalDavMcpRunnerTests.cs
@@ -19,6 +19,16 @@ public class CalDavMcpRunnerTests
         result.ShouldBeTrue();
     }
 
+    [Theory]
+    [InlineData("true", true)]
+    [InlineData("TRUE", true)]
+    [InlineData("false", false)]
+    [InlineData(null, false)]
+    public void ShouldExposeExactTools_UsesIndependentOptIn(string? envValue, bool expected)
+    {
+        CalDavMcpRunner.ShouldExposeExactTools(_ => envValue).ShouldBe(expected);
+    }
+
     [Fact]
     public async Task RunAsync_WithAllConfigMissing_ReturnsExitCode1()
     {

--- a/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/CalendarResourceToolsTests.cs
+++ b/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/CalendarResourceToolsTests.cs
@@ -1,0 +1,271 @@
+using System.Text;
+using System.Xml;
+using DotnetAgents.CalDav.Core.Abstractions;
+using DotnetAgents.CalDav.Core.Models;
+using DotnetAgents.CalDav.Mcp.Tools;
+using ModelContextProtocol.Protocol;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace DotnetAgents.CalDav.Mcp.Tests.Unit;
+
+public sealed class CalendarResourceToolsTests
+{
+    [Fact]
+    public async Task GetAsync_ReturnsFrozenSnapshotShapeWithoutLeakingContentToText()
+    {
+        const string calendarHref = "https://cal.example/events/";
+        const string resourceHref = "https://cal.example/events/a.ics";
+        const string content = "BEGIN:VCALENDAR\r\nBEGIN:VEVENT\r\nUID:u1\r\nSUMMARY:Secret summary\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n";
+        var bytes = Encoding.UTF8.GetBytes(content);
+        var service = Substitute.For<ICalendarService>();
+        service.GetResourceAsync(resourceHref, Arg.Any<CancellationToken>()).Returns(
+            CalendarResourceRead.Success(resourceHref, "\"r1\"", bytes) with
+            {
+                Snapshot = new CalendarResourceSnapshot(
+                    calendarHref,
+                    resourceHref,
+                    "\"r1\"",
+                    bytes,
+                    [],
+                    new CalendarResourceProjection(CalendarResourceProjectionKind.Event, "u1", "Secret summary"),
+                    [])
+            });
+        var sut = new CalendarResourceTools(service);
+
+        var result = await sut.GetAsync(resourceHref, CancellationToken.None);
+
+        result.IsError.ShouldBe(false);
+        var structured = result.StructuredContent!.Value;
+        structured.GetProperty("snapshot").GetProperty("resourceRevision").GetProperty("entityTag").GetString().ShouldBe("\"r1\"");
+        structured.GetProperty("snapshot").GetProperty("authoritativePayload").GetProperty("base64Utf8").GetString()
+            .ShouldBe(Convert.ToBase64String(bytes));
+        structured.GetProperty("snapshot").GetProperty("projection").GetProperty("kind").GetString().ShouldBe("event");
+        structured.GetProperty("snapshot").GetProperty("entityRevision").GetProperty("entityUid").GetString().ShouldBe("u1");
+        result.Content.ShouldHaveSingleItem();
+        result.Content[0].ShouldBeOfType<TextContentBlock>().Text.ShouldNotContain("Secret summary");
+        result.Content[0].ShouldBeOfType<TextContentBlock>().Text.ShouldNotContain(Convert.ToBase64String(bytes));
+    }
+
+    [Fact]
+    public async Task GetAsync_MapsTodoPropertiesAndEveryResourceDiagnosticSeverity()
+    {
+        const string resourceHref = "https://cal.example/tasks/a.ics";
+        var bytes = Encoding.UTF8.GetBytes("BEGIN:VCALENDAR\r\nEND:VCALENDAR\r\n");
+        var properties = new[]
+        {
+            new CalendarProperty(
+                [new CalendarComponentPathSegment("VCALENDAR", 0), new CalendarComponentPathSegment("VTODO", 0)],
+                "DTSTAMP",
+                [],
+                CalendarPropertyValueType.DateTime,
+                "20260815T120000Z",
+                "DTSTAMP:20260815T120000Z\r\n")
+        };
+        var diagnostics = new[]
+        {
+            new CalendarResourceDiagnostic("info", "safe", CalendarResourceDiagnosticSeverity.Info),
+            new CalendarResourceDiagnostic("warning", "safe", CalendarResourceDiagnosticSeverity.Warning),
+            new CalendarResourceDiagnostic("error", "safe", CalendarResourceDiagnosticSeverity.Error)
+        };
+        var snapshot = new CalendarResourceSnapshot(
+            "https://cal.example/tasks/",
+            resourceHref,
+            "\"r1\"",
+            bytes,
+            properties,
+            new CalendarResourceProjection(CalendarResourceProjectionKind.Todo, "u1", null),
+            diagnostics);
+        var service = Substitute.For<ICalendarService>();
+        service.GetResourceAsync(resourceHref, Arg.Any<CancellationToken>()).Returns(
+            CalendarResourceRead.Success(resourceHref, snapshot.EntityTag, bytes) with { Snapshot = snapshot });
+        var sut = new CalendarResourceTools(service);
+
+        var result = await sut.GetAsync(resourceHref, CancellationToken.None);
+
+        var serializedSnapshot = result.StructuredContent!.Value.GetProperty("snapshot");
+        serializedSnapshot.GetProperty("projection").GetProperty("kind").GetString().ShouldBe("todo");
+        serializedSnapshot.GetProperty("entityRevision").GetProperty("entityKind").GetString().ShouldBe("todo");
+        serializedSnapshot.GetProperty("calendarProperties")[0].GetProperty("valueType").GetString().ShouldBe("date-time");
+        serializedSnapshot.GetProperty("diagnostics").EnumerateArray().Select(item => item.GetProperty("severity").GetString())
+            .ShouldBe(["info", "warning", "error"]);
+    }
+
+    [Fact]
+    public async Task GetAsync_MapsUpstreamCancellationToRetryableUnavailable()
+    {
+        var service = Substitute.For<ICalendarService>();
+        service.GetResourceAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns<Task<CalendarResourceRead>>(_ => throw new OperationCanceledException());
+        var sut = new CalendarResourceTools(service);
+
+        var result = await sut.GetAsync("https://cal.example/events/a.ics", CancellationToken.None);
+
+        result.IsError.ShouldBe(true);
+        result.StructuredContent!.Value.GetProperty("code").GetString().ShouldBe("upstream_unavailable");
+        result.StructuredContent.Value.GetProperty("retryable").GetBoolean().ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task GetAsync_RejectsStructuredSnapshotLargerThanFourMiB()
+    {
+        var payload = new byte[3 * 1024 * 1024];
+        var service = Substitute.For<ICalendarService>();
+        service.GetResourceAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(
+            CalendarResourceRead.Success("https://cal.example/events/a.ics", "\"r1\"", payload) with
+            {
+                Snapshot = new CalendarResourceSnapshot(
+                    "https://cal.example/events/",
+                    "https://cal.example/events/a.ics",
+                    "\"r1\"",
+                    payload,
+                    [],
+                    new CalendarResourceProjection(CalendarResourceProjectionKind.Opaque, null, null),
+                    [])
+            });
+        var sut = new CalendarResourceTools(service);
+
+        var result = await sut.GetAsync("https://cal.example/events/a.ics", CancellationToken.None);
+
+        result.IsError.ShouldBe(true);
+        result.StructuredContent!.Value.GetProperty("code").GetString().ShouldBe("payload_too_large");
+        result.StructuredContent.Value.GetProperty("limits").GetProperty("byteCount").GetInt32().ShouldBeGreaterThan(4 * 1024 * 1024);
+    }
+
+    [Fact]
+    public async Task GetAsync_ReportsObservedTransportOverflowWithoutPartialSnapshot()
+    {
+        var service = Substitute.For<ICalendarService>();
+        service.GetResourceAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(
+            new CalendarResourceRead(CalendarResourceReadCode.PayloadTooLarge, ObservedByteCount: (4 * 1024 * 1024) + 1));
+        var sut = new CalendarResourceTools(service);
+
+        var result = await sut.GetAsync("https://cal.example/events/a.ics", CancellationToken.None);
+
+        result.IsError.ShouldBe(true);
+        result.StructuredContent!.Value.GetProperty("code").GetString().ShouldBe("payload_too_large");
+        result.StructuredContent.Value.GetProperty("limits").GetProperty("byteCount").GetInt32().ShouldBe((4 * 1024 * 1024) + 1);
+        result.StructuredContent.Value.TryGetProperty("snapshot", out _).ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task GetAsync_MapsDiscoveryXmlFailureToSafeProtocolError()
+    {
+        var service = Substitute.For<ICalendarService>();
+        service.GetResourceAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns<Task<CalendarResourceRead>>(_ => throw new XmlException("unsafe upstream text"));
+        var sut = new CalendarResourceTools(service);
+
+        var result = await sut.GetAsync("https://cal.example/events/a.ics", CancellationToken.None);
+
+        result.StructuredContent!.Value.GetProperty("code").GetString().ShouldBe("upstream_protocol_error");
+        result.StructuredContent.Value.GetProperty("retryable").GetBoolean().ShouldBeFalse();
+        result.StructuredContent.Value.GetProperty("phase").GetString().ShouldBe("selectionDiscoveryCapability");
+        result.Content.OfType<TextContentBlock>().Single().Text.ShouldNotContain("unsafe upstream text");
+    }
+
+    [Fact]
+    public async Task GetAsync_MapsDiscoveryLimitWithoutSnapshot()
+    {
+        var service = Substitute.For<ICalendarService>();
+        service.GetResourceAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns<Task<CalendarResourceRead>>(_ => throw new CalendarDiscoveryLimitException(257));
+        var sut = new CalendarResourceTools(service);
+
+        var result = await sut.GetAsync("https://cal.example/events/a.ics", CancellationToken.None);
+
+        result.StructuredContent!.Value.GetProperty("code").GetString().ShouldBe("limit_exhausted");
+        result.StructuredContent.Value.GetProperty("limits").GetProperty("calendarCount").GetInt32().ShouldBe(257);
+        result.StructuredContent.Value.TryGetProperty("snapshot", out _).ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task GetAsync_MapsDiscoveryProtocolFailureToSafeProtocolError()
+    {
+        var service = Substitute.For<ICalendarService>();
+        service.GetResourceAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns<Task<CalendarResourceRead>>(_ => throw new CalendarDiscoveryProtocolException("unsafe href"));
+        var sut = new CalendarResourceTools(service);
+
+        var result = await sut.GetAsync("https://cal.example/events/a.ics", CancellationToken.None);
+
+        result.StructuredContent!.Value.GetProperty("code").GetString().ShouldBe("upstream_protocol_error");
+        result.StructuredContent.Value.GetProperty("phase").GetString().ShouldBe("selectionDiscoveryCapability");
+        result.Content.OfType<TextContentBlock>().Single().Text.ShouldNotContain("unsafe href");
+    }
+
+    [Fact]
+    public async Task GetAsync_MapsExceptionalDiscoveryNotFoundToProtocolError()
+    {
+        var service = Substitute.For<ICalendarService>();
+        service.GetResourceAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromException<CalendarResourceRead>(new HttpRequestException("discovery", null, System.Net.HttpStatusCode.NotFound)));
+        var sut = new CalendarResourceTools(service);
+
+        var result = await sut.GetAsync("https://cal.example/events/a.ics", CancellationToken.None);
+
+        result.StructuredContent!.Value.GetProperty("code").GetString().ShouldBe("upstream_protocol_error");
+        result.StructuredContent.Value.GetProperty("phase").GetString().ShouldBe("selectionDiscoveryCapability");
+    }
+
+    [Theory]
+    [InlineData(CalendarResourceReadCode.InvalidInput, "invalid_input")]
+    [InlineData(CalendarResourceReadCode.OutsideScope, "outside_scope")]
+    [InlineData(CalendarResourceReadCode.NotFound, "not_found")]
+    [InlineData(CalendarResourceReadCode.ConcurrencyUnavailable, "concurrency_unavailable")]
+    [InlineData(CalendarResourceReadCode.PayloadTooLarge, "payload_too_large")]
+    [InlineData(CalendarResourceReadCode.UpstreamProtocolError, "upstream_protocol_error")]
+    public async Task GetAsync_MapsEveryTypedReadFailure(CalendarResourceReadCode readCode, string expectedCode)
+    {
+        var service = Substitute.For<ICalendarService>();
+        service.GetResourceAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(new CalendarResourceRead(readCode));
+        var sut = new CalendarResourceTools(service);
+
+        var result = await sut.GetAsync("https://cal.example/events/a.ics", CancellationToken.None);
+
+        result.IsError.ShouldBe(true);
+        result.StructuredContent!.Value.GetProperty("code").GetString().ShouldBe(expectedCode);
+    }
+
+    [Theory]
+    [InlineData(System.Net.HttpStatusCode.Unauthorized, "upstream_unauthorized", false)]
+    [InlineData(System.Net.HttpStatusCode.Forbidden, "upstream_forbidden", false)]
+    [InlineData(System.Net.HttpStatusCode.RequestEntityTooLarge, "payload_too_large", false)]
+    [InlineData(System.Net.HttpStatusCode.TooManyRequests, "upstream_rate_limited", true)]
+    [InlineData(System.Net.HttpStatusCode.MethodNotAllowed, "unsupported_capability", false)]
+    [InlineData(System.Net.HttpStatusCode.NotImplemented, "unsupported_capability", false)]
+    [InlineData(System.Net.HttpStatusCode.InsufficientStorage, "upstream_unavailable", false)]
+    [InlineData(System.Net.HttpStatusCode.InternalServerError, "upstream_unavailable", true)]
+    [InlineData(System.Net.HttpStatusCode.BadRequest, "upstream_protocol_error", false)]
+    public async Task GetAsync_MapsEveryRelevantHttpFailure(
+        System.Net.HttpStatusCode statusCode,
+        string expectedCode,
+        bool retryable)
+    {
+        var service = Substitute.For<ICalendarService>();
+        service.GetResourceAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(
+            Task.FromException<CalendarResourceRead>(new HttpRequestException("unsafe upstream", null, statusCode)));
+        var sut = new CalendarResourceTools(service);
+
+        var result = await sut.GetAsync("https://cal.example/events/a.ics", CancellationToken.None);
+
+        result.StructuredContent!.Value.GetProperty("code").GetString().ShouldBe(expectedCode);
+        result.StructuredContent.Value.GetProperty("retryable").GetBoolean().ShouldBe(retryable);
+        result.Content.OfType<TextContentBlock>().Single().Text.ShouldNotContain("unsafe upstream");
+    }
+
+    [Fact]
+    public async Task GetAsync_MapsTimeoutToRetryableUnavailable()
+    {
+        var service = Substitute.For<ICalendarService>();
+        service.GetResourceAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns<Task<CalendarResourceRead>>(_ => throw new TimeoutException());
+        var sut = new CalendarResourceTools(service);
+
+        var result = await sut.GetAsync("https://cal.example/events/a.ics", CancellationToken.None);
+
+        result.StructuredContent!.Value.GetProperty("code").GetString().ShouldBe("upstream_unavailable");
+        result.StructuredContent.Value.GetProperty("retryable").GetBoolean().ShouldBeTrue();
+    }
+}

--- a/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/ExactCalendarResourceTests.cs
+++ b/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/ExactCalendarResourceTests.cs
@@ -1,0 +1,166 @@
+using System.Text;
+using DotnetAgents.CalDav.Core.Abstractions;
+using DotnetAgents.CalDav.Core.Models;
+using DotnetAgents.CalDav.Mcp.Hosting;
+using DotnetAgents.CalDav.Mcp.Tools;
+using ModelContextProtocol.Protocol;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace DotnetAgents.CalDav.Mcp.Tests.Unit;
+
+public sealed class ExactCalendarResourceTests
+{
+    [Fact]
+    public async Task ExactGetAsync_ReturnsNativeResourceLinkWithoutRawContent()
+    {
+        var snapshot = CreateSnapshot("\"r1\"");
+        var service = Substitute.For<ICalendarService>();
+        service.GetResourceAsync(snapshot.ResourceHref, Arg.Any<CancellationToken>()).Returns(
+            CalendarResourceRead.Success(snapshot.ResourceHref, snapshot.EntityTag, snapshot.AuthoritativeUtf8) with { Snapshot = snapshot });
+        var sut = new ExactCalendarResourceTools(service);
+
+        var result = await sut.GetAsync(snapshot.ResourceHref, CancellationToken.None);
+
+        result.IsError.ShouldBe(false);
+        result.Content.OfType<ResourceLinkBlock>().ShouldHaveSingleItem();
+        result.Content.OfType<TextContentBlock>().Single().Text.ShouldNotContain("BEGIN:VCALENDAR");
+        result.StructuredContent!.Value.GetProperty("resourceLink").GetProperty("type").GetString().ShouldBe("resource_link");
+    }
+
+    [Fact]
+    public async Task ReadAsync_ReturnsOnlyTheRevisionBoundByTheProtectedLink()
+    {
+        var snapshot = CreateSnapshot("\"r1\"");
+        var service = Substitute.For<ICalendarService>();
+        service.GetResourceAsync(snapshot.ResourceHref, Arg.Any<CancellationToken>()).Returns(
+            CalendarResourceRead.Success(snapshot.ResourceHref, snapshot.EntityTag, snapshot.AuthoritativeUtf8) with { Snapshot = snapshot });
+        var link = ExactCalendarResourceLink.Create(snapshot);
+
+        var result = await ExactCalendarResourceHandler.ReadAsync(link.Uri, service, CancellationToken.None);
+
+        result.CacheScope.ShouldBe(CacheScope.Private);
+        result.TimeToLive.ShouldBe(TimeSpan.Zero);
+        result.Contents.ShouldHaveSingleItem().ShouldBeOfType<TextResourceContents>().Text
+            .ShouldBe(Encoding.UTF8.GetString(snapshot.AuthoritativeUtf8.Span));
+        ExactCalendarResourceHandler.List().Resources.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task ReadAsync_RejectsAChangedRevision()
+    {
+        var linked = CreateSnapshot("\"r1\"");
+        var changed = CreateSnapshot("\"r2\"");
+        var service = Substitute.For<ICalendarService>();
+        service.GetResourceAsync(linked.ResourceHref, Arg.Any<CancellationToken>()).Returns(
+            CalendarResourceRead.Success(changed.ResourceHref, changed.EntityTag, changed.AuthoritativeUtf8) with { Snapshot = changed });
+        var link = ExactCalendarResourceLink.Create(linked);
+
+        await Should.ThrowAsync<InvalidOperationException>(() =>
+            ExactCalendarResourceHandler.ReadAsync(link.Uri, service, CancellationToken.None));
+    }
+
+    [Theory]
+    [InlineData(CalendarResourceReadCode.NotFound)]
+    [InlineData(CalendarResourceReadCode.Success)]
+    public async Task ReadAsync_RejectsUnavailableTypedRead(CalendarResourceReadCode readCode)
+    {
+        var linked = CreateSnapshot("\"r1\"");
+        var service = Substitute.For<ICalendarService>();
+        service.GetResourceAsync(linked.ResourceHref, Arg.Any<CancellationToken>()).Returns(new CalendarResourceRead(readCode));
+        var link = ExactCalendarResourceLink.Create(linked);
+
+        await Should.ThrowAsync<InvalidOperationException>(() =>
+            ExactCalendarResourceHandler.ReadAsync(link.Uri, service, CancellationToken.None));
+    }
+
+    [Theory]
+    [InlineData("https://snapshot/abc?etag=abc")]
+    [InlineData("caldav-exact://other/abc?etag=abc")]
+    [InlineData("caldav-exact://snapshot/?etag=abc")]
+    [InlineData("caldav-exact://snapshot/abc?other=abc")]
+    [InlineData("caldav-exact://user@snapshot/abc?etag=abc")]
+    [InlineData("caldav-exact://snapshot:123/abc?etag=abc")]
+    [InlineData("caldav-exact://snapshot/abc?etag=abc#fragment")]
+    [InlineData("caldav-exact://snapshot/abc?etag=")]
+    [InlineData("caldav-exact://snapshot/abc?etag=abc&extra=1")]
+    [InlineData("caldav-exact://snapshot/a/b?etag=abc")]
+    [InlineData("caldav-exact://snapshot/aA==?etag=abc")]
+    [InlineData("caldav-exact://snapshot/aB?etag=abc")]
+    [InlineData("caldav-exact://snapshot/wyg?etag=InIxIg")]
+    public async Task ReadAsync_RejectsForgedLinkWithoutCallingService(string uri)
+    {
+        var service = Substitute.For<ICalendarService>();
+
+        await Should.ThrowAsync<InvalidOperationException>(() =>
+            ExactCalendarResourceHandler.ReadAsync(uri, service, CancellationToken.None));
+
+        await service.DidNotReceive().GetResourceAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Theory]
+    [InlineData("relative", "\"r1\"")]
+    [InlineData("ftp://cal.example/events/a.ics", "\"r1\"")]
+    [InlineData("https://user@cal.example/events/a.ics", "\"r1\"")]
+    [InlineData("https://cal.example/events/a.ics?query=1", "\"r1\"")]
+    [InlineData("https://cal.example/events/a.ics#fragment", "\"r1\"")]
+    [InlineData("https://cal.example/events/a.ics", "W/\"weak\"")]
+    [InlineData("https://cal.example/events/a.ics", "not-an-etag")]
+    public async Task ReadAsync_RejectsInvalidDecodedBindingsWithoutCallingService(string href, string entityTag)
+    {
+        var uri = $"caldav-exact://snapshot/{Encode(href)}?etag={Encode(entityTag)}";
+        var service = Substitute.For<ICalendarService>();
+
+        await Should.ThrowAsync<InvalidOperationException>(() =>
+            ExactCalendarResourceHandler.ReadAsync(uri, service, CancellationToken.None));
+
+        await service.DidNotReceive().GetResourceAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ExactGetAsync_UsesSharedSafeUpstreamFailureMapping()
+    {
+        var service = Substitute.For<ICalendarService>();
+        service.GetResourceAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns<Task<CalendarResourceRead>>(_ => throw new OperationCanceledException());
+        var sut = new ExactCalendarResourceTools(service);
+
+        var result = await sut.GetAsync("https://cal.example/events/a.ics", CancellationToken.None);
+
+        result.IsError.ShouldBe(true);
+        result.StructuredContent!.Value.GetProperty("code").GetString().ShouldBe("upstream_unavailable");
+    }
+
+    [Fact]
+    public async Task ExactGetAsync_UsesSharedDiscoveryLimitMapping()
+    {
+        var service = Substitute.For<ICalendarService>();
+        service.GetResourceAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns<Task<CalendarResourceRead>>(_ => throw new CalendarDiscoveryLimitException(300));
+        var sut = new ExactCalendarResourceTools(service);
+
+        var result = await sut.GetAsync("https://cal.example/events/a.ics", CancellationToken.None);
+
+        result.StructuredContent!.Value.GetProperty("code").GetString().ShouldBe("limit_exhausted");
+        result.StructuredContent.Value.GetProperty("limits").GetProperty("calendarCount").GetInt32().ShouldBe(300);
+    }
+
+    private static CalendarResourceSnapshot CreateSnapshot(string entityTag)
+    {
+        var bytes = Encoding.UTF8.GetBytes("BEGIN:VCALENDAR\r\nEND:VCALENDAR\r\n");
+        return new CalendarResourceSnapshot(
+            "https://cal.example/events/",
+            "https://cal.example/events/a.ics",
+            entityTag,
+            bytes,
+            [],
+            new CalendarResourceProjection(CalendarResourceProjectionKind.Opaque, null, null),
+            []);
+    }
+
+    private static string Encode(string value) => Convert.ToBase64String(Encoding.UTF8.GetBytes(value))
+        .TrimEnd('=')
+        .Replace('+', '-')
+        .Replace('/', '_');
+}

--- a/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/McpMetadataTests.cs
+++ b/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/McpMetadataTests.cs
@@ -57,6 +57,7 @@ public class McpMetadataTests
         envVarNames.ShouldContain("CALDAV_URL");
         envVarNames.ShouldContain("CALDAV_USERNAME");
         envVarNames.ShouldContain("CALDAV_PASSWORD");
+        envVarNames.ShouldContain("CALDAV_EXPOSE_EXACT_TOOLS");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- read authoritative, revision-coherent Calendar Object Resource snapshots with exact UTF-8 bytes and a lossless content-line index
- project valid VEVENT and VTODO resources conservatively while keeping unsupported or malformed known content readable as opaque
- expose calendar_resources.get by default and independently gate calendar_resources.exact_get with protected native MCP resource links
- harden canonical scope, XML parsing, UTF-8, strong ETag, size-budget, and typed-error handling

## Testing

- Release build: 0 warnings and 0 errors
- Core Release coverage tests: 289 passed
- MCP Release coverage tests: 199 passed
- filtered coverage: 96.5% line, 86.4% branch
- ContractCatalogTests: 4 passed
- Slopwatch: 0 issues

The live Docker/Radicale stdio integration slice is included and compiles, but the local environment could not complete it: Testcontainers ResourceReaper initialization was canceled, and a retry with Ryuk disabled timed out during the initial MKCOL. CI remains responsible for the Radicale matrix.

Closes #38

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>