### PR TITLE
feat: query calendar entities across Calendar Scope

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,9 +33,9 @@ dotnet tool run slopwatch analyze --config .slopwatch/slopwatch.json --fail-on w
 
 ## Boundaries
 
-- Runtime flow is `MCP tools -> ITaskService -> TaskService -> CalDavClient -> HttpClient`; `TaskService` stays thin. WebDAV request/response logic belongs under `Core/Internal/Xml`, and iCalendar mapping belongs under `Core/Internal/Ical`.
+- Runtime is transitional: unified Calendar tools use `ICalendarService`, while legacy task tools retain `ITaskService` until the 0.2 cleanup. Both services stay thin; WebDAV request/response logic belongs under `Core/Internal/Xml`, and iCalendar mapping belongs under `Core/Internal/Ical`.
 - `Program.cs` maps `CALDAV_*` environment variables, then delegates startup to `CalDavMcpRunner` and `CalDavHostBuilder`; keep startup testable through those types rather than adding logic to top-level statements.
-- The default host exposes only `TaskListTools` and `ChatTaskTools`. `CALDAV_EXPOSE_ADVANCED_TOOLS=true` additionally registers href-based `TaskQueryTools` and `TaskMutationTools`.
+- The default host exposes `calendars.list`, `calendar_entities.query`, `calendar_resources.get`, and the staged legacy chat-safe tools. `CALDAV_EXPOSE_EXACT_TOOLS=true` enables exact Calendar resource access; the legacy `CALDAV_EXPOSE_ADVANCED_TOOLS=true` gate remains until its tools are removed.
 - `.opencode/opencode.jsonc` launches the published NuGet tool through `dnx`; it does not run the current checkout. Do not treat that configuration as source-level end-to-end validation.
 
 ## Invariants

--- a/README.md
+++ b/README.md
@@ -57,9 +57,10 @@ Add this MCP server to VS Code, Claude Desktop, Cursor, or any MCP client:
 ### Calendar resource tools
 
 - `calendar_resources.get` — Read an authoritative semantic-or-opaque snapshot by confirmed absolute href.
+- `calendar_entities.query` — Query bounded persisted Event and To-do snapshots across default, selected, or explicit-all Calendar Scope.
 - `calendar_resources.exact_get` — Opt-in exact read through a protected MCP resource link; enable with `CALDAV_EXPOSE_EXACT_TOOLS=true`.
 
-By default, the server exposes `calendars.list` and `calendar_resources.get` alongside the legacy chat-safe tools retained during the staged migration. Set `CALDAV_EXPOSE_ADVANCED_TOOLS=true` to also expose the legacy href-based advanced tools.
+By default, the server exposes `calendars.list`, `calendar_resources.get`, and `calendar_entities.query` alongside the legacy chat-safe tools retained during the staged migration. Set `CALDAV_EXPOSE_ADVANCED_TOOLS=true` to also expose the legacy href-based advanced tools.
 
 ## Supported servers
 

--- a/src/DotnetAgents.CalDav.Core/Abstractions/ICalendarClient.cs
+++ b/src/DotnetAgents.CalDav.Core/Abstractions/ICalendarClient.cs
@@ -8,6 +8,14 @@ public interface ICalendarClient
     /// <summary>Discovers every Calendar collection visible to the configured account.</summary>
     Task<IReadOnlyList<CalendarDescriptor>> GetCalendarsAsync(CancellationToken cancellationToken);
 
+    /// <summary>Uses a minimal CalDAV REPORT to collect candidate resource hrefs.</summary>
+    Task<IReadOnlyList<string>> QueryCalendarResourceHrefsAsync(
+        string calendarHref,
+        CalendarEntityKind entityKind,
+        DateTimeOffset? from,
+        DateTimeOffset? to,
+        CancellationToken cancellationToken);
+
     /// <summary>Reads one complete Calendar Object Resource revision by canonical absolute href.</summary>
     Task<CalendarResourceRead> GetCalendarResourceAsync(string href, CancellationToken cancellationToken);
 }

--- a/src/DotnetAgents.CalDav.Core/Abstractions/ICalendarService.cs
+++ b/src/DotnetAgents.CalDav.Core/Abstractions/ICalendarService.cs
@@ -13,6 +13,11 @@ public interface ICalendarService
         CalendarEntityKind entityKind,
         CancellationToken cancellationToken);
 
+    /// <summary>Queries persisted Event and To-do snapshots within an explicit Calendar Scope.</summary>
+    Task<CalendarEntityQueryResult> QueryEntitiesAsync(
+        CalendarEntityQuery query,
+        CancellationToken cancellationToken);
+
     /// <summary>Reads one authoritative Calendar Object Resource snapshot.</summary>
     Task<CalendarResourceRead> GetResourceAsync(string href, CancellationToken cancellationToken);
 }

--- a/src/DotnetAgents.CalDav.Core/DependencyInjection/CalDavServiceCollectionExtensions.cs
+++ b/src/DotnetAgents.CalDav.Core/DependencyInjection/CalDavServiceCollectionExtensions.cs
@@ -78,10 +78,10 @@ public static class CalDavServiceCollectionExtensions
         })
         .AddStandardResilienceHandler(options =>
         {
-            // CalDAV operations use conditional headers (If-Match, If-None-Match) that make
-            // retries safe for all methods: duplicate creates get 412, duplicate updates get 412,
-            // and deletes are idempotent (404 on repeat). Keep default retry behavior for all methods.
-            options.Retry.MaxRetryAttempts = 3;
+            // Three total attempts are available only to idempotent reads. A conditional write can
+            // still have an ambiguous transport outcome and must be reconciled before another dispatch.
+            options.Retry.MaxRetryAttempts = 2;
+            options.Retry.DisableForUnsafeHttpMethods();
             options.Retry.BackoffType = DelayBackoffType.Exponential;
             options.Retry.UseJitter = true;
             options.Retry.Delay = TimeSpan.FromMilliseconds(200);
@@ -91,7 +91,7 @@ public static class CalDavServiceCollectionExtensions
             // circuit breaker is more useful for high-throughput service-to-service scenarios.
             // SamplingDuration must be >= 2x AttemptTimeout.Timeout (validation rule).
             options.AttemptTimeout.Timeout = TimeSpan.FromSeconds(10);
-            options.TotalRequestTimeout.Timeout = TimeSpan.FromMinutes(5);
+            options.TotalRequestTimeout.Timeout = TimeSpan.FromSeconds(30);
             options.CircuitBreaker.SamplingDuration = TimeSpan.FromSeconds(30);
         });
 

--- a/src/DotnetAgents.CalDav.Core/Internal/CalDavClient.cs
+++ b/src/DotnetAgents.CalDav.Core/Internal/CalDavClient.cs
@@ -107,13 +107,68 @@ internal sealed class CalDavClient : ICalDavClient, ICalendarClient
     }
 
     /// <inheritdoc />
+    public async Task<IReadOnlyList<string>> QueryCalendarResourceHrefsAsync(
+        string calendarHref,
+        CalendarEntityKind entityKind,
+        DateTimeOffset? from,
+        DateTimeOffset? to,
+        CancellationToken cancellationToken)
+    {
+        if (!TryCanonicalizeCalendarHref(
+                new Uri(_options.Value.BaseUrl, UriKind.Absolute),
+                calendarHref,
+                out var authorizedCalendarHref))
+        {
+            throw new CalendarDiscoveryProtocolException("Unsafe CalDAV REPORT href.");
+        }
+        var authorizedCalendarUri = new Uri(authorizedCalendarHref, UriKind.Absolute);
+        var body = DavRequestBuilder.BuildCalendarEntityQuery(entityKind, from, to);
+        (string Content, Uri RequestUri) response;
+        try
+        {
+            response = await SendReportAsync(calendarHref, body, cancellationToken);
+        }
+        catch (CalendarQueryFilterUnsupportedException) when (from is not null && to is not null)
+        {
+            try
+            {
+                response = await SendReportAsync(
+                    calendarHref,
+                    DavRequestBuilder.BuildCalendarEntityQuery(entityKind),
+                    cancellationToken);
+            }
+            catch (CalendarQueryFilterUnsupportedException exception)
+            {
+                throw new CalendarDiscoveryUnsupportedCapabilityException(exception.Message);
+            }
+        }
+        catch (CalendarQueryFilterUnsupportedException exception)
+        {
+            throw new CalendarDiscoveryUnsupportedCapabilityException(exception.Message);
+        }
+        var calendarUri = response.RequestUri;
+        var hrefs = new List<string>();
+        foreach (var candidateHref in DavResponseParser.ParseCalendarResourceHrefs(response.Content))
+        {
+            if (IsCollectionSelfHref(calendarUri, candidateHref))
+                continue;
+            if (!TryCanonicalizeResourceHref(calendarUri, candidateHref, out var canonicalHref))
+                throw new CalendarDiscoveryProtocolException("Unsafe Calendar Object Resource candidate href.");
+            if (!IsDirectResourceOf(authorizedCalendarUri, new Uri(canonicalHref, UriKind.Absolute)))
+                throw new CalendarDiscoveryProtocolException("Calendar Object Resource candidate escaped its authorized Calendar identity.");
+            hrefs.Add(canonicalHref);
+        }
+
+        return hrefs.Distinct(StringComparer.Ordinal).Order(StringComparer.Ordinal).ToArray();
+    }
+
+    /// <inheritdoc />
     public async Task<CalendarResourceRead> GetCalendarResourceAsync(string href, CancellationToken cancellationToken)
     {
         if (!TryValidateAbsoluteResourceHref(href, out var resourceUri))
             return new CalendarResourceRead(CalendarResourceReadCode.InvalidInput);
 
-        using var request = new HttpRequestMessage(HttpMethod.Get, resourceUri);
-        using var response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+        using var response = await SendGetWithRedirectHandlingAsync(resourceUri, cancellationToken);
         if (response.StatusCode == HttpStatusCode.NotFound)
             return new CalendarResourceRead(CalendarResourceReadCode.NotFound);
 
@@ -136,8 +191,64 @@ internal sealed class CalDavClient : ICalDavClient, ICalendarClient
             return new CalendarResourceRead(CalendarResourceReadCode.UpstreamProtocolError);
         }
 
-        return CalendarResourceRead.Success(href, entityTag, content);
+        return CalendarResourceRead.Success(resourceUri.AbsoluteUri, entityTag, content);
     }
+
+    private async Task<HttpResponseMessage> SendGetWithRedirectHandlingAsync(
+        Uri initialUri,
+        CancellationToken cancellationToken,
+        int maxRedirects = 5)
+    {
+        var currentUri = initialUri;
+        for (var attempt = 0; ; attempt++)
+        {
+            using var request = new HttpRequestMessage(HttpMethod.Get, currentUri);
+            var response = await _httpClient.SendAsync(
+                request,
+                HttpCompletionOption.ResponseHeadersRead,
+                cancellationToken);
+            if (response.StatusCode == HttpStatusCode.RedirectMethod)
+            {
+                response.Dispose();
+                throw new CalendarDiscoveryProtocolException("A 303 redirect is invalid for a CalDAV resource read.");
+            }
+
+            if (!IsPreservingReadRedirect(response.StatusCode))
+                return response;
+            if (attempt == maxRedirects)
+            {
+                response.Dispose();
+                throw new CalendarDiscoveryProtocolException("CalDAV redirect limit was exceeded.");
+            }
+
+            var location = response.Headers.Location;
+            if (location is null)
+            {
+                response.Dispose();
+                throw new CalendarDiscoveryProtocolException("A CalDAV redirect is missing its Location header.");
+            }
+            if (location.OriginalString.Contains("%2e", StringComparison.OrdinalIgnoreCase))
+            {
+                response.Dispose();
+                throw new CalendarDiscoveryProtocolException("Unsafe CalDAV resource redirect href.");
+            }
+            var redirectUri = location.IsAbsoluteUri ? location : new Uri(currentUri, location);
+            if (!TryValidateAbsoluteResourceHref(redirectUri.AbsoluteUri, out var canonicalRedirectUri))
+            {
+                response.Dispose();
+                throw new CalendarDiscoveryProtocolException("Unsafe CalDAV resource redirect href.");
+            }
+
+            response.Dispose();
+            currentUri = canonicalRedirectUri;
+        }
+    }
+
+    private static bool IsPreservingReadRedirect(HttpStatusCode statusCode) => statusCode is
+        HttpStatusCode.MovedPermanently or
+        HttpStatusCode.Redirect or
+        HttpStatusCode.TemporaryRedirect or
+        HttpStatusCode.PermanentRedirect;
 
     private bool TryValidateAbsoluteResourceHref(string href, out Uri resourceUri)
     {
@@ -222,7 +333,7 @@ internal sealed class CalDavClient : ICalDavClient, ICalendarClient
             Models.TaskStatus.Completed => DavRequestBuilder.BuildCalendarQuery(completedOnly: true),
             _ => DavRequestBuilder.BuildCalendarQuery()
         };
-        var responseXml = await SendReportAsync(taskListHref, reportBody, cancellationToken);
+        var responseXml = (await SendReportAsync(taskListHref, reportBody, cancellationToken)).Content;
 
         var calendarDataItems = DavResponseParser.ParseCalendarData(responseXml);
         var tasks = new List<TaskItem>();
@@ -515,16 +626,45 @@ internal sealed class CalDavClient : ICalDavClient, ICalendarClient
         return (content, requestUri);
     }
 
-    private async Task<string> SendReportAsync(string href, string body, CancellationToken cancellationToken)
+    private async Task<(string Content, Uri RequestUri)> SendReportAsync(
+        string href,
+        string body,
+        CancellationToken cancellationToken)
     {
-        var request = new HttpRequestMessage(ReportMethod, BuildUrl(href))
+        if (!TryCanonicalizeCalendarHref(new Uri(_options.Value.BaseUrl, UriKind.Absolute), href, out var canonicalHref))
+            throw new CalendarDiscoveryProtocolException("Unsafe CalDAV REPORT href.");
+
+        var request = new HttpRequestMessage(ReportMethod, canonicalHref)
         {
             Content = new StringContent(body, Encoding.UTF8, "application/xml")
         };
         request.Headers.Add("Depth", "1");
 
-        using var response = await SendWithRedirectHandlingAsync(request, body, cancellationToken);
-        return await response.Content.ReadAsStringAsync(cancellationToken);
+        using var response = await SendWithRedirectHandlingAsync(request, body, cancellationToken, ensureSuccess: false);
+        var bounded = await ReadBoundedContentAsync(response.Content, cancellationToken);
+        if (bounded.Content is null)
+        {
+            throw new HttpRequestException(
+                "The CalDAV REPORT response exceeded the safe payload limit.",
+                null,
+                HttpStatusCode.RequestEntityTooLarge);
+        }
+        try
+        {
+            var content = StrictUtf8.GetString(bounded.Content);
+            if (!response.IsSuccessStatusCode)
+            {
+                if (response.StatusCode is HttpStatusCode.BadRequest or HttpStatusCode.Forbidden
+                    && DavResponseParser.IsSupportedFilterError(content))
+                    throw new CalendarQueryFilterUnsupportedException();
+                response.EnsureSuccessStatusCode();
+            }
+            return (content, response.RequestMessage?.RequestUri ?? new Uri(canonicalHref, UriKind.Absolute));
+        }
+        catch (DecoderFallbackException)
+        {
+            throw new CalendarDiscoveryProtocolException("The CalDAV REPORT response was not valid UTF-8.");
+        }
     }
 
     /// <summary>
@@ -534,7 +674,11 @@ internal sealed class CalDavClient : ICalDavClient, ICalendarClient
     /// like PROPFIND and REPORT must be preserved across redirects.
     /// </summary>
     private async Task<HttpResponseMessage> SendWithRedirectHandlingAsync(
-        HttpRequestMessage originalRequest, string body, CancellationToken cancellationToken, int maxRedirects = 5)
+        HttpRequestMessage originalRequest,
+        string body,
+        CancellationToken cancellationToken,
+        int maxRedirects = 5,
+        bool ensureSuccess = true)
     {
         HttpResponseMessage? response = null;
         var currentRequest = originalRequest;
@@ -547,7 +691,11 @@ internal sealed class CalDavClient : ICalDavClient, ICalendarClient
         for (var attempt = 0; attempt <= maxRedirects; attempt++)
         {
             response?.Dispose();
-            response = await _httpClient.SendAsync(currentRequest, cancellationToken);
+            response = await _httpClient.SendAsync(
+                currentRequest,
+                HttpCompletionOption.ResponseHeadersRead,
+                cancellationToken);
+            response.RequestMessage = currentRequest;
 
             var redirectRequest = CreateRedirectRequest(response, currentRequest, method, body, contentType, depthValues, attempt, maxRedirects);
             if (redirectRequest is null)
@@ -555,6 +703,8 @@ internal sealed class CalDavClient : ICalDavClient, ICalendarClient
             currentRequest = redirectRequest;
         }
 
+        if (!ensureSuccess)
+            return response!;
         try
         {
             response!.EnsureSuccessStatusCode();
@@ -567,6 +717,10 @@ internal sealed class CalDavClient : ICalDavClient, ICalendarClient
         return response;
     }
 
+    private sealed class CalendarQueryFilterUnsupportedException : Exception
+    {
+    }
+
     private HttpRequestMessage? CreateRedirectRequest(
         HttpResponseMessage response,
         HttpRequestMessage currentRequest,
@@ -577,6 +731,11 @@ internal sealed class CalDavClient : ICalDavClient, ICalendarClient
         int attempt,
         int maxRedirects)
     {
+        if (response.StatusCode == HttpStatusCode.RedirectMethod)
+        {
+            response.Dispose();
+            throw new CalendarDiscoveryProtocolException("A 303 redirect is invalid for a CalDAV method.");
+        }
         var redirectUrl = GetRedirectUrl(response, currentRequest.RequestUri);
         if (redirectUrl is null)
             return null;
@@ -666,6 +825,59 @@ internal sealed class CalDavClient : ICalDavClient, ICalendarClient
 
         canonicalHref = candidate.AbsoluteUri;
         return true;
+    }
+
+    private bool TryCanonicalizeResourceHref(Uri calendarUri, string href, out string canonicalHref)
+    {
+        canonicalHref = string.Empty;
+        var absoluteInput = href.StartsWith("http://", StringComparison.OrdinalIgnoreCase)
+            || href.StartsWith("https://", StringComparison.OrdinalIgnoreCase);
+        if (href.Contains("%2e", StringComparison.OrdinalIgnoreCase)
+            || !Uri.TryCreate(calendarUri, href, out var candidate)
+            || !IsCanonicalReportCandidate(candidate, href, absoluteInput))
+        {
+            return false;
+        }
+
+        var calendarPath = calendarUri.AbsolutePath.EndsWith('/')
+            ? calendarUri.AbsolutePath
+            : calendarUri.AbsolutePath + '/';
+        if (!candidate.AbsolutePath.StartsWith(calendarPath, StringComparison.Ordinal))
+            return false;
+        var relative = candidate.AbsolutePath[calendarPath.Length..];
+        if (relative.Length == 0 || relative.Contains('/'))
+            return false;
+
+        canonicalHref = candidate.AbsoluteUri;
+        return true;
+    }
+
+    private bool IsCanonicalReportCandidate(Uri candidate, string href, bool absoluteInput) =>
+        IsSafeCanonicalUri(candidate, candidate.AbsoluteUri)
+        && (!absoluteInput || string.Equals(candidate.AbsoluteUri, href, StringComparison.Ordinal))
+        && HasSameOrigin(new Uri(_options.Value.BaseUrl, UriKind.Absolute), candidate);
+
+    private static bool IsCollectionSelfHref(Uri calendarUri, string href) =>
+        Uri.TryCreate(calendarUri, href, out var candidate)
+        && HasSameOrigin(calendarUri, candidate)
+        && IsSafeCanonicalUri(candidate, candidate.AbsoluteUri)
+        && string.Equals(
+            candidate.AbsolutePath.TrimEnd('/'),
+            calendarUri.AbsolutePath.TrimEnd('/'),
+            StringComparison.Ordinal)
+        && string.Equals(candidate.Query, calendarUri.Query, StringComparison.Ordinal);
+
+    private static bool IsDirectResourceOf(Uri calendarUri, Uri resourceUri)
+    {
+        if (!HasSameOrigin(calendarUri, resourceUri))
+            return false;
+        var calendarPath = calendarUri.AbsolutePath.EndsWith('/')
+            ? calendarUri.AbsolutePath
+            : calendarUri.AbsolutePath + '/';
+        if (!resourceUri.AbsolutePath.StartsWith(calendarPath, StringComparison.Ordinal))
+            return false;
+        var relativePath = resourceUri.AbsolutePath[calendarPath.Length..];
+        return relativePath.Length > 0 && !relativePath.Contains('/');
     }
 
     private static bool MatchesQuery(TaskItem task, TaskQuery query)

--- a/src/DotnetAgents.CalDav.Core/Internal/Ical/CalendarEntityTemporalMatcher.cs
+++ b/src/DotnetAgents.CalDav.Core/Internal/Ical/CalendarEntityTemporalMatcher.cs
@@ -1,0 +1,381 @@
+using System.Text;
+using System.Xml;
+using DotnetAgents.CalDav.Core.Models;
+using Ical.Net;
+using Ical.Net.CalendarComponents;
+using Ical.Net.DataTypes;
+using Ical.Net.Evaluation;
+using CalendarProperty = DotnetAgents.CalDav.Core.Models.CalendarProperty;
+using IcalCalendar = Ical.Net.Calendar;
+
+namespace DotnetAgents.CalDav.Core.Internal.Ical;
+
+internal enum CalendarEntityTemporalMatch
+{
+    Match,
+    NoMatch,
+    Unresolved,
+    Unevaluable,
+    LimitExhausted
+}
+
+internal readonly record struct CalendarEntityTemporalResult(
+    CalendarEntityTemporalMatch Match,
+    int OccurrenceCount = 0);
+
+/// <summary>Applies final instant-window predicates to authoritative snapshot properties.</summary>
+internal static class CalendarEntityTemporalMatcher
+{
+    private const int MaximumEntityOccurrences = 2000;
+    private const int MaximumUnmatchedIncrements = 10_000;
+    private static readonly string[] TemporalPropertyNames =
+        ["DTSTART", "DTEND", "DUE", "RDATE", "EXDATE", "RECURRENCE-ID"];
+
+    public static CalendarEntityTemporalResult Matches(
+        CalendarResourceSnapshot snapshot,
+        DateTimeOffset? from,
+        DateTimeOffset? to,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        if (from is null || to is null)
+            return new(CalendarEntityTemporalMatch.Match);
+        if (snapshot.Projection.Kind == CalendarResourceProjectionKind.Opaque)
+            return MatchOpaque(snapshot);
+
+        var componentName = snapshot.Projection.Kind == CalendarResourceProjectionKind.Event ? "VEVENT" : "VTODO";
+        var entityProperties = snapshot.CalendarProperties.Where(property => IsEntityProperty(property, componentName)).ToArray();
+        var resolver = new CalendarTemporalResolver(
+            snapshot.CalendarProperties,
+            snapshot.AuthoritativeUtf8.Span,
+            cancellationToken);
+        if (HasUnresolvedTemporalValue(entityProperties, resolver, cancellationToken))
+            return new(CalendarEntityTemporalMatch.Unresolved);
+        var masterProperties = entityProperties.Where(property => property.ComponentPath[1].Occurrence == 0).ToArray();
+        var recurrence = ClassifyRecurrence(entityProperties, masterProperties);
+        if (recurrence == RecurrenceDisposition.Unevaluable)
+            return new(CalendarEntityTemporalMatch.Unevaluable);
+        if (recurrence == RecurrenceDisposition.Recurring)
+            return MatchRecurring(snapshot, entityProperties, resolver, from.Value, to.Value, cancellationToken);
+        var match = snapshot.Projection.Kind == CalendarResourceProjectionKind.Event
+            ? MatchEvent(masterProperties, resolver, from.Value, to.Value)
+            : MatchTodo(masterProperties, resolver, from.Value, to.Value);
+        return new(match, match == CalendarEntityTemporalMatch.NoMatch ? 0 : 1);
+    }
+
+    private static CalendarEntityTemporalResult MatchOpaque(CalendarResourceSnapshot snapshot)
+    {
+        _ = snapshot;
+        return new(CalendarEntityTemporalMatch.Unresolved);
+    }
+
+    private static CalendarEntityTemporalResult MatchRecurring(
+        CalendarResourceSnapshot snapshot,
+        IReadOnlyList<CalendarProperty> entityProperties,
+        CalendarTemporalResolver resolver,
+        DateTimeOffset from,
+        DateTimeOffset to,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var replay = CalendarContentDocument.Parse(snapshot.AuthoritativeUtf8.Span).ReplayForTypedValidation();
+            var calendar = IcalCalendar.Load(Encoding.UTF8.GetString(replay));
+            if (calendar is null)
+                return new(CalendarEntityTemporalMatch.Unevaluable);
+            cancellationToken.ThrowIfCancellationRequested();
+            var searchStart = SubtractSafely(from, GetMaximumLookback(entityProperties, resolver, cancellationToken));
+            var options = new EvaluationOptions { MaxUnmatchedIncrementsLimit = MaximumUnmatchedIncrements };
+            var occurrences = snapshot.Projection.Kind == CalendarResourceProjectionKind.Event
+                ? calendar.GetOccurrences<CalendarEvent>(new CalDateTime(searchStart.UtcDateTime), options)
+                : calendar.GetOccurrences<Todo>(new CalDateTime(searchStart.UtcDateTime), options);
+            return EvaluateOccurrences(occurrences, resolver, from, to, cancellationToken);
+        }
+        catch (EvaluationLimitExceededException)
+        {
+            return new(CalendarEntityTemporalMatch.LimitExhausted);
+        }
+        catch (EvaluationOutOfRangeException)
+        {
+            return new(CalendarEntityTemporalMatch.Unevaluable);
+        }
+        catch (Exception exception) when (exception is FormatException or ArgumentException or InvalidOperationException)
+        {
+            return new(CalendarEntityTemporalMatch.Unevaluable);
+        }
+    }
+
+    private static RecurrenceDisposition ClassifyRecurrence(
+        IReadOnlyList<CalendarProperty> entityProperties,
+        IReadOnlyList<CalendarProperty> masterProperties)
+    {
+        if (entityProperties.Any(HasUnsupportedRangeParameter))
+            return RecurrenceDisposition.Unevaluable;
+        if (entityProperties.Any(property => property.ComponentPath[1].Occurrence > 0
+                && property.Name.Equals("RRULE", StringComparison.OrdinalIgnoreCase)))
+            return RecurrenceDisposition.Unevaluable;
+        var recurrenceRuleCount = entityProperties.Count(property =>
+            property.Name.Equals("RRULE", StringComparison.OrdinalIgnoreCase));
+        if (recurrenceRuleCount > 1)
+            return RecurrenceDisposition.Unevaluable;
+        return recurrenceRuleCount == 1
+            || masterProperties.Any(property => property.Name.Equals("RDATE", StringComparison.OrdinalIgnoreCase)
+                || property.Name.Equals("EXDATE", StringComparison.OrdinalIgnoreCase))
+            || entityProperties.Any(property => property.ComponentPath[1].Occurrence > 0)
+            ? RecurrenceDisposition.Recurring
+            : RecurrenceDisposition.None;
+    }
+
+    private static bool HasUnsupportedRangeParameter(CalendarProperty property) =>
+        property.Name.Equals("RECURRENCE-ID", StringComparison.OrdinalIgnoreCase)
+        && property.Parameters.Any(parameter => parameter.Name.Equals("RANGE", StringComparison.OrdinalIgnoreCase));
+
+    private static CalendarEntityTemporalResult EvaluateOccurrences(
+        IEnumerable<Occurrence> occurrences,
+        CalendarTemporalResolver resolver,
+        DateTimeOffset from,
+        DateTimeOffset to,
+        CancellationToken cancellationToken)
+    {
+        var count = 0;
+        var matched = false;
+        foreach (var occurrence in occurrences)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (!TryResolveOccurrence(occurrence, resolver, out var start, out var end, out var failure))
+                return new(failure, count);
+            if (start >= to)
+                break;
+            count++;
+            if (count > MaximumEntityOccurrences)
+                return new(CalendarEntityTemporalMatch.LimitExhausted, count);
+            matched |= Overlaps(start, end, from, to) == CalendarEntityTemporalMatch.Match;
+        }
+        return new(matched ? CalendarEntityTemporalMatch.Match : CalendarEntityTemporalMatch.NoMatch, count);
+    }
+
+    private static bool TryResolveOccurrence(
+        Occurrence occurrence,
+        CalendarTemporalResolver resolver,
+        out DateTimeOffset start,
+        out DateTimeOffset end,
+        out CalendarEntityTemporalMatch failure)
+    {
+        start = default;
+        end = default;
+        failure = CalendarEntityTemporalMatch.Unevaluable;
+        var resolvedStart = resolver.Resolve(occurrence.Period.StartTime);
+        if (resolvedStart.Value is null)
+        {
+            failure = ToFailure(resolvedStart);
+            return false;
+        }
+        start = resolvedStart.Value.Value;
+        var effectiveEnd = occurrence.Period.EffectiveEndTime;
+        if (effectiveEnd is null)
+        {
+            end = start;
+            return true;
+        }
+        var resolvedEnd = resolver.Resolve(effectiveEnd);
+        if (resolvedEnd.Value is null)
+        {
+            failure = ToFailure(resolvedEnd);
+            return false;
+        }
+        end = resolvedEnd.Value.Value;
+        return true;
+    }
+
+    private static TimeSpan GetMaximumLookback(
+        IReadOnlyList<CalendarProperty> properties,
+        CalendarTemporalResolver resolver,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        var maximum = properties
+            .GroupBy(property => property.ComponentPath[1].Occurrence)
+            .Select(group => GetComponentSpan(group.ToArray(), resolver))
+            .DefaultIfEmpty(TimeSpan.Zero)
+            .Max();
+        foreach (var property in properties.Where(property =>
+                     property.Name.Equals("RDATE", StringComparison.OrdinalIgnoreCase)
+                     && property.ValueType == CalendarPropertyValueType.Period))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            foreach (var period in property.RawEncodedValue.Split(',', StringSplitOptions.None))
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                maximum = Max(maximum, GetPeriodSpan(property, period, resolver));
+            }
+        }
+        return maximum;
+    }
+
+    private static TimeSpan GetComponentSpan(
+        IReadOnlyList<CalendarProperty> properties,
+        CalendarTemporalResolver resolver)
+    {
+        var start = resolver.Resolve(GetProperty(properties, "DTSTART")).Value;
+        if (start is null)
+            return TimeSpan.Zero;
+        var end = resolver.Resolve(GetProperty(properties, "DTEND") ?? GetProperty(properties, "DUE")).Value;
+        if (end > start)
+            return end.Value - start.Value;
+        var duration = GetDuration(properties);
+        return duration > TimeSpan.Zero ? duration.Value : TimeSpan.Zero;
+    }
+
+    private static TimeSpan GetPeriodSpan(
+        CalendarProperty property,
+        string period,
+        CalendarTemporalResolver resolver)
+    {
+        var parts = period.Split('/', StringSplitOptions.None);
+        if (parts.Length != 2)
+            return TimeSpan.Zero;
+        var start = resolver.ResolveToken(property, parts[0]).Value;
+        if (start is null)
+            return TimeSpan.Zero;
+        if (parts[1].StartsWith('P') || parts[1].StartsWith("-P", StringComparison.Ordinal))
+        {
+            try
+            {
+                var duration = XmlConvert.ToTimeSpan(parts[1]);
+                return duration > TimeSpan.Zero ? duration : TimeSpan.Zero;
+            }
+            catch (FormatException)
+            {
+                return TimeSpan.Zero;
+            }
+        }
+        var end = resolver.ResolveToken(property, parts[1]).Value;
+        return end > start ? end.Value - start.Value : TimeSpan.Zero;
+    }
+
+    private static TimeSpan Max(TimeSpan left, TimeSpan right) => left >= right ? left : right;
+
+    private static DateTimeOffset SubtractSafely(DateTimeOffset instant, TimeSpan lookback) =>
+        instant - DateTimeOffset.MinValue < lookback ? DateTimeOffset.MinValue : instant - lookback;
+
+    private static bool HasUnresolvedTemporalValue(
+        IEnumerable<CalendarProperty> properties,
+        CalendarTemporalResolver resolver,
+        CancellationToken cancellationToken)
+    {
+        foreach (var property in properties.Where(property =>
+                     TemporalPropertyNames.Contains(property.Name, StringComparer.OrdinalIgnoreCase)))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (!resolver.CanResolve(property))
+                return true;
+        }
+        return false;
+    }
+
+    private static CalendarEntityTemporalMatch MatchEvent(
+        IReadOnlyList<CalendarProperty> properties,
+        CalendarTemporalResolver resolver,
+        DateTimeOffset from,
+        DateTimeOffset to)
+    {
+        var start = resolver.Resolve(GetProperty(properties, "DTSTART"));
+        if (start.Value is null)
+            return ToFailure(start);
+
+        var end = GetProperty(properties, "DTEND");
+        var resolvedEnd = end is null ? default : resolver.Resolve(end);
+        if (end is not null && resolvedEnd.Value is null)
+            return ToFailure(resolvedEnd);
+        var endInstant = resolvedEnd.Value
+            ?? ApplyDuration(properties, start.Value.Value)
+            ?? start.Value.Value;
+        return Overlaps(start.Value.Value, endInstant, from, to);
+    }
+
+    private static CalendarEntityTemporalMatch MatchTodo(
+        IReadOnlyList<CalendarProperty> properties,
+        CalendarTemporalResolver resolver,
+        DateTimeOffset from,
+        DateTimeOffset to)
+    {
+        var start = GetProperty(properties, "DTSTART");
+        var due = GetProperty(properties, "DUE");
+        if (start is null)
+            return MatchTodoWithoutStart(due, resolver, from, to);
+
+        var resolvedStart = resolver.Resolve(start);
+        if (resolvedStart.Value is null)
+            return ToFailure(resolvedStart);
+        if (due is null)
+        {
+            var end = ApplyDuration(properties, resolvedStart.Value.Value) ?? resolvedStart.Value.Value;
+            return Overlaps(resolvedStart.Value.Value, end, from, to);
+        }
+
+        var resolvedDue = resolver.Resolve(due);
+        return resolvedDue.Value is null
+            ? ToFailure(resolvedDue)
+            : Overlaps(resolvedStart.Value.Value, resolvedDue.Value.Value, from, to);
+    }
+
+    private static CalendarEntityTemporalMatch MatchTodoWithoutStart(
+        CalendarProperty? due,
+        CalendarTemporalResolver resolver,
+        DateTimeOffset from,
+        DateTimeOffset to)
+    {
+        if (due is null)
+            return CalendarEntityTemporalMatch.NoMatch;
+        var resolved = resolver.Resolve(due);
+        return resolved.Value is null
+            ? ToFailure(resolved)
+            : Overlaps(resolved.Value.Value, resolved.Value.Value, from, to);
+    }
+
+    private static DateTimeOffset? ApplyDuration(
+        IReadOnlyList<CalendarProperty> properties,
+        DateTimeOffset start) => GetDuration(properties) is { } duration ? start + duration : null;
+
+    private static TimeSpan? GetDuration(IReadOnlyList<CalendarProperty> properties)
+    {
+        var duration = GetProperty(properties, "DURATION");
+        if (duration is null)
+            return null;
+
+        try
+        {
+            return XmlConvert.ToTimeSpan(duration.RawEncodedValue);
+        }
+        catch (FormatException)
+        {
+            return null;
+        }
+    }
+
+    private static CalendarEntityTemporalMatch Overlaps(
+        DateTimeOffset start,
+        DateTimeOffset end,
+        DateTimeOffset from,
+        DateTimeOffset to) => end > start
+            ? start < to && end > from ? CalendarEntityTemporalMatch.Match : CalendarEntityTemporalMatch.NoMatch
+            : start >= from && start < to ? CalendarEntityTemporalMatch.Match : CalendarEntityTemporalMatch.NoMatch;
+
+    private static CalendarEntityTemporalMatch ToFailure(ResolvedCalendarInstant instant) => instant.Unresolved
+        ? CalendarEntityTemporalMatch.Unresolved
+        : CalendarEntityTemporalMatch.Unevaluable;
+
+    private static CalendarProperty? GetProperty(IEnumerable<CalendarProperty> properties, string name) =>
+        properties.FirstOrDefault(property => property.Name.Equals(name, StringComparison.OrdinalIgnoreCase));
+
+    private static bool IsEntityProperty(CalendarProperty property, string componentName) =>
+        property.ComponentPath.Count == 2
+        && property.ComponentPath[1].Name.Equals(componentName, StringComparison.OrdinalIgnoreCase);
+
+    private enum RecurrenceDisposition
+    {
+        None,
+        Recurring,
+        Unevaluable
+    }
+}

--- a/src/DotnetAgents.CalDav.Core/Internal/Ical/CalendarResourceProjector.cs
+++ b/src/DotnetAgents.CalDav.Core/Internal/Ical/CalendarResourceProjector.cs
@@ -17,7 +17,7 @@ internal static class CalendarResourceProjector
     {
         "UID", "RECURRENCE-ID", "SUMMARY", "DESCRIPTION", "DTSTART", "DTEND", "DUE", "DURATION",
         "LOCATION", "STATUS", "TRANSP", "CLASS", "PRIORITY", "URL", "COMPLETED", "DTSTAMP",
-        "CREATED", "LAST-MODIFIED", "GEO", "ORGANIZER", "PERCENT-COMPLETE", "SEQUENCE", "RRULE"
+        "CREATED", "LAST-MODIFIED", "GEO", "ORGANIZER", "PERCENT-COMPLETE", "SEQUENCE"
     };
 
     public static CalendarProjectionResult Project(ReadOnlySpan<byte> authoritativeUtf8)
@@ -31,6 +31,20 @@ internal static class CalendarResourceProjector
         {
             return Opaque([], "invalid_calendar_data");
         }
+    }
+
+    public static CalendarResourceRead AttachSnapshot(string calendarHref, CalendarResourceRead read)
+    {
+        var projection = Project(read.AuthoritativeUtf8.Span);
+        var snapshot = new CalendarResourceSnapshot(
+            calendarHref,
+            read.ResourceHref!,
+            read.EntityTag!,
+            read.AuthoritativeUtf8,
+            projection.Properties,
+            projection.Projection,
+            projection.Diagnostics);
+        return read with { Snapshot = snapshot };
     }
 
     private static CalendarProjectionResult ProjectDocument(CalendarContentDocument document)
@@ -130,9 +144,7 @@ internal static class CalendarResourceProjector
         var recurrenceError = ValidateRecurrenceFamily(entities, masters[0]);
         if (recurrenceError is not null)
             return recurrenceError;
-        return HasRecurrenceDefinition(masters[0]) || entities.Count == 1
-            ? null
-            : "recurrence_override_without_recurrence_set";
+        return null;
     }
 
     private static string? ValidateBasicEntityShape(IReadOnlyList<EntityComponent> entities)
@@ -169,10 +181,6 @@ internal static class CalendarResourceProjector
                 ? "recurrence_identity_family_mismatch"
                 : null;
     }
-
-    private static bool HasRecurrenceDefinition(EntityComponent entity) => entity.Properties.Any(property =>
-        property.Name.Equals("RRULE", StringComparison.OrdinalIgnoreCase)
-        || property.Name.Equals("RDATE", StringComparison.OrdinalIgnoreCase));
 
     private static string? ValidateCalendarProperties(IReadOnlyList<CalendarContentProperty> properties)
     {

--- a/src/DotnetAgents.CalDav.Core/Internal/Ical/CalendarTemporalResolver.cs
+++ b/src/DotnetAgents.CalDav.Core/Internal/Ical/CalendarTemporalResolver.cs
@@ -1,0 +1,268 @@
+using System.Globalization;
+using System.Text;
+using DotnetAgents.CalDav.Core.Models;
+using Ical.Net;
+using Ical.Net.CalendarComponents;
+using Ical.Net.DataTypes;
+using Ical.Net.Evaluation;
+using NodaTime;
+using CalendarProperty = DotnetAgents.CalDav.Core.Models.CalendarProperty;
+using IcalCalendar = Ical.Net.Calendar;
+
+namespace DotnetAgents.CalDav.Core.Internal.Ical;
+
+/// <summary>Resolves UTC and named-zone entity values without a host-zone fallback.</summary>
+internal sealed class CalendarTemporalResolver
+{
+    private const int MaximumZoneTransitions = 10_000;
+    private readonly IReadOnlyList<CalendarProperty> _properties;
+    private readonly IcalCalendar? _typedCalendar;
+    private readonly CancellationToken _cancellationToken;
+
+    public CalendarTemporalResolver(
+        IReadOnlyList<CalendarProperty> properties,
+        ReadOnlySpan<byte> authoritativeUtf8,
+        CancellationToken cancellationToken = default)
+    {
+        _properties = properties;
+        _cancellationToken = cancellationToken;
+        _typedCalendar = LoadTypedCalendar(authoritativeUtf8);
+    }
+
+    public ResolvedCalendarInstant Resolve(CalendarProperty? property)
+    {
+        _cancellationToken.ThrowIfCancellationRequested();
+        if (property is null)
+            return new(null, false);
+        if (property.ValueType == CalendarPropertyValueType.Date)
+            return new(null, true);
+        return ResolveToken(property.RawEncodedValue, GetTimeZoneId(property));
+    }
+
+    public bool CanResolve(CalendarProperty property)
+    {
+        _cancellationToken.ThrowIfCancellationRequested();
+        return property.ValueType switch
+        {
+            CalendarPropertyValueType.Date => false,
+            CalendarPropertyValueType.DateTime => property.RawEncodedValue
+                .Split(',', StringSplitOptions.None)
+                .All(token => ResolveToken(token, GetTimeZoneId(property)).Value is not null),
+            CalendarPropertyValueType.Period => property.RawEncodedValue
+                .Split(',', StringSplitOptions.None)
+                .All(token => CanResolvePeriod(token, GetTimeZoneId(property))),
+            _ => true
+        };
+    }
+
+    public ResolvedCalendarInstant ResolveToken(CalendarProperty property, string raw) =>
+        ResolveToken(raw, GetTimeZoneId(property));
+
+    public ResolvedCalendarInstant Resolve(CalDateTime value)
+    {
+        _cancellationToken.ThrowIfCancellationRequested();
+        if (!value.HasTime)
+            return new(null, true);
+        if (value.IsUtc)
+            return new(new DateTimeOffset(DateTime.SpecifyKind(value.Value, DateTimeKind.Utc)), false);
+        return value.TzId is { Length: > 0 } timeZoneId
+            ? ResolveLocal(DateTime.SpecifyKind(value.Value, DateTimeKind.Unspecified), timeZoneId)
+            : new(null, true);
+    }
+
+    private static IcalCalendar? LoadTypedCalendar(ReadOnlySpan<byte> authoritativeUtf8)
+    {
+        try
+        {
+            var replay = CalendarContentDocument.Parse(authoritativeUtf8).ReplayForTypedValidation();
+            return IcalCalendar.Load(Encoding.UTF8.GetString(replay));
+        }
+        catch (Exception exception) when (exception is FormatException or ArgumentException or InvalidOperationException)
+        {
+            return null;
+        }
+    }
+
+    private bool CanResolvePeriod(string period, string? timeZoneId)
+    {
+        var parts = period.Split('/', StringSplitOptions.None);
+        return parts.Length == 2
+            && ResolveToken(parts[0], timeZoneId).Value is not null
+            && (parts[1].StartsWith('P')
+                || parts[1].StartsWith("-P", StringComparison.Ordinal)
+                || ResolveToken(parts[1], timeZoneId).Value is not null);
+    }
+
+    private ResolvedCalendarInstant ResolveToken(string raw, string? timeZoneId)
+    {
+        _cancellationToken.ThrowIfCancellationRequested();
+        if (raw.EndsWith('Z'))
+        {
+            var parsed = DateTimeOffset.TryParseExact(
+                raw,
+                "yyyyMMdd'T'HHmmss'Z'",
+                CultureInfo.InvariantCulture,
+                DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
+                out var instant);
+            return new(parsed ? instant : null, false);
+        }
+        if (timeZoneId is null
+            || !DateTime.TryParseExact(raw, "yyyyMMdd'T'HHmmss", CultureInfo.InvariantCulture,
+                DateTimeStyles.None, out var local))
+            return new(null, true);
+
+        return ResolveLocal(local, timeZoneId);
+    }
+
+    private ResolvedCalendarInstant ResolveLocal(DateTime local, string timeZoneId)
+    {
+        _cancellationToken.ThrowIfCancellationRequested();
+        var rawDefinitionCount = CountRawLocalDefinitions(timeZoneId);
+        if (rawDefinitionCount > 1)
+            return new(null, true);
+        if (rawDefinitionCount == 0)
+            return ResolveFromIana(local, timeZoneId);
+        var typedDefinitions = FindTypedLocalDefinitions(timeZoneId);
+        return typedDefinitions.Count == 1
+            ? ResolveFromLocalDefinition(local, typedDefinitions[0], _cancellationToken)
+            : new(null, true);
+    }
+
+    private int CountRawLocalDefinitions(string timeZoneId) => _properties.Count(property =>
+        property.Name.Equals("TZID", StringComparison.OrdinalIgnoreCase)
+        && property.ComponentPath.Count == 2
+        && property.ComponentPath[1].Name.Equals("VTIMEZONE", StringComparison.OrdinalIgnoreCase)
+        && property.RawEncodedValue.Equals(timeZoneId, StringComparison.Ordinal));
+
+    private IReadOnlyList<VTimeZone> FindTypedLocalDefinitions(string timeZoneId) => _typedCalendar?.TimeZones
+        .Where(zone => string.Equals(zone.TzId, timeZoneId, StringComparison.Ordinal))
+        .ToArray() ?? [];
+
+    private static ResolvedCalendarInstant ResolveFromIana(DateTime local, string timeZoneId)
+    {
+        try
+        {
+            var zone = DateTimeZoneProviders.Tzdb.GetZoneOrNull(timeZoneId);
+            if (zone is null)
+                return new(null, true);
+            var mapping = zone.MapLocal(LocalDateTime.FromDateTime(local));
+            return mapping.Count == 1
+                ? new(mapping.Single().ToDateTimeOffset().ToUniversalTime(), false)
+                : new(null, true);
+        }
+        catch (ArgumentException)
+        {
+            return new(null, true);
+        }
+    }
+
+    private static ResolvedCalendarInstant ResolveFromLocalDefinition(
+        DateTime local,
+        VTimeZone zone,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (!TryGetConsistentTransitions(zone, local, cancellationToken, out var transitions)
+                || transitions.Length == 0
+                || IsAmbiguousOrInvalid(local, transitions))
+                return new(null, true);
+            var previous = transitions.LastOrDefault(item => item.LocalStart <= local);
+            var offset = previous?.OffsetTo ?? transitions[0].OffsetFrom;
+            var utcTicks = checked(local.Ticks - offset.Ticks);
+            return new(new DateTimeOffset(new DateTime(utcTicks, DateTimeKind.Utc)), false);
+        }
+        catch (Exception exception) when (exception is EvaluationLimitExceededException
+            or EvaluationOutOfRangeException
+            or ZoneTransitionLimitException
+            or FormatException
+            or ArgumentException
+            or OverflowException
+            or InvalidOperationException)
+        {
+            return new(null, true);
+        }
+    }
+
+    private static IEnumerable<ZoneTransition> GetTransitions(
+        VTimeZone zone,
+        DateTime local,
+        CancellationToken cancellationToken)
+    {
+        var count = 0;
+        var end = local.AddYears(1);
+        var options = new EvaluationOptions { MaxUnmatchedIncrementsLimit = MaximumZoneTransitions };
+        if (zone.TimeZoneInfos.Count == 0)
+            throw new InvalidOperationException("The VTIMEZONE has no observances.");
+        foreach (var observance in zone.TimeZoneInfos)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (observance.DtStart is null || observance.OffsetFrom is null || observance.OffsetTo is null)
+                throw new InvalidOperationException("The VTIMEZONE contains an incomplete observance.");
+            var from = (TimeSpan)observance.OffsetFrom;
+            var to = (TimeSpan)observance.OffsetTo;
+            foreach (var occurrence in observance.GetOccurrences(observance.DtStart, options))
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var transition = occurrence.Period.StartTime.Value;
+                if (transition > end)
+                    break;
+                count++;
+                if (count > MaximumZoneTransitions)
+                    throw new ZoneTransitionLimitException();
+                yield return new ZoneTransition(transition, from, to);
+            }
+        }
+    }
+
+    private static bool TryGetConsistentTransitions(
+        VTimeZone zone,
+        DateTime local,
+        CancellationToken cancellationToken,
+        out ZoneTransition[] transitions)
+    {
+        transitions = GetTransitions(zone, local, cancellationToken)
+            .Distinct()
+            .OrderBy(item => item.LocalStart)
+            .ToArray();
+        if (transitions.GroupBy(item => item.LocalStart).Any(group => group.Count() > 1))
+            return false;
+        for (var index = 1; index < transitions.Length; index++)
+        {
+            if (transitions[index - 1].OffsetTo != transitions[index].OffsetFrom)
+                return false;
+        }
+        return true;
+    }
+
+    private static bool IsAmbiguousOrInvalid(DateTime local, IEnumerable<ZoneTransition> transitions)
+    {
+        foreach (var transition in transitions)
+        {
+            var change = transition.OffsetTo - transition.OffsetFrom;
+            if (change > TimeSpan.Zero
+                && local >= transition.LocalStart
+                && local < transition.LocalStart + change)
+                return true;
+            if (change < TimeSpan.Zero
+                && local >= transition.LocalStart + change
+                && local < transition.LocalStart)
+                return true;
+        }
+        return false;
+    }
+
+    private static string? GetTimeZoneId(CalendarProperty property) => property.Parameters
+        .Where(parameter => parameter.Name.Equals("TZID", StringComparison.OrdinalIgnoreCase))
+        .SelectMany(parameter => parameter.Values)
+        .SingleOrDefault();
+
+    private sealed record ZoneTransition(DateTime LocalStart, TimeSpan OffsetFrom, TimeSpan OffsetTo);
+
+    private sealed class ZoneTransitionLimitException : Exception
+    {
+    }
+}
+
+internal readonly record struct ResolvedCalendarInstant(DateTimeOffset? Value, bool Unresolved);

--- a/src/DotnetAgents.CalDav.Core/Internal/Xml/DavRequestBuilder.cs
+++ b/src/DotnetAgents.CalDav.Core/Internal/Xml/DavRequestBuilder.cs
@@ -1,4 +1,5 @@
 using System.Xml.Linq;
+using DotnetAgents.CalDav.Core.Models;
 
 namespace DotnetAgents.CalDav.Core.Internal.Xml;
 
@@ -87,4 +88,59 @@ internal static class DavRequestBuilder
 
         return doc.ToString(SaveOptions.DisableFormatting);
     }
+
+    /// <summary>Builds a minimal Calendar Entity candidate REPORT for one requested kind.</summary>
+    public static string BuildCalendarEntityQuery(
+        CalendarEntityKind entityKind,
+        DateTimeOffset? from = null,
+        DateTimeOffset? to = null)
+    {
+        var entityFilter = new XElement(CalDav + "comp-filter",
+            new XAttribute("name", entityKind == CalendarEntityKind.Event ? "VEVENT" : "VTODO"));
+        if (from is not null && to is not null && TryGetSafeReportRange(from.Value, to.Value, out var reportFrom, out var reportTo))
+        {
+            entityFilter.Add(new XElement(CalDav + "time-range",
+                new XAttribute("start", FormatUtcSecond(reportFrom)),
+                new XAttribute("end", FormatUtcSecond(reportTo))));
+        }
+
+        var document = new XDocument(
+            new XDeclaration("1.0", "utf-8", null),
+            new XElement(CalDav + "calendar-query",
+                new XAttribute(XNamespace.Xmlns + "d", Dav.NamespaceName),
+                new XAttribute(XNamespace.Xmlns + "c", CalDav.NamespaceName),
+                new XElement(Dav + "prop", new XElement(Dav + "getetag")),
+                new XElement(CalDav + "filter",
+                    new XElement(CalDav + "comp-filter",
+                        new XAttribute("name", "VCALENDAR"),
+                        entityFilter))));
+        return document.ToString(SaveOptions.DisableFormatting);
+    }
+
+    private static bool TryGetSafeReportRange(
+        DateTimeOffset from,
+        DateTimeOffset to,
+        out DateTimeOffset reportFrom,
+        out DateTimeOffset reportTo)
+    {
+        reportFrom = from.AddTicks(-(from.Ticks % TimeSpan.TicksPerSecond));
+        var remainder = to.Ticks % TimeSpan.TicksPerSecond;
+        if (remainder == 0)
+        {
+            reportTo = to;
+            return true;
+        }
+        var ticksToAdd = TimeSpan.TicksPerSecond - remainder;
+        if (to.Ticks > DateTimeOffset.MaxValue.Ticks - ticksToAdd)
+        {
+            reportTo = default;
+            return false;
+        }
+        reportTo = to.AddTicks(ticksToAdd);
+        return true;
+    }
+
+    private static string FormatUtcSecond(DateTimeOffset value) => value.UtcDateTime.ToString(
+        "yyyyMMdd'T'HHmmss'Z'",
+        System.Globalization.CultureInfo.InvariantCulture);
 }

--- a/src/DotnetAgents.CalDav.Core/Internal/Xml/DavResponseParser.cs
+++ b/src/DotnetAgents.CalDav.Core/Internal/Xml/DavResponseParser.cs
@@ -66,6 +66,50 @@ internal static class DavResponseParser
             .ToList();
     }
 
+    /// <summary>Parses successful Calendar Object Resource hrefs from a REPORT multistatus.</summary>
+    public static IReadOnlyList<string> ParseCalendarResourceHrefs(string multistatusXml)
+    {
+        var document = ParseDocument(multistatusXml);
+        return document.Descendants(Dav + "response")
+            .Select(TryParseCalendarResourceHref)
+            .OfType<string>()
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+    }
+
+    /// <summary>Recognizes the bounded CalDAV precondition that rejects a REPORT filter.</summary>
+    public static bool IsSupportedFilterError(string responseXml)
+    {
+        try
+        {
+            var document = ParseDocument(responseXml);
+            return document.Descendants().Any(element =>
+                element.Name.Namespace == CalDav
+                && element.Name.LocalName is "supported-filter" or "supported-collation");
+        }
+        catch (XmlException)
+        {
+            return false;
+        }
+    }
+
+    private static string? TryParseCalendarResourceHref(XElement response)
+    {
+        var responseStatus = response.Element(Dav + "status");
+        var responseSucceeded = responseStatus is not null && IsSuccessStatus(responseStatus.Value);
+        var getEtagSucceeded = response.Elements(Dav + "propstat")
+            .Any(propStat => IsSuccessfulProperty(propStat, Dav + "getetag"));
+
+        if (!responseSucceeded && !getEtagSucceeded)
+            return null;
+
+        var href = response.Element(Dav + "href")?.Value?.Trim();
+        if (string.IsNullOrEmpty(href))
+            throw new XmlException("A successful WebDAV response is missing its href.");
+
+        return href;
+    }
+
     private static TaskList? TryParseTaskList(XElement response)
     {
         var href = response.Element(Dav + "href")?.Value?.Trim() ?? string.Empty;
@@ -209,7 +253,7 @@ internal static class DavResponseParser
     private static bool HasSuccessStatus(XElement response)
     {
         var status = response.Element(Dav + "status")?.Value;
-        return status is null || status.Contains("200");
+        return status is null || IsSuccessStatus(status);
     }
 
     private static string? GetPropValue(XElement response, XName propertyName)
@@ -222,15 +266,48 @@ internal static class DavResponseParser
         var propStats = response.Descendants(Dav + "propstat");
         foreach (var propStat in propStats)
         {
-            var status = propStat.Element(Dav + "status")?.Value;
-            if (status is not null && status.Contains("200"))
-            {
-                var prop = propStat.Element(Dav + "prop")?.Element(propertyName);
-                if (prop is not null)
-                    return prop;
-            }
+            if (IsSuccessfulProperty(propStat, propertyName))
+                return propStat.Element(Dav + "prop")!.Element(propertyName);
         }
 
         return null;
+    }
+
+    private static bool IsSuccessfulProperty(XElement propStat, XName propertyName)
+    {
+        var status = propStat.Element(Dav + "status")?.Value;
+        return status is not null
+            && IsSuccessStatus(status)
+            && propStat.Element(Dav + "prop")?.Element(propertyName) is not null;
+    }
+
+    private static bool IsSuccessStatus(string rawStatus)
+    {
+        var parts = rawStatus.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries);
+        if (parts.Length < 2
+            || !IsHttpVersion(parts[0])
+            || parts[1].Length != 3
+            || !int.TryParse(parts[1], System.Globalization.NumberStyles.None,
+                System.Globalization.CultureInfo.InvariantCulture, out var statusCode)
+            || statusCode is < 100 or > 599)
+        {
+            throw new XmlException("The WebDAV response contains a malformed HTTP status line.");
+        }
+
+        return statusCode is >= 200 and <= 299;
+    }
+
+    private static bool IsHttpVersion(string value)
+    {
+        if (!value.StartsWith("HTTP/", StringComparison.OrdinalIgnoreCase))
+            return false;
+        var version = value.AsSpan(5);
+        var dot = version.IndexOf('.');
+        return dot < 0
+            ? !version.IsEmpty && version.ContainsAnyExceptInRange('0', '9') is false
+            : dot > 0
+                && dot < version.Length - 1
+                && version[..dot].ContainsAnyExceptInRange('0', '9') is false
+                && version[(dot + 1)..].ContainsAnyExceptInRange('0', '9') is false;
     }
 }

--- a/src/DotnetAgents.CalDav.Core/InternalsVisibleTo.cs
+++ b/src/DotnetAgents.CalDav.Core/InternalsVisibleTo.cs
@@ -1,4 +1,5 @@
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("DotnetAgents.CalDav.Core.Tests.Unit")]
+[assembly: InternalsVisibleTo("DotnetAgents.CalDav.Mcp.Tests.Unit")]
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]

--- a/src/DotnetAgents.CalDav.Core/Models/CalendarDiscoveryResult.cs
+++ b/src/DotnetAgents.CalDav.Core/Models/CalendarDiscoveryResult.cs
@@ -32,6 +32,9 @@ public sealed class CalendarDiscoveryLimitException(int calendarCount) : Excepti
 /// <summary>Signals a CalDAV discovery response that cannot be used safely.</summary>
 public sealed class CalendarDiscoveryProtocolException(string message) : Exception(message);
 
+/// <summary>Signals that a mandatory CalDAV REPORT filter is unsupported.</summary>
+public sealed class CalendarDiscoveryUnsupportedCapabilityException(string message) : Exception(message);
+
 /// <summary>Typed outcome of resolving a configured default Calendar.</summary>
 public sealed record CalendarSelectionResult(
     CalendarSelectionCode Code,

--- a/src/DotnetAgents.CalDav.Core/Models/CalendarEntityQuery.cs
+++ b/src/DotnetAgents.CalDav.Core/Models/CalendarEntityQuery.cs
@@ -1,0 +1,75 @@
+namespace DotnetAgents.CalDav.Core.Models;
+
+/// <summary>Explicit Calendar Scope mode for a semantic query.</summary>
+public enum CalendarEntityScopeMode
+{
+    Default,
+    Selected,
+    All
+}
+
+/// <summary>Exact Calendar selector by display name or canonical href.</summary>
+public sealed record CalendarReference(string? Name = null, string? Href = null);
+
+/// <summary>Explicit Calendar Scope for a persisted Calendar Entity query.</summary>
+public sealed record CalendarEntityScope(CalendarEntityScopeMode Mode, CalendarReference? Calendar = null)
+{
+    public static CalendarEntityScope Default { get; } = new(CalendarEntityScopeMode.Default);
+
+    public static CalendarEntityScope All { get; } = new(CalendarEntityScopeMode.All);
+
+    public static CalendarEntityScope Selected(CalendarReference calendar) =>
+        new(CalendarEntityScopeMode.Selected, calendar);
+}
+
+/// <summary>Bounded semantic query for persisted Calendar Object Resources.</summary>
+public sealed record CalendarEntityQuery(
+    CalendarEntityScope Scope,
+    IReadOnlyList<CalendarEntityKind> EntityKinds,
+    DateTimeOffset? From = null,
+    DateTimeOffset? To = null);
+
+/// <summary>Typed Calendar Entity query outcome.</summary>
+public sealed record CalendarEntityQueryResult(
+    CalendarEntityQueryCode Code,
+    IReadOnlyList<CalendarResourceSnapshot> Items,
+    IReadOnlyList<CalendarResourceDiagnostic> Diagnostics,
+    IReadOnlyList<CalendarDescriptor> AuthorizedCandidates,
+    CalendarEntityQueryExecutionLimits? Limits = null)
+{
+    public static CalendarEntityQueryResult Success(
+        IReadOnlyList<CalendarResourceSnapshot> items,
+        IReadOnlyList<CalendarResourceDiagnostic>? diagnostics = null) =>
+        new(CalendarEntityQueryCode.Success, items, diagnostics ?? [], []);
+
+    public static CalendarEntityQueryResult Failure(
+        CalendarEntityQueryCode code,
+        IReadOnlyList<CalendarDescriptor>? authorizedCandidates = null,
+        CalendarEntityQueryExecutionLimits? limits = null) =>
+        new(code, [], [], authorizedCandidates ?? [], limits);
+}
+
+/// <summary>Truthful numeric observation when a Calendar Entity query exhausts a frozen budget.</summary>
+public sealed record CalendarEntityQueryExecutionLimits(
+    int? ResourcesInspected = null,
+    int? OccurrenceCount = null,
+    int? ByteCount = null);
+
+/// <summary>Closed service outcomes for Calendar Entity queries.</summary>
+public enum CalendarEntityQueryCode
+{
+    Success,
+    InvalidInput,
+    UnsafeScope,
+    NotFound,
+    Ambiguous,
+    OutsideScope,
+    EntityKindMismatch,
+    UnsupportedCapability,
+    ConcurrencyUnavailable,
+    LimitExhausted,
+    PayloadTooLarge,
+    UpstreamProtocolError,
+    TemporalUnresolved,
+    RecurrenceUnevaluable
+}

--- a/src/DotnetAgents.CalDav.Core/Services/CalendarEntityQueryEngine.cs
+++ b/src/DotnetAgents.CalDav.Core/Services/CalendarEntityQueryEngine.cs
@@ -1,0 +1,415 @@
+using DotnetAgents.CalDav.Core.Abstractions;
+using DotnetAgents.CalDav.Core.Configuration;
+using DotnetAgents.CalDav.Core.Internal.Ical;
+using DotnetAgents.CalDav.Core.Models;
+
+namespace DotnetAgents.CalDav.Core.Services;
+
+/// <summary>Owns bounded Calendar Scope planning, REPORT candidate collection, snapshot reads, and local filtering.</summary>
+internal sealed class CalendarEntityQueryEngine
+{
+    private const int MaximumDiagnostics = 32;
+    private const int MaximumQueryOccurrences = 5000;
+    private const int MaximumQueryResources = 5000;
+    private readonly ICalendarClient _calendarClient;
+    private readonly CalDavOptions _options;
+    private readonly Func<IReadOnlyList<CalendarDescriptor>, CalendarDiscoveryResult> _applyScope;
+    private readonly Func<CalendarEntityKind, IReadOnlyList<CalendarDescriptor>, IReadOnlyList<CalendarDescriptor>, CalendarSelectionResult>
+        _resolveDefault;
+
+    public CalendarEntityQueryEngine(
+        ICalendarClient calendarClient,
+        CalDavOptions options,
+        Func<IReadOnlyList<CalendarDescriptor>, CalendarDiscoveryResult> applyScope,
+        Func<CalendarEntityKind, IReadOnlyList<CalendarDescriptor>, IReadOnlyList<CalendarDescriptor>, CalendarSelectionResult> resolveDefault)
+    {
+        _calendarClient = calendarClient;
+        _options = options;
+        _applyScope = applyScope;
+        _resolveDefault = resolveDefault;
+    }
+
+    public async Task<CalendarEntityQueryResult> QueryAsync(
+        CalendarEntityQuery query,
+        CancellationToken cancellationToken)
+    {
+        if (!IsValidQueryShape(query))
+            return CalendarEntityQueryResult.Failure(CalendarEntityQueryCode.InvalidInput);
+        var prevalidation = PrevalidateSelectedHref(query);
+        if (prevalidation is not null)
+            return prevalidation;
+
+        var discovered = await _calendarClient.GetCalendarsAsync(cancellationToken);
+        var scopeResult = _applyScope(discovered);
+        var scoped = scopeResult.Items;
+        var plan = CreateSelectionPlan(query, discovered, scoped);
+        if (plan.Code != CalendarEntityQueryCode.Success)
+            return CalendarEntityQueryResult.Failure(plan.Code, plan.AuthorizedCandidates);
+
+        plan = plan with
+        {
+            Diagnostics = scopeResult.Diagnostics.Select(ToResourceDiagnostic)
+                .Concat(plan.Diagnostics)
+                .Take(MaximumDiagnostics)
+                .ToArray()
+        };
+        var candidates = await CollectCandidatesAsync(plan.Selections, query, cancellationToken);
+        if (candidates is null)
+            return CalendarEntityQueryResult.Failure(
+                CalendarEntityQueryCode.LimitExhausted,
+                limits: new CalendarEntityQueryExecutionLimits(ResourcesInspected: MaximumQueryResources + 1));
+        var fetched = await FetchSnapshotsAsync(candidates, plan.Diagnostics, cancellationToken);
+        if (fetched.Code != CalendarEntityQueryCode.Success)
+            return CalendarEntityQueryResult.Failure(fetched.Code, limits: fetched.Limits);
+
+        var filtered = ApplyFilters(fetched.Snapshots, query, fetched.Diagnostics, cancellationToken);
+        return filtered.Code == CalendarEntityQueryCode.Success
+            ? CalendarEntityQueryResult.Success(filtered.Snapshots, fetched.Diagnostics)
+            : CalendarEntityQueryResult.Failure(
+                filtered.Code,
+                limits: filtered.Code == CalendarEntityQueryCode.LimitExhausted
+                    && filtered.OccurrenceCount > 0
+                    ? new CalendarEntityQueryExecutionLimits(OccurrenceCount: filtered.OccurrenceCount)
+                    : null);
+    }
+
+    private async Task<IReadOnlyDictionary<string, CalendarDescriptor>?> CollectCandidatesAsync(
+        IReadOnlyList<(CalendarDescriptor Calendar, CalendarEntityKind Kind)> selections,
+        CalendarEntityQuery query,
+        CancellationToken cancellationToken)
+    {
+        var candidates = new Dictionary<string, CalendarDescriptor>(StringComparer.Ordinal);
+        foreach (var selection in selections.Distinct())
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var hrefs = await _calendarClient.QueryCalendarResourceHrefsAsync(
+                selection.Calendar.Href,
+                selection.Kind,
+                query.From,
+                query.To,
+                cancellationToken);
+            foreach (var href in hrefs)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                if (candidates.TryAdd(href, selection.Calendar)
+                    && candidates.Count > MaximumQueryResources)
+                    return null;
+            }
+        }
+        return candidates;
+    }
+
+    private async Task<CandidateFetchResult> FetchSnapshotsAsync(
+        IReadOnlyDictionary<string, CalendarDescriptor> candidates,
+        IReadOnlyList<CalendarResourceDiagnostic> initialDiagnostics,
+        CancellationToken cancellationToken)
+    {
+        var snapshots = new List<CalendarResourceSnapshot>();
+        var snapshotKeys = new HashSet<(string CalendarHref, string ResourceHref)>();
+        var diagnostics = initialDiagnostics.ToList();
+        foreach (var candidate in candidates)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var read = await ReadSnapshotAsync(candidate.Value, candidate.Key, cancellationToken);
+            if (read.Code == CalendarResourceReadCode.NotFound)
+            {
+                AddDiagnostic(diagnostics, "resource_disappeared_during_query",
+                    "A REPORT candidate disappeared before its authoritative snapshot was read.");
+                continue;
+            }
+            if (read.Code != CalendarResourceReadCode.Success || read.Snapshot is null)
+                return CandidateFetchResult.Failure(
+                    MapReadFailure(read.Code),
+                    read.ObservedByteCount is null
+                        ? null
+                        : new CalendarEntityQueryExecutionLimits(ByteCount: read.ObservedByteCount));
+            if (snapshotKeys.Add((read.Snapshot.CalendarHref, read.Snapshot.ResourceHref)))
+                snapshots.Add(read.Snapshot);
+            if (read.Snapshot.Projection.Kind == CalendarResourceProjectionKind.Opaque)
+            {
+                AddDiagnostic(diagnostics, "opaque_filter_unresolved",
+                    "An opaque Calendar Object Resource could not be classified by the requested semantic filters.");
+            }
+        }
+        return CandidateFetchResult.Success(snapshots, diagnostics);
+    }
+
+    private async Task<CalendarResourceRead> ReadSnapshotAsync(
+        CalendarDescriptor calendar,
+        string href,
+        CancellationToken cancellationToken)
+    {
+        var read = await _calendarClient.GetCalendarResourceAsync(href, cancellationToken);
+        if (read.Code != CalendarResourceReadCode.Success)
+            return read;
+        return CalendarResourceProjector.AttachSnapshot(calendar.Href, read);
+    }
+
+    private static FilterResult ApplyFilters(
+        IReadOnlyList<CalendarResourceSnapshot> snapshots,
+        CalendarEntityQuery query,
+        ICollection<CalendarResourceDiagnostic> diagnostics,
+        CancellationToken cancellationToken)
+    {
+        var filtered = new List<CalendarResourceSnapshot>();
+        var occurrenceCount = 0;
+        foreach (var snapshot in snapshots.Where(snapshot => MatchesKind(snapshot, query.EntityKinds)))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (snapshot.Projection.Kind == CalendarResourceProjectionKind.Opaque)
+            {
+                filtered.Add(snapshot);
+                continue;
+            }
+            var temporal = CalendarEntityTemporalMatcher.Matches(
+                snapshot,
+                query.From,
+                query.To,
+                cancellationToken);
+            occurrenceCount += temporal.OccurrenceCount;
+            if (temporal.Match == CalendarEntityTemporalMatch.LimitExhausted || occurrenceCount > MaximumQueryOccurrences)
+                return FilterResult.Failure(CalendarEntityQueryCode.LimitExhausted, occurrenceCount);
+            if (temporal.Match == CalendarEntityTemporalMatch.Unresolved)
+                return FilterResult.Failure(CalendarEntityQueryCode.TemporalUnresolved);
+            if (temporal.Match == CalendarEntityTemporalMatch.Unevaluable)
+                return FilterResult.Failure(CalendarEntityQueryCode.RecurrenceUnevaluable);
+            if (temporal.Match == CalendarEntityTemporalMatch.NoMatch)
+                continue;
+            filtered.Add(snapshot);
+        }
+        return FilterResult.Success(filtered.OrderBy(snapshot => snapshot.CalendarHref, StringComparer.Ordinal)
+            .ThenBy(snapshot => snapshot.ResourceHref, StringComparer.Ordinal)
+            .ToArray());
+    }
+
+    private static bool MatchesKind(CalendarResourceSnapshot snapshot, IReadOnlyList<CalendarEntityKind> kinds) =>
+        snapshot.Projection.Kind == CalendarResourceProjectionKind.Opaque
+        || kinds.Any(kind => snapshot.Projection.Kind == ToProjectionKind(kind));
+
+    private static void AddDiagnostic(
+        ICollection<CalendarResourceDiagnostic> diagnostics,
+        string code,
+        string message)
+    {
+        if (diagnostics.Count < MaximumDiagnostics)
+            diagnostics.Add(new CalendarResourceDiagnostic(code, message, CalendarResourceDiagnosticSeverity.Warning));
+    }
+
+    private CalendarEntityQueryResult? PrevalidateSelectedHref(CalendarEntityQuery query)
+    {
+        var href = query.Scope.Mode == CalendarEntityScopeMode.Selected ? query.Scope.Calendar?.Href : null;
+        if (href is null)
+            return null;
+        if (!TryValidateCalendarHref(href))
+            return CalendarEntityQueryResult.Failure(CalendarEntityQueryCode.UnsafeScope);
+        var configuredScope = ParseScope(_options.CalendarHrefs);
+        return configuredScope.Count > 0 && !configuredScope.Contains(href, StringComparer.Ordinal)
+            ? CalendarEntityQueryResult.Failure(CalendarEntityQueryCode.OutsideScope)
+            : null;
+    }
+
+    private bool TryValidateCalendarHref(string href)
+    {
+        if (!Uri.TryCreate(href, UriKind.Absolute, out var candidate) || !HasSafeCalendarShape(candidate, href))
+            return false;
+        var origin = new Uri(_options.BaseUrl, UriKind.Absolute);
+        return string.Equals(origin.Scheme, candidate.Scheme, StringComparison.OrdinalIgnoreCase)
+            && string.Equals(origin.Host, candidate.Host, StringComparison.OrdinalIgnoreCase)
+            && origin.Port == candidate.Port;
+    }
+
+    private static bool HasSafeCalendarShape(Uri candidate, string href) =>
+        candidate.Scheme is "http" or "https"
+        && string.IsNullOrEmpty(candidate.UserInfo)
+        && string.IsNullOrEmpty(candidate.Fragment)
+        && string.IsNullOrEmpty(candidate.Query)
+        && !candidate.AbsolutePath.Contains("%2F", StringComparison.OrdinalIgnoreCase)
+        && !candidate.AbsolutePath.Contains("%5C", StringComparison.OrdinalIgnoreCase)
+        && !href.Contains("%2e", StringComparison.OrdinalIgnoreCase)
+        && !href.Contains('\\')
+        && string.Equals(candidate.AbsoluteUri, href, StringComparison.Ordinal);
+
+    private QuerySelectionPlan CreateSelectionPlan(
+        CalendarEntityQuery query,
+        IReadOnlyList<CalendarDescriptor> discovered,
+        IReadOnlyList<CalendarDescriptor> scoped) => query.Scope.Mode switch
+        {
+            CalendarEntityScopeMode.Default => CreateDefaultSelectionPlan(query.EntityKinds, discovered, scoped),
+            CalendarEntityScopeMode.Selected => CreateSelectedSelectionPlan(query, scoped),
+            CalendarEntityScopeMode.All => CreateAllSelectionPlan(query.EntityKinds, scoped),
+            _ => QuerySelectionPlan.Failure(CalendarEntityQueryCode.InvalidInput)
+        };
+
+    private QuerySelectionPlan CreateDefaultSelectionPlan(
+        IReadOnlyList<CalendarEntityKind> kinds,
+        IReadOnlyList<CalendarDescriptor> discovered,
+        IReadOnlyList<CalendarDescriptor> scoped)
+    {
+        var selections = new List<(CalendarDescriptor Calendar, CalendarEntityKind Kind)>();
+        foreach (var kind in kinds)
+        {
+            var selection = _resolveDefault(kind, discovered, scoped);
+            if (selection.Code != CalendarSelectionCode.Success)
+                return QuerySelectionPlan.Failure(MapSelectionCode(selection.Code), selection.Candidates);
+            selections.Add((selection.Calendar!, kind));
+        }
+        return QuerySelectionPlan.Success(selections);
+    }
+
+    private static QuerySelectionPlan CreateSelectedSelectionPlan(
+        CalendarEntityQuery query,
+        IReadOnlyList<CalendarDescriptor> scoped)
+    {
+        var scopedMatches = FindCalendarMatches(scoped, query.Scope.Calendar!);
+        if (scopedMatches.Length == 0)
+            return QuerySelectionPlan.Failure(CalendarEntityQueryCode.NotFound, scoped.Take(MaximumDiagnostics).ToArray());
+        if (scopedMatches.Length > 1)
+            return QuerySelectionPlan.Failure(CalendarEntityQueryCode.Ambiguous, scopedMatches.Take(MaximumDiagnostics).ToArray());
+        return CreateSelectedSuccess(query.EntityKinds, scopedMatches[0]);
+    }
+
+    private static QuerySelectionPlan CreateSelectedSuccess(
+        IReadOnlyList<CalendarEntityKind> kinds,
+        CalendarDescriptor calendar)
+    {
+        IReadOnlyList<CalendarResourceDiagnostic> diagnostics = kinds.Any(kind => !SupportsEntityKind(calendar, kind))
+            ? [new CalendarResourceDiagnostic(
+                "entity_kind_not_advertised",
+                "The selected Calendar does not advertise one requested Entity Kind.",
+                CalendarResourceDiagnosticSeverity.Warning)]
+            : [];
+        return QuerySelectionPlan.Success(kinds.Select(kind => (calendar, kind)).ToArray(), diagnostics);
+    }
+
+    private static QuerySelectionPlan CreateAllSelectionPlan(
+        IReadOnlyList<CalendarEntityKind> kinds,
+        IReadOnlyList<CalendarDescriptor> scoped) => QuerySelectionPlan.Success(scoped
+            .SelectMany(calendar => kinds.Where(kind => SupportsEntityKind(calendar, kind)).Select(kind => (calendar, kind)))
+            .ToArray());
+
+    private static CalendarDescriptor[] FindCalendarMatches(
+        IReadOnlyList<CalendarDescriptor> calendars,
+        CalendarReference reference) => calendars.Where(calendar => reference.Name is not null
+            ? string.Equals(calendar.DisplayName?.Trim(), reference.Name, StringComparison.OrdinalIgnoreCase)
+            : string.Equals(calendar.Href, reference.Href, StringComparison.Ordinal)).ToArray();
+
+    private static bool IsValidQueryShape(CalendarEntityQuery query) =>
+        query.EntityKinds.Count is >= 1 and <= 2
+        && query.EntityKinds.All(kind => kind is CalendarEntityKind.Event or CalendarEntityKind.Todo)
+        && query.EntityKinds.Distinct().Count() == query.EntityKinds.Count
+        && HasValidWindow(query.From, query.To)
+        && query.Scope.Mode switch
+        {
+            CalendarEntityScopeMode.Default => query.Scope.Calendar is null,
+            CalendarEntityScopeMode.Selected => HasExactlyOneSelector(query.Scope.Calendar),
+            CalendarEntityScopeMode.All => query.Scope.Calendar is null,
+            _ => false
+        };
+
+    private static bool HasValidWindow(DateTimeOffset? from, DateTimeOffset? to)
+    {
+        if (from is null || to is null)
+            return from is null && to is null;
+        return from.Value.Offset == TimeSpan.Zero
+            && to.Value.Offset == TimeSpan.Zero
+            && to > from
+            && to - from <= TimeSpan.FromDays(366);
+    }
+
+    private static bool HasExactlyOneSelector(CalendarReference? reference)
+    {
+        if (reference is null)
+            return false;
+        var hasName = !string.IsNullOrWhiteSpace(reference.Name);
+        var hasHref = !string.IsNullOrWhiteSpace(reference.Href);
+        return hasName != hasHref && (!hasName || IsCanonicalName(reference.Name));
+    }
+
+    private static bool IsCanonicalName(string? name) => !string.IsNullOrWhiteSpace(name)
+        && string.Equals(name, name.Trim(), StringComparison.Ordinal);
+
+    private static bool SupportsEntityKind(CalendarDescriptor calendar, CalendarEntityKind entityKind) => entityKind switch
+    {
+        CalendarEntityKind.Event => calendar.EventSupport != EntityKindSupport.NotAdvertised,
+        CalendarEntityKind.Todo => calendar.TodoSupport != EntityKindSupport.NotAdvertised,
+        _ => false
+    };
+
+    private static CalendarResourceProjectionKind ToProjectionKind(CalendarEntityKind kind) => kind switch
+    {
+        CalendarEntityKind.Event => CalendarResourceProjectionKind.Event,
+        _ => CalendarResourceProjectionKind.Todo
+    };
+
+    private static CalendarEntityQueryCode MapSelectionCode(CalendarSelectionCode code) => code switch
+    {
+        CalendarSelectionCode.NotFound => CalendarEntityQueryCode.NotFound,
+        CalendarSelectionCode.Ambiguous => CalendarEntityQueryCode.Ambiguous,
+        CalendarSelectionCode.OutsideScope => CalendarEntityQueryCode.OutsideScope,
+        _ => CalendarEntityQueryCode.UnsupportedCapability
+    };
+
+    private static CalendarEntityQueryCode MapReadFailure(CalendarResourceReadCode code) => code switch
+    {
+        CalendarResourceReadCode.ConcurrencyUnavailable => CalendarEntityQueryCode.ConcurrencyUnavailable,
+        CalendarResourceReadCode.PayloadTooLarge => CalendarEntityQueryCode.PayloadTooLarge,
+        _ => CalendarEntityQueryCode.UpstreamProtocolError
+    };
+
+    private static CalendarResourceDiagnostic ToResourceDiagnostic(CalendarDiagnostic diagnostic) => new(
+        diagnostic.Code,
+        diagnostic.Message,
+        diagnostic.Severity switch
+        {
+            CalendarDiagnosticSeverity.Info => CalendarResourceDiagnosticSeverity.Info,
+            CalendarDiagnosticSeverity.Warning => CalendarResourceDiagnosticSeverity.Warning,
+            _ => CalendarResourceDiagnosticSeverity.Error
+        });
+
+    private static IReadOnlyList<string> ParseScope(string? calendarHrefs) => calendarHrefs is null
+        ? []
+        : calendarHrefs.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+    private sealed record CandidateFetchResult(
+        CalendarEntityQueryCode Code,
+        IReadOnlyList<CalendarResourceSnapshot> Snapshots,
+        List<CalendarResourceDiagnostic> Diagnostics,
+        CalendarEntityQueryExecutionLimits? Limits)
+    {
+        public static CandidateFetchResult Success(
+            IReadOnlyList<CalendarResourceSnapshot> snapshots,
+            List<CalendarResourceDiagnostic> diagnostics) => new(CalendarEntityQueryCode.Success, snapshots, diagnostics, null);
+
+        public static CandidateFetchResult Failure(
+            CalendarEntityQueryCode code,
+            CalendarEntityQueryExecutionLimits? limits = null) => new(code, [], [], limits);
+    }
+
+    private sealed record FilterResult(
+        CalendarEntityQueryCode Code,
+        IReadOnlyList<CalendarResourceSnapshot> Snapshots,
+        int OccurrenceCount)
+    {
+        public static FilterResult Success(IReadOnlyList<CalendarResourceSnapshot> snapshots) =>
+            new(CalendarEntityQueryCode.Success, snapshots, 0);
+
+        public static FilterResult Failure(CalendarEntityQueryCode code, int occurrenceCount = 0) =>
+            new(code, [], occurrenceCount);
+    }
+
+    private sealed record QuerySelectionPlan(
+        CalendarEntityQueryCode Code,
+        IReadOnlyList<(CalendarDescriptor Calendar, CalendarEntityKind Kind)> Selections,
+        IReadOnlyList<CalendarResourceDiagnostic> Diagnostics,
+        IReadOnlyList<CalendarDescriptor> AuthorizedCandidates)
+    {
+        public static QuerySelectionPlan Success(
+            IReadOnlyList<(CalendarDescriptor Calendar, CalendarEntityKind Kind)> selections,
+            IReadOnlyList<CalendarResourceDiagnostic>? diagnostics = null) =>
+            new(CalendarEntityQueryCode.Success, selections, diagnostics ?? [], []);
+
+        public static QuerySelectionPlan Failure(
+            CalendarEntityQueryCode code,
+            IReadOnlyList<CalendarDescriptor>? authorizedCandidates = null) => new(code, [], [], authorizedCandidates ?? []);
+    }
+}

--- a/src/DotnetAgents.CalDav.Core/Services/CalendarService.cs
+++ b/src/DotnetAgents.CalDav.Core/Services/CalendarService.cs
@@ -39,7 +39,14 @@ internal sealed class CalendarService : ICalendarService
         CancellationToken cancellationToken)
     {
         var discovered = await _calendarClient.GetCalendarsAsync(cancellationToken);
-        var scoped = ApplyScope(discovered).Items;
+        return ResolveDefaultCalendar(entityKind, discovered, ApplyScope(discovered).Items);
+    }
+
+    private CalendarSelectionResult ResolveDefaultCalendar(
+        CalendarEntityKind entityKind,
+        IReadOnlyList<CalendarDescriptor> discovered,
+        IReadOnlyList<CalendarDescriptor> scoped)
+    {
         var authorizedCandidates = scoped.Take(MaximumDiagnostics).ToArray();
         var name = GetDefaultName(entityKind);
         if (string.IsNullOrWhiteSpace(name))
@@ -65,6 +72,15 @@ internal sealed class CalendarService : ICalendarService
     }
 
     /// <inheritdoc />
+    public async Task<CalendarEntityQueryResult> QueryEntitiesAsync(
+        CalendarEntityQuery query,
+        CancellationToken cancellationToken) => await new CalendarEntityQueryEngine(
+            _calendarClient,
+            _options.Value,
+            ApplyScope,
+            ResolveDefaultCalendar).QueryAsync(query, cancellationToken);
+
+    /// <inheritdoc />
     public async Task<CalendarResourceRead> GetResourceAsync(string href, CancellationToken cancellationToken)
     {
         if (!TryGetCanonicalResourceUri(href, out var resourceUri))
@@ -82,20 +98,18 @@ internal sealed class CalendarService : ICalendarService
         if (calendar is null)
             return new CalendarResourceRead(CalendarResourceReadCode.OutsideScope);
 
+        return await CreateSnapshotAsync(calendar, href, cancellationToken);
+    }
+
+    private async Task<CalendarResourceRead> CreateSnapshotAsync(
+        CalendarDescriptor calendar,
+        string href,
+        CancellationToken cancellationToken)
+    {
         var read = await _calendarClient.GetCalendarResourceAsync(href, cancellationToken);
         if (read.Code != CalendarResourceReadCode.Success)
             return read;
-
-        var projection = CalendarResourceProjector.Project(read.AuthoritativeUtf8.Span);
-        var snapshot = new CalendarResourceSnapshot(
-            calendar.Href,
-            read.ResourceHref!,
-            read.EntityTag!,
-            read.AuthoritativeUtf8,
-            projection.Properties,
-            projection.Projection,
-            projection.Diagnostics);
-        return read with { Snapshot = snapshot };
+        return CalendarResourceProjector.AttachSnapshot(calendar.Href, read);
     }
 
     private bool TryGetCanonicalResourceUri(string href, out Uri resourceUri)

--- a/src/DotnetAgents.CalDav.Mcp/Hosting/CalDavHostBuilder.cs
+++ b/src/DotnetAgents.CalDav.Mcp/Hosting/CalDavHostBuilder.cs
@@ -30,7 +30,10 @@ public sealed class CalDavHostBuilder
 
         var mcpBuilder = builder.Services.AddMcpServer(options => options.ProtocolVersion = "2026-07-28")
             .WithStdioServerTransport()
+            .WithMessageFilters(filters => filters.AddIncomingFilter(StrictToolInputGuard.Incoming))
+            .WithRequestFilters(filters => filters.AddCallToolFilter(StrictToolInputGuard.CallTool))
             .WithTools<CalendarTools>()
+            .WithTools<CalendarEntityTools>()
             .WithTools<CalendarResourceTools>()
             .WithTools<TaskListTools>()
             .WithTools<ChatTaskTools>();
@@ -60,6 +63,11 @@ public sealed class CalDavHostBuilder
         builder.Services.PostConfigure<ModelContextProtocol.Server.McpServerOptions>(ConfigureCalendarToolContract);
 
         builder.Services.AddSingleton(TimeProvider.System);
+        builder.Services.AddSingleton<CalendarEntityCursorProtector>();
+        builder.Services.AddTransient(serviceProvider => new CalendarEntityTools(
+            serviceProvider.GetRequiredService<DotnetAgents.CalDav.Core.Abstractions.ICalendarService>(),
+            serviceProvider.GetRequiredService<CalendarEntityCursorProtector>(),
+            serviceProvider.GetRequiredService<TimeProvider>()));
         builder.Services.AddTransient<TaskCompletion>();
 
         return builder;
@@ -72,6 +80,7 @@ public sealed class CalDavHostBuilder
 
         options.ToolCollection = new OrderedToolCollection(options.ToolCollection.ToArray());
         ConfigureTool(options.ToolCollection, "calendars.list");
+        ConfigureTool(options.ToolCollection, "calendar_entities.query");
         ConfigureTool(options.ToolCollection, "calendar_resources.get");
         ConfigureTool(options.ToolCollection, "calendar_resources.exact_get");
     }

--- a/src/DotnetAgents.CalDav.Mcp/Hosting/OrderedToolCollection.cs
+++ b/src/DotnetAgents.CalDav.Mcp/Hosting/OrderedToolCollection.cs
@@ -8,14 +8,15 @@ internal sealed class OrderedToolCollection : McpServerPrimitiveCollection<McpSe
     private static readonly IReadOnlyDictionary<string, int> Ranks = new Dictionary<string, int>(StringComparer.Ordinal)
     {
         ["calendars.list"] = 0,
-        ["calendar_resources.get"] = 1,
-        ["calendar_resources.exact_get"] = 2,
-        ["list_task_lists"] = 3,
-        ["show_tasks"] = 4,
-        ["add_task"] = 5,
-        ["find_tasks"] = 6,
-        ["complete_task_by_summary"] = 7,
-        ["delete_task_by_summary"] = 8
+        ["calendar_entities.query"] = 1,
+        ["calendar_resources.get"] = 2,
+        ["calendar_resources.exact_get"] = 3,
+        ["list_task_lists"] = 4,
+        ["show_tasks"] = 5,
+        ["add_task"] = 6,
+        ["find_tasks"] = 7,
+        ["complete_task_by_summary"] = 8,
+        ["delete_task_by_summary"] = 9
     };
 
     public OrderedToolCollection(IEnumerable<McpServerTool> tools)

--- a/src/DotnetAgents.CalDav.Mcp/Hosting/StrictToolInputGuard.cs
+++ b/src/DotnetAgents.CalDav.Mcp/Hosting/StrictToolInputGuard.cs
@@ -1,0 +1,114 @@
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using DotnetAgents.CalDav.Mcp.Tools;
+using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
+
+namespace DotnetAgents.CalDav.Mcp.Hosting;
+
+/// <summary>Preserves strict JSON argument evidence before the SDK materializes tool dictionaries.</summary>
+internal static class StrictToolInputGuard
+{
+    private const string ArgumentBytesKey = "DotnetAgents.CalDav.Mcp.StrictToolInputGuard.ArgumentBytes";
+    private const string DuplicateKey = "DotnetAgents.CalDav.Mcp.StrictToolInputGuard.Duplicate";
+
+    public static McpMessageFilter Incoming => next => async (context, cancellationToken) =>
+    {
+        Inspect(context);
+        await next(context, cancellationToken).ConfigureAwait(false);
+    };
+
+    public static McpRequestFilter<CallToolRequestParams, CallToolResult> CallTool => next =>
+        (request, cancellationToken) =>
+        {
+            var evidence = new StrictToolInputEvidence(
+                request.Items.TryGetValue(ArgumentBytesKey, out var size) && size is int argumentBytes
+                    ? argumentBytes
+                    : null,
+                request.Items.TryGetValue(DuplicateKey, out var duplicate) && duplicate is true);
+            var rejection = Reject(request.Params?.Name, evidence);
+            return rejection is null
+                ? next(request, cancellationToken)
+                : ValueTask.FromResult(rejection);
+        };
+
+    internal static CallToolResult? Reject(string? toolName, StrictToolInputEvidence evidence)
+    {
+        if (toolName != "calendar_entities.query")
+            return null;
+        if (evidence.ArgumentBytes > CalendarEntityTools.MaximumArgumentBytes)
+            return CalendarEntityTools.CreateInputGuardError(payloadTooLarge: true);
+        return evidence.HasDuplicateProperty
+            ? CalendarEntityTools.CreateInputGuardError(payloadTooLarge: false)
+            : null;
+    }
+
+    internal static StrictToolInputEvidence InspectArguments(JsonNode? arguments)
+    {
+        if (arguments is null)
+            return default;
+        try
+        {
+            var utf8 = Encoding.UTF8.GetBytes(arguments.ToJsonString());
+            return new StrictToolInputEvidence(utf8.Length, ContainsDuplicateProperty(utf8));
+        }
+        catch (InvalidOperationException)
+        {
+            return new StrictToolInputEvidence(null, true);
+        }
+    }
+
+    internal static void Inspect(MessageContext context)
+    {
+        if (context.JsonRpcMessage is not JsonRpcRequest { Method: "tools/call", Params: JsonObject parameters })
+            return;
+
+        JsonNode? arguments;
+        try
+        {
+            arguments = parameters["arguments"];
+        }
+        catch (InvalidOperationException)
+        {
+            context.Items[DuplicateKey] = true;
+            return;
+        }
+        var evidence = InspectArguments(arguments);
+        if (evidence.ArgumentBytes is { } argumentBytes)
+            context.Items[ArgumentBytesKey] = argumentBytes;
+        if (evidence.HasDuplicateProperty)
+            context.Items[DuplicateKey] = true;
+    }
+
+    private static bool ContainsDuplicateProperty(ReadOnlySpan<byte> utf8)
+    {
+        var reader = new Utf8JsonReader(utf8);
+        var scopes = new Stack<HashSet<string>?>();
+        while (reader.Read())
+        {
+            switch (reader.TokenType)
+            {
+                case JsonTokenType.StartObject:
+                    scopes.Push(new HashSet<string>(StringComparer.Ordinal));
+                    break;
+                case JsonTokenType.StartArray:
+                    scopes.Push(null);
+                    break;
+                case JsonTokenType.EndObject:
+                case JsonTokenType.EndArray:
+                    scopes.Pop();
+                    break;
+                case JsonTokenType.PropertyName:
+                    if (scopes.Peek() is { } properties && !properties.Add(reader.GetString()!))
+                        return true;
+                    break;
+            }
+        }
+        return false;
+    }
+}
+
+internal readonly record struct StrictToolInputEvidence(
+    int? ArgumentBytes,
+    bool HasDuplicateProperty);

--- a/src/DotnetAgents.CalDav.Mcp/Tools/CalendarEntityCursorProtector.cs
+++ b/src/DotnetAgents.CalDav.Mcp/Tools/CalendarEntityCursorProtector.cs
@@ -1,0 +1,181 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using DotnetAgents.CalDav.Core.Configuration;
+using Microsoft.Extensions.Options;
+
+namespace DotnetAgents.CalDav.Mcp.Tools;
+
+/// <summary>Process-local authenticated cursor codec for non-snapshot Calendar Entity pagination.</summary>
+internal sealed class CalendarEntityCursorProtector
+{
+    internal const int MaximumCursorCharacters = 2048;
+    private static readonly TimeSpan Lifetime = TimeSpan.FromMinutes(10);
+    private readonly byte[] _encryptionKey;
+    private readonly string _credentialContext;
+    private readonly TimeProvider _timeProvider;
+
+    public CalendarEntityCursorProtector(TimeProvider timeProvider, IOptions<CalDavOptions> options)
+        : this(timeProvider, options, RandomNumberGenerator.GetBytes(64))
+    {
+    }
+
+    internal CalendarEntityCursorProtector(
+        TimeProvider timeProvider,
+        IOptions<CalDavOptions> options,
+        byte[] keyMaterial)
+    {
+        ArgumentNullException.ThrowIfNull(timeProvider);
+        ArgumentNullException.ThrowIfNull(options);
+        if (keyMaterial.Length != 64)
+            throw new ArgumentException("Cursor key material must contain 64 bytes.", nameof(keyMaterial));
+
+        _timeProvider = timeProvider;
+        _encryptionKey = keyMaterial[..32];
+        var configured = options.Value;
+        _credentialContext = Hash(JsonSerializer.SerializeToUtf8Bytes(new CredentialBinding(
+            configured.BaseUrl,
+            configured.Username,
+            configured.Password)));
+    }
+
+    public string Protect(string queryContext, string calendarHref, string resourceHref)
+    {
+        var payload = JsonSerializer.SerializeToUtf8Bytes(new CursorPayload(
+            1,
+            _timeProvider.GetUtcNow().Add(Lifetime).ToUnixTimeSeconds(),
+            Hash(queryContext),
+            _credentialContext,
+            calendarHref,
+            resourceHref));
+        var nonce = RandomNumberGenerator.GetBytes(12);
+        var cipherText = new byte[payload.Length];
+        var tag = new byte[16];
+        using (var cipher = new AesGcm(_encryptionKey, tag.Length))
+            cipher.Encrypt(nonce, payload, cipherText, tag);
+
+        var encoded = Base64UrlEncode([.. nonce, .. tag, .. cipherText]);
+        if (encoded.Length > MaximumCursorCharacters)
+            throw new InvalidOperationException("The protected cursor exceeds the safe size limit.");
+        return encoded;
+    }
+
+    public bool TryProtect(
+        string queryContext,
+        string calendarHref,
+        string resourceHref,
+        out string? cursor)
+    {
+        try
+        {
+            cursor = Protect(queryContext, calendarHref, resourceHref);
+            return true;
+        }
+        catch (InvalidOperationException)
+        {
+            cursor = null;
+            return false;
+        }
+    }
+
+    public bool TryUnprotect(
+        string cursor,
+        string queryContext,
+        out CalendarEntityContinuation continuation,
+        out bool expired)
+    {
+        continuation = default;
+        expired = false;
+        if (!TryDecodeProtectedCursor(cursor, out var protectedBytes))
+            return false;
+
+        var nonce = protectedBytes.AsSpan(0, 12);
+        var tag = protectedBytes.AsSpan(12, 16);
+        var cipherText = protectedBytes.AsSpan(28);
+        var payload = new byte[cipherText.Length];
+        try
+        {
+            using var cipher = new AesGcm(_encryptionKey, tag.Length);
+            cipher.Decrypt(nonce, cipherText, tag, payload);
+            var decoded = JsonSerializer.Deserialize<CursorPayload>(payload);
+            if (!IsValidPayload(decoded, queryContext))
+                return false;
+
+            var validPayload = decoded!;
+            expired = _timeProvider.GetUtcNow().ToUnixTimeSeconds() >= validPayload.ExpiresAtUnixSeconds;
+            if (expired)
+                return false;
+            continuation = new CalendarEntityContinuation(validPayload.CalendarHref, validPayload.ResourceHref);
+            return true;
+        }
+        catch (CryptographicException)
+        {
+            return false;
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
+    }
+
+    private bool IsValidPayload(CursorPayload? payload, string queryContext) => payload is not null
+        && payload.Version == 1
+        && !string.IsNullOrEmpty(payload.CalendarHref)
+        && !string.IsNullOrEmpty(payload.ResourceHref)
+        && HasFixedTimeMatch(payload.QueryHash, Hash(queryContext))
+        && HasFixedTimeMatch(payload.CredentialContext, _credentialContext);
+
+    private static bool HasFixedTimeMatch(string left, string right) => CryptographicOperations.FixedTimeEquals(
+        Encoding.UTF8.GetBytes(left),
+        Encoding.UTF8.GetBytes(right));
+
+    private static bool TryDecodeProtectedCursor(string cursor, out byte[] protectedBytes)
+    {
+        protectedBytes = [];
+        return cursor.Length is > 0 and <= MaximumCursorCharacters
+            && TryBase64UrlDecode(cursor, out protectedBytes)
+            && protectedBytes.Length > 28;
+    }
+
+    private static string Hash(string value) => Hash(Encoding.UTF8.GetBytes(value));
+
+    private static string Hash(ReadOnlySpan<byte> value) => Convert.ToHexStringLower(SHA256.HashData(value));
+
+    private static string Base64UrlEncode(ReadOnlySpan<byte> value) => Convert.ToBase64String(value)
+        .TrimEnd('=')
+        .Replace('+', '-')
+        .Replace('/', '_');
+
+    private static bool TryBase64UrlDecode(string value, out byte[] bytes)
+    {
+        bytes = [];
+        if (value.Any(character => !(char.IsAsciiLetterOrDigit(character) || character is '-' or '_')))
+            return false;
+        var padded = value.Replace('-', '+').Replace('_', '/');
+        padded += new string('=', (4 - (padded.Length % 4)) % 4);
+        try
+        {
+            bytes = Convert.FromBase64String(padded);
+            return string.Equals(Base64UrlEncode(bytes), value, StringComparison.Ordinal);
+        }
+        catch (FormatException)
+        {
+            return false;
+        }
+    }
+
+    private sealed record CursorPayload(
+        int Version,
+        long ExpiresAtUnixSeconds,
+        string QueryHash,
+        string CredentialContext,
+        string CalendarHref,
+        string ResourceHref);
+
+    private sealed record CredentialBinding(
+        string BaseUrl,
+        string Username,
+        string Password);
+}
+
+internal readonly record struct CalendarEntityContinuation(string CalendarHref, string ResourceHref);

--- a/src/DotnetAgents.CalDav.Mcp/Tools/CalendarEntityTools.cs
+++ b/src/DotnetAgents.CalDav.Mcp/Tools/CalendarEntityTools.cs
@@ -1,0 +1,770 @@
+using System.ComponentModel;
+using System.Globalization;
+using System.Net;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Xml;
+using DotnetAgents.CalDav.Core.Abstractions;
+using DotnetAgents.CalDav.Core.Models;
+using Microsoft.Extensions.DependencyInjection;
+using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
+
+namespace DotnetAgents.CalDav.Mcp.Tools;
+
+/// <summary>Bounded persisted Calendar Entity queries.</summary>
+[McpServerToolType]
+public sealed class CalendarEntityTools
+{
+    private const int DefaultPageSize = 50;
+    private const int MaximumPageSize = 200;
+    internal const int MaximumArgumentBytes = 256 * 1024;
+    internal const int MaximumHumanReadableBytes = 64 * 1024;
+    internal const int MaximumStructuredResultBytes = 4 * 1024 * 1024;
+    private readonly ICalendarService _calendarService;
+    private readonly CalendarEntityCursorProtector _cursorProtector;
+    private readonly TimeProvider _timeProvider;
+
+    public CalendarEntityTools(IServiceProvider services)
+        : this(
+            services.GetRequiredService<ICalendarService>(),
+            services.GetRequiredService<CalendarEntityCursorProtector>(),
+            services.GetRequiredService<TimeProvider>())
+    {
+    }
+
+    internal CalendarEntityTools(
+        ICalendarService calendarService,
+        CalendarEntityCursorProtector cursorProtector,
+        TimeProvider timeProvider)
+    {
+        _calendarService = calendarService;
+        _cursorProtector = cursorProtector;
+        _timeProvider = timeProvider;
+    }
+
+    /// <summary>Queries persisted Event and To-do Calendar Object Resources.</summary>
+    [McpServerTool(
+        Name = "calendar_entities.query",
+        ReadOnly = true,
+        Destructive = false,
+        Idempotent = true,
+        OpenWorld = true,
+        UseStructuredContent = true,
+        OutputSchemaType = typeof(CalendarEntityQuerySuccessResult)),
+     Description("Query persisted Event or To-do resource snapshots within an explicit Calendar Scope.")]
+    public Task<CallToolResult> QueryAsync(
+        RequestContext<CallToolRequestParams> requestContext,
+        CancellationToken cancellationToken) =>
+        QueryRawAsync(requestContext.Params?.Arguments, cancellationToken);
+
+    internal async Task<CallToolResult> QueryRawAsync(
+        IDictionary<string, JsonElement>? arguments,
+        CancellationToken cancellationToken)
+    {
+        if (arguments is not null && JsonSerializer.SerializeToUtf8Bytes(arguments).Length > MaximumArgumentBytes)
+            return EnsureBoundedResult(Error("payload_too_large", "limitsAndAdmission", "The query arguments exceed the safe payload limit.", false, "admissionAndPayload"));
+        if (!TryDeserializeRawArguments(arguments, out var parsed))
+            return EnsureBoundedResult(Error("invalid_input", "input", "The Calendar Entity query input is invalid.", false, "schemaLexicalDiscriminator"));
+        return await QueryCoreAsync(
+            parsed.Scope,
+            parsed.EntityKinds,
+            cancellationToken,
+            parsed.From,
+            parsed.To,
+            parsed.PageSize,
+            parsed.Cursor,
+            arguments);
+    }
+
+    internal static CallToolResult CreateInputGuardError(bool payloadTooLarge) => EnsureBoundedResult(
+        payloadTooLarge
+            ? Error("payload_too_large", "limitsAndAdmission", "The query arguments exceed the safe payload limit.", false, "admissionAndPayload")
+            : Error("invalid_input", "input", "The Calendar Entity query input is invalid.", false, "schemaLexicalDiscriminator"));
+
+    internal async Task<CallToolResult> QueryCoreAsync(
+        CalendarEntityScopeArgument scope,
+        IReadOnlyList<string> entityKinds,
+        CancellationToken cancellationToken,
+        CalendarEntityUtcArgument? from = null,
+        CalendarEntityUtcArgument? to = null,
+        int? pageSize = null,
+        string? cursor = null,
+        IDictionary<string, JsonElement>? rawArguments = null)
+    {
+        if (MeasureArguments(scope, entityKinds, from, to, pageSize, cursor, rawArguments) > MaximumArgumentBytes)
+            return EnsureBoundedResult(Error("payload_too_large", "limitsAndAdmission", "The query arguments exceed the safe payload limit.", false, "admissionAndPayload"));
+        if (!TryPrepareQuery(
+                scope,
+                entityKinds,
+                from,
+                to,
+                pageSize,
+                cursor,
+                rawArguments,
+                out var query,
+                out var effectivePageSize))
+        {
+            return EnsureBoundedResult(Error("invalid_input", "input", "The Calendar Entity query input is invalid.", false, "schemaLexicalDiscriminator"));
+        }
+
+        var queryContext = CreateQueryContext(query, effectivePageSize);
+        CalendarEntityContinuation? continuation = null;
+        if (cursor is not null)
+        {
+            if (!_cursorProtector.TryUnprotect(cursor, queryContext, out var decoded, out _))
+                return EnsureBoundedResult(Error("invalid_input", "input", "The continuation cursor is invalid or expired.", false, "schemaLexicalDiscriminator"));
+            continuation = decoded;
+        }
+
+        var result = await ExecuteQuerySafelyAsync(
+            query,
+            continuation,
+            queryContext,
+            effectivePageSize,
+            cancellationToken);
+        return EnsureBoundedResult(result);
+    }
+
+    private static bool TryPrepareQuery(
+        CalendarEntityScopeArgument scope,
+        IReadOnlyList<string> entityKinds,
+        CalendarEntityUtcArgument? from,
+        CalendarEntityUtcArgument? to,
+        int? pageSize,
+        string? cursor,
+        IDictionary<string, JsonElement>? rawArguments,
+        out CalendarEntityQuery query,
+        out int effectivePageSize)
+    {
+        query = null!;
+        effectivePageSize = pageSize ?? DefaultPageSize;
+        return HasFrozenRawShape(rawArguments)
+            && TryCreateQuery(scope, entityKinds, from, to, out query)
+            && effectivePageSize is >= 1 and <= MaximumPageSize
+            && (cursor is null || cursor.Length <= CalendarEntityCursorProtector.MaximumCursorCharacters);
+    }
+
+    private async Task<CallToolResult> ExecuteQuerySafelyAsync(
+        CalendarEntityQuery query,
+        CalendarEntityContinuation? continuation,
+        string queryContext,
+        int effectivePageSize,
+        CancellationToken cancellationToken)
+    {
+        var deadlineAt = _timeProvider.GetUtcNow().AddSeconds(30);
+        using var deadline = new CancellationTokenSource(TimeSpan.FromSeconds(30), _timeProvider);
+        using var linked = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, deadline.Token);
+        try
+        {
+            var result = await _calendarService.QueryEntitiesAsync(query, linked.Token);
+            ThrowIfDeadlineExpired(deadlineAt, linked.Token);
+            if (result.Code != CalendarEntityQueryCode.Success)
+                return MapQueryFailure(result);
+            return CreatePage(result, continuation, queryContext, effectivePageSize, deadlineAt, linked.Token);
+        }
+        catch (CalendarDiscoveryLimitException exception)
+        {
+            return Error("limit_exhausted", "limitsAndAdmission", "The query exceeded the Calendar limit.", false,
+                "admissionAndPayload", new CalendarEntityExecutionLimits(CalendarCount: exception.CalendarCount));
+        }
+        catch (HttpRequestException exception)
+        {
+            return MapHttpFailure(exception.StatusCode);
+        }
+        catch (OperationCanceledException) when (deadline.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+        {
+            return DeadlineError();
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            return Error("upstream_unavailable", "upstream", "The Calendar Entity query is temporarily unavailable.", true, "execution");
+        }
+        catch (TimeoutException)
+        {
+            return Error("upstream_unavailable", "upstream", "The Calendar Entity query is temporarily unavailable.", true, "execution");
+        }
+        catch (XmlException)
+        {
+            return ProtocolError();
+        }
+        catch (CalendarDiscoveryProtocolException)
+        {
+            return ProtocolError();
+        }
+        catch (CalendarDiscoveryUnsupportedCapabilityException)
+        {
+            return Error("unsupported_capability", "capabilityAndProjection",
+                "The server does not support the required Calendar query capability.", false,
+                "selectionDiscoveryCapability");
+        }
+        catch (CalendarEntityDeadlineException)
+        {
+            return DeadlineError();
+        }
+    }
+
+    private CallToolResult CreatePage(
+        CalendarEntityQueryResult result,
+        CalendarEntityContinuation? continuation,
+        string queryContext,
+        int pageSize,
+        DateTimeOffset deadlineAt,
+        CancellationToken cancellationToken)
+    {
+        var eligible = result.Items.Where(item => continuation is null || IsAfter(item, continuation.Value)).ToArray();
+        var page = new List<CalendarSnapshotResult>(Math.Min(pageSize, eligible.Length));
+        for (var index = 0; index < eligible.Length && page.Count < pageSize; index++)
+        {
+            ThrowIfDeadlineExpired(deadlineAt, cancellationToken);
+            page.Add(CalendarSnapshotResult.FromSnapshot(eligible[index]));
+            var hasMore = index + 1 < eligible.Length;
+            if (!TryCreateCursor(hasMore, queryContext, eligible[index], out var candidateCursor))
+                return CursorPayloadError();
+            var candidate = CreateSuccess(page, result.Diagnostics, hasMore ? candidateCursor : null);
+            if (MeasureResult(candidate) <= MaximumStructuredResultBytes)
+                continue;
+
+            page.RemoveAt(page.Count - 1);
+            if (page.Count == 0)
+                return Error("payload_too_large", "limitsAndAdmission", "One Calendar Entity cannot fit in a result page.", false, "admissionAndPayload");
+            break;
+        }
+
+        ThrowIfDeadlineExpired(deadlineAt, cancellationToken);
+        string? nextCursor = null;
+        if (page.Count < eligible.Length && !_cursorProtector.TryProtect(
+                queryContext, page[^1].Calendar.Href, page[^1].ResourceRevision.Href, out nextCursor))
+            return CursorPayloadError();
+        return CreateSuccess(page, result.Diagnostics, nextCursor);
+    }
+
+    private bool TryCreateCursor(
+        bool required,
+        string queryContext,
+        CalendarResourceSnapshot item,
+        out string? cursor)
+    {
+        cursor = null;
+        return !required || _cursorProtector.TryProtect(
+            queryContext,
+            item.CalendarHref,
+            item.ResourceHref,
+            out cursor);
+    }
+
+    private void ThrowIfDeadlineExpired(DateTimeOffset deadlineAt, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        if (_timeProvider.GetUtcNow() >= deadlineAt)
+            throw new CalendarEntityDeadlineException();
+    }
+
+    private static CallToolResult DeadlineError() => Error(
+        "limit_exhausted",
+        "limitsAndAdmission",
+        "The Calendar Entity query exhausted the elapsed_time execution budget.",
+        false,
+        "execution");
+
+    private static CallToolResult CursorPayloadError() => Error(
+        "payload_too_large",
+        "limitsAndAdmission",
+        "The continuation cursor exceeds the safe payload limit.",
+        false,
+        "admissionAndPayload");
+
+    private static CallToolResult CreateSuccess(
+        IReadOnlyList<CalendarSnapshotResult> items,
+        IReadOnlyList<CalendarResourceDiagnostic> diagnostics,
+        string? nextCursor) => new()
+        {
+            IsError = false,
+            StructuredContent = JsonSerializer.SerializeToElement(new CalendarEntityQuerySuccessResult(
+                "success",
+                items,
+                diagnostics.Select(CalendarDiagnosticResult.FromResourceDiagnostic).ToArray(),
+                new CalendarPagination("non_snapshot", nextCursor))),
+            Content = [new TextContentBlock { Text = "Calendar Entity query completed." }]
+        };
+
+    private static bool IsAfter(CalendarResourceSnapshot item, CalendarEntityContinuation continuation)
+    {
+        var calendarComparison = string.CompareOrdinal(item.CalendarHref, continuation.CalendarHref);
+        return calendarComparison > 0
+            || calendarComparison == 0 && string.CompareOrdinal(item.ResourceHref, continuation.ResourceHref) > 0;
+    }
+
+    private static CallToolResult MapQueryFailure(CalendarEntityQueryResult result)
+    {
+        var candidates = result.AuthorizedCandidates.Select(CalendarAuthorizedCandidateResult.FromDescriptor).ToArray();
+        return result.Code switch
+        {
+            CalendarEntityQueryCode.InvalidInput => Error("invalid_input", "input", "The Calendar Entity query input is invalid.", false, "schemaLexicalDiscriminator"),
+            CalendarEntityQueryCode.UnsafeScope => Error("invalid_input", "input", "The Calendar Entity query Calendar href is unsafe.", false, "originScopeAuthorization"),
+            CalendarEntityQueryCode.NotFound => Error("not_found", "selection", "No matching authorized Calendar was found.", false, "selectionDiscoveryCapability", candidates: candidates),
+            CalendarEntityQueryCode.Ambiguous => Error("ambiguous", "selection", "The Calendar selector matched more than one authorized Calendar.", false, "selectionDiscoveryCapability", candidates: candidates),
+            CalendarEntityQueryCode.OutsideScope => Error("outside_scope", "selection", "The selected Calendar is outside the configured Calendar Scope.", false, "originScopeAuthorization", candidates: candidates),
+            CalendarEntityQueryCode.EntityKindMismatch => Error("entity_kind_mismatch", "selection", "The requested Entity Kind does not match the resource.", false, "completeResourceSemantics"),
+            CalendarEntityQueryCode.UnsupportedCapability => Error("unsupported_capability", "capabilityAndProjection", "The server does not support the required Calendar query capability.", false, "selectionDiscoveryCapability"),
+            CalendarEntityQueryCode.ConcurrencyUnavailable => Error("concurrency_unavailable", "state", "A query candidate did not provide a strong Entity Tag.", false, "targetRevision"),
+            CalendarEntityQueryCode.LimitExhausted => Error(
+                "limit_exhausted",
+                "limitsAndAdmission",
+                "The Calendar Entity query exhausted its execution budget.",
+                false,
+                "execution",
+                result.Limits is null
+                    ? null
+                    : new CalendarEntityExecutionLimits(
+                        result.Limits.ResourcesInspected,
+                        OccurrenceCount: result.Limits.OccurrenceCount,
+                        ByteCount: result.Limits.ByteCount)),
+            CalendarEntityQueryCode.PayloadTooLarge => Error(
+                "payload_too_large",
+                "limitsAndAdmission",
+                "A Calendar Object Resource exceeds the safe payload limit.",
+                false,
+                "admissionAndPayload",
+                result.Limits?.ByteCount is { } byteCount
+                    ? new CalendarEntityExecutionLimits(ByteCount: byteCount)
+                    : null),
+            CalendarEntityQueryCode.TemporalUnresolved => Error("temporal_unresolved", "capabilityAndProjection", "Temporal evaluation could not be resolved.", false, "completeResourceSemantics"),
+            CalendarEntityQueryCode.RecurrenceUnevaluable => Error("recurrence_unevaluable", "capabilityAndProjection", "The Recurrence Set could not be evaluated.", false, "completeResourceSemantics"),
+            _ => ProtocolError()
+        };
+    }
+
+    private static CallToolResult MapHttpFailure(HttpStatusCode? statusCode) => statusCode switch
+    {
+        HttpStatusCode.Unauthorized => Error("upstream_unauthorized", "upstream", "The Calendar Entity query was not authorized.", false, "execution"),
+        HttpStatusCode.Forbidden => Error("upstream_forbidden", "upstream", "The Calendar Entity query was forbidden.", false, "execution"),
+        HttpStatusCode.TooManyRequests => Error("upstream_rate_limited", "upstream", "The Calendar Entity query is rate limited.", true, "execution"),
+        HttpStatusCode.MethodNotAllowed or HttpStatusCode.NotImplemented => Error("unsupported_capability", "capabilityAndProjection", "The server does not support the required Calendar query capability.", false, "selectionDiscoveryCapability"),
+        HttpStatusCode.RequestEntityTooLarge => Error("payload_too_large", "limitsAndAdmission", "The Calendar Entity query response is too large.", false, "admissionAndPayload"),
+        HttpStatusCode.Conflict or HttpStatusCode.PreconditionFailed => Error("conflict", "state", "The Calendar Entity query encountered an upstream state conflict.", false, "execution"),
+        HttpStatusCode.RequestTimeout => Error("upstream_unavailable", "upstream", "The Calendar Entity query is temporarily unavailable.", true, "execution"),
+        HttpStatusCode.InsufficientStorage => Error("upstream_unavailable", "upstream", "The Calendar Entity query is unavailable.", false, "execution"),
+        null => Error("upstream_unavailable", "upstream", "The Calendar Entity query is temporarily unavailable.", true, "execution"),
+        >= HttpStatusCode.InternalServerError => Error("upstream_unavailable", "upstream", "The Calendar Entity query is temporarily unavailable.", true, "execution"),
+        _ => ProtocolError()
+    };
+
+    private static CallToolResult ProtocolError() => Error(
+        "upstream_protocol_error",
+        "upstream",
+        "The Calendar Entity query returned an invalid response.",
+        false,
+        "execution");
+
+    private static CallToolResult Error(
+        string code,
+        string category,
+        string message,
+        bool retryable,
+        string phase,
+        CalendarEntityExecutionLimits? limits = null,
+        IReadOnlyList<CalendarAuthorizedCandidateResult>? candidates = null) => new()
+        {
+            IsError = true,
+            StructuredContent = JsonSerializer.SerializeToElement(new CalendarEntityQueryErrorResult(
+                code,
+                category,
+                message,
+                retryable,
+                phase,
+                limits,
+                candidates is { Count: > 0 } ? candidates : null)),
+            Content = [new TextContentBlock { Text = "Calendar Entity query failed." }]
+        };
+
+    private static bool TryCreateQuery(
+        CalendarEntityScopeArgument scope,
+        IReadOnlyList<string> entityKinds,
+        CalendarEntityUtcArgument? from,
+        CalendarEntityUtcArgument? to,
+        out CalendarEntityQuery query)
+    {
+        query = null!;
+        if (!TryCreateScope(scope, out var domainScope)
+            || !TryCreateKinds(entityKinds, out var domainKinds)
+            || !TryCreateWindow(from, to, out var domainFrom, out var domainTo))
+            return false;
+        query = new CalendarEntityQuery(domainScope, domainKinds, domainFrom, domainTo);
+        return true;
+    }
+
+    private static bool TryCreateScope(CalendarEntityScopeArgument scope, out CalendarEntityScope domainScope)
+    {
+        domainScope = null!;
+        if (scope.Mode == "default" && scope.Calendar is null)
+        {
+            domainScope = CalendarEntityScope.Default;
+            return true;
+        }
+        if (scope.Mode == "all" && scope.Calendar is null)
+        {
+            domainScope = CalendarEntityScope.All;
+            return true;
+        }
+        if (scope.Mode != "selected" || scope.Calendar is null)
+            return false;
+        return scope.Calendar.By switch
+        {
+            "name" => TryCreateNameScope(scope.Calendar, out domainScope),
+            "href" => TryCreateHrefScope(scope.Calendar, out domainScope),
+            _ => false
+        };
+    }
+
+    private static bool TryCreateNameScope(
+        CalendarEntityReferenceArgument reference,
+        out CalendarEntityScope domainScope)
+    {
+        domainScope = null!;
+        if (reference.Name is not { Length: > 0 } name || name != name.Trim() || reference.Href is not null)
+            return false;
+        domainScope = CalendarEntityScope.Selected(new CalendarReference(Name: name));
+        return true;
+    }
+
+    private static bool TryCreateHrefScope(
+        CalendarEntityReferenceArgument reference,
+        out CalendarEntityScope domainScope)
+    {
+        domainScope = null!;
+        if (reference.Href is not { Length: > 0 } href || reference.Name is not null)
+            return false;
+        domainScope = CalendarEntityScope.Selected(new CalendarReference(Href: href));
+        return true;
+    }
+
+    private static bool TryCreateKinds(IReadOnlyList<string> values, out IReadOnlyList<CalendarEntityKind> kinds)
+    {
+        kinds = [];
+        if (values.Count is < 1 or > 2 || values.Distinct(StringComparer.Ordinal).Count() != values.Count)
+            return false;
+        var parsed = new List<CalendarEntityKind>(values.Count);
+        foreach (var value in values)
+        {
+            if (value == "event")
+                parsed.Add(CalendarEntityKind.Event);
+            else if (value == "todo")
+                parsed.Add(CalendarEntityKind.Todo);
+            else
+                return false;
+        }
+        kinds = parsed;
+        return true;
+    }
+
+    private static bool TryCreateWindow(
+        CalendarEntityUtcArgument? from,
+        CalendarEntityUtcArgument? to,
+        out DateTimeOffset? domainFrom,
+        out DateTimeOffset? domainTo)
+    {
+        domainFrom = null;
+        domainTo = null;
+        if (from is null || to is null)
+            return from is null && to is null;
+        return TryParseUtc(from, out domainFrom) && TryParseUtc(to, out domainTo);
+    }
+
+    private static bool TryParseUtc(CalendarEntityUtcArgument argument, out DateTimeOffset? value)
+    {
+        value = null;
+        if (argument.Kind != "utcDateTime")
+            return false;
+        var lexical = argument.Value;
+        var hasFraction = lexical.Length > 20 && lexical.Length >= 22 && lexical[19] == '.';
+        var secondLexical = hasFraction ? lexical[..19] + "Z" : lexical;
+        if (!DateTimeOffset.TryParseExact(
+                secondLexical,
+                "yyyy-MM-dd'T'HH:mm:ss'Z'",
+                CultureInfo.InvariantCulture,
+                DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
+                out var parsed))
+            return false;
+        if (!hasFraction)
+        {
+            value = parsed;
+            return true;
+        }
+        var fraction = lexical.AsSpan(20, lexical.Length - 21);
+        if (lexical[^1] != 'Z' || fraction.IsEmpty || !fraction.ToString().All(char.IsAsciiDigit))
+            return false;
+        return TryApplyFraction(parsed, fraction, out value);
+    }
+
+    private static bool TryApplyFraction(
+        DateTimeOffset parsed,
+        ReadOnlySpan<char> fraction,
+        out DateTimeOffset? value)
+    {
+        value = null;
+        var representedDigits = Math.Min(7, fraction.Length);
+        var ticksText = fraction[..representedDigits].ToString().PadRight(7, '0');
+        var ticks = int.Parse(ticksText, CultureInfo.InvariantCulture);
+        if (fraction[representedDigits..].ContainsAnyExcept('0'))
+            ticks++;
+        if (ticks == TimeSpan.TicksPerSecond)
+        {
+            if (parsed.Ticks > DateTimeOffset.MaxValue.Ticks - TimeSpan.TicksPerSecond)
+                return false;
+            parsed = parsed.AddSeconds(1);
+            ticks = 0;
+        }
+        value = parsed.AddTicks(ticks);
+        return true;
+    }
+
+    private static int MeasureArguments(
+        CalendarEntityScopeArgument scope,
+        IReadOnlyList<string> entityKinds,
+        CalendarEntityUtcArgument? from,
+        CalendarEntityUtcArgument? to,
+        int? pageSize,
+        string? cursor,
+        IDictionary<string, JsonElement>? rawArguments) => rawArguments is { } raw
+            ? JsonSerializer.SerializeToUtf8Bytes(raw).Length
+            : JsonSerializer.SerializeToUtf8Bytes(new
+            {
+                scope,
+                entityKinds,
+                from,
+                to,
+                pageSize,
+                cursor
+            }).Length;
+
+    private static bool TryDeserializeRawArguments(
+        IDictionary<string, JsonElement>? arguments,
+        out CalendarEntityRawArguments parsed)
+    {
+        parsed = null!;
+        if (arguments is null
+            || !arguments.TryGetValue("scope", out var scopeElement)
+            || !arguments.TryGetValue("entityKinds", out var kindsElement)
+            || !HasFrozenRawShape(arguments))
+            return false;
+        try
+        {
+            var scope = scopeElement.Deserialize<CalendarEntityScopeArgument>();
+            var kinds = kindsElement.Deserialize<string[]>();
+            if (scope is null || kinds is null)
+                return false;
+            parsed = new CalendarEntityRawArguments(
+                scope,
+                kinds,
+                DeserializeOptional<CalendarEntityUtcArgument>(arguments, "from"),
+                DeserializeOptional<CalendarEntityUtcArgument>(arguments, "to"),
+                DeserializeOptional<int?>(arguments, "pageSize"),
+                DeserializeOptional<string>(arguments, "cursor"));
+            return !HasPresentNull(arguments, "from")
+                && !HasPresentNull(arguments, "to")
+                && !HasPresentNull(arguments, "pageSize")
+                && !HasPresentNull(arguments, "cursor");
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
+        catch (InvalidOperationException)
+        {
+            return false;
+        }
+    }
+
+    private static T? DeserializeOptional<T>(IDictionary<string, JsonElement> arguments, string name) =>
+        arguments.TryGetValue(name, out var element) ? element.Deserialize<T>() : default;
+
+    private static bool HasPresentNull(IDictionary<string, JsonElement> arguments, string name) =>
+        arguments.TryGetValue(name, out var element) && element.ValueKind == JsonValueKind.Null;
+
+    internal static bool HasFrozenRawShape(IDictionary<string, JsonElement>? arguments)
+    {
+        if (arguments is null)
+            return true;
+        var allowed = new[] { "scope", "entityKinds", "from", "to", "pageSize", "cursor" };
+        if (arguments.Keys.Any(key => !allowed.Contains(key, StringComparer.Ordinal)))
+            return false;
+        return (!arguments.TryGetValue("scope", out var scope) || HasScopeShape(scope))
+            && (!arguments.TryGetValue("from", out var from) || HasTemporalShape(from))
+            && (!arguments.TryGetValue("to", out var to) || HasTemporalShape(to));
+    }
+
+    private static bool HasScopeShape(JsonElement scope)
+    {
+        if (!TryGetUniqueProperties(scope, out var properties)
+            || !properties.TryGetValue("mode", out var modeElement)
+            || modeElement.ValueKind != JsonValueKind.String)
+            return false;
+        var mode = modeElement.GetString();
+        if (mode is "default" or "all")
+            return properties.Count == 1;
+        return mode == "selected"
+            && properties.Count == 2
+            && properties.TryGetValue("calendar", out var calendar)
+            && HasCalendarReferenceShape(calendar);
+    }
+
+    private static bool HasCalendarReferenceShape(JsonElement calendar)
+    {
+        if (!TryGetUniqueProperties(calendar, out var properties)
+            || !properties.TryGetValue("by", out var byElement)
+            || byElement.ValueKind != JsonValueKind.String
+            || properties.Count != 2)
+            return false;
+        var by = byElement.GetString();
+        return by == "name" && properties.ContainsKey("name")
+            || by == "href" && properties.ContainsKey("href");
+    }
+
+    private static bool HasTemporalShape(JsonElement temporal) =>
+        TryGetUniqueProperties(temporal, out var properties)
+        && properties.Count == 2
+        && properties.ContainsKey("kind")
+        && properties.ContainsKey("value");
+
+    private static bool TryGetUniqueProperties(
+        JsonElement element,
+        out Dictionary<string, JsonElement> properties)
+    {
+        properties = new Dictionary<string, JsonElement>(StringComparer.Ordinal);
+        if (element.ValueKind != JsonValueKind.Object)
+            return false;
+        foreach (var property in element.EnumerateObject())
+        {
+            if (!properties.TryAdd(property.Name, property.Value))
+                return false;
+        }
+        return true;
+    }
+
+    internal static int MeasureResult(CallToolResult result) => JsonSerializer.SerializeToUtf8Bytes(result).Length;
+
+    internal static int MeasureHumanReadableResult(CallToolResult result)
+    {
+        var diagnostics = result.StructuredContent is { ValueKind: JsonValueKind.Object } structured
+            && structured.TryGetProperty("diagnostics", out var value)
+            ? value
+            : JsonSerializer.SerializeToElement(Array.Empty<object>());
+        return JsonSerializer.SerializeToUtf8Bytes(new CalendarHumanReadableBudget(
+            result.Content.OfType<TextContentBlock>().Select(block => block.Text).ToArray(),
+            diagnostics)).Length;
+    }
+
+    internal static CallToolResult EnsureBoundedResult(CallToolResult result)
+    {
+        var humanReadableBytes = MeasureHumanReadableResult(result);
+        if (humanReadableBytes > MaximumHumanReadableBytes)
+        {
+            return Error(
+                "payload_too_large",
+                "limitsAndAdmission",
+                "The Calendar Entity query human-readable result exceeds the safe payload limit.",
+                false,
+                "admissionAndPayload",
+                new CalendarEntityExecutionLimits(ByteCount: humanReadableBytes));
+        }
+        var observedBytes = MeasureResult(result);
+        return observedBytes <= MaximumStructuredResultBytes
+            ? result
+            : Error(
+                "payload_too_large",
+                "limitsAndAdmission",
+                "The Calendar Entity query result exceeds the safe payload limit.",
+                false,
+                "admissionAndPayload",
+                new CalendarEntityExecutionLimits(ByteCount: observedBytes));
+    }
+
+    private static string CreateQueryContext(CalendarEntityQuery query, int pageSize)
+    {
+        var selectorKind = query.Scope.Calendar?.Name is not null ? "name" : "href";
+        var selectorValue = query.Scope.Calendar?.Name is not null
+            ? query.Scope.Calendar.Name.ToUpperInvariant()
+            : query.Scope.Calendar?.Href;
+        return JsonSerializer.Serialize(new CalendarEntityCursorQueryBinding(
+            query.Scope.Mode,
+            selectorKind,
+            selectorValue,
+            query.EntityKinds.Order().Select(kind => kind.ToString()).ToArray(),
+            query.From?.ToString("O", CultureInfo.InvariantCulture) ?? string.Empty,
+            query.To?.ToString("O", CultureInfo.InvariantCulture) ?? string.Empty,
+            pageSize));
+    }
+
+    private sealed record CalendarEntityCursorQueryBinding(
+        CalendarEntityScopeMode ScopeMode,
+        string SelectorKind,
+        string? SelectorValue,
+        IReadOnlyList<string> EntityKinds,
+        string From,
+        string To,
+        int PageSize);
+
+    private sealed record CalendarEntityRawArguments(
+        CalendarEntityScopeArgument Scope,
+        IReadOnlyList<string> EntityKinds,
+        CalendarEntityUtcArgument? From,
+        CalendarEntityUtcArgument? To,
+        int? PageSize,
+        string? Cursor);
+
+    private sealed record CalendarHumanReadableBudget(
+        IReadOnlyList<string> Text,
+        JsonElement Diagnostics);
+
+    private sealed class CalendarEntityDeadlineException : Exception
+    {
+    }
+}
+
+public sealed record CalendarEntityScopeArgument(
+    [property: JsonPropertyName("mode")] string Mode,
+    [property: JsonPropertyName("calendar")] CalendarEntityReferenceArgument? Calendar = null);
+
+public sealed record CalendarEntityReferenceArgument(
+    [property: JsonPropertyName("by")] string By,
+    [property: JsonPropertyName("name")] string? Name = null,
+    [property: JsonPropertyName("href")] string? Href = null);
+
+public sealed record CalendarEntityUtcArgument(
+    [property: JsonPropertyName("kind")] string Kind,
+    [property: JsonPropertyName("value")] string Value);
+
+public sealed record CalendarEntityQuerySuccessResult(
+    [property: JsonPropertyName("outcome")] string Outcome,
+    [property: JsonPropertyName("items")] IReadOnlyList<CalendarSnapshotResult> Items,
+    [property: JsonPropertyName("diagnostics")] IReadOnlyList<CalendarDiagnosticResult> Diagnostics,
+    [property: JsonPropertyName("pagination")] CalendarPagination Pagination);
+
+public sealed record CalendarEntityQueryErrorResult(
+    [property: JsonPropertyName("code")] string Code,
+    [property: JsonPropertyName("category")] string Category,
+    [property: JsonPropertyName("message")] string Message,
+    [property: JsonPropertyName("retryable")] bool Retryable,
+    [property: JsonPropertyName("phase")] string Phase,
+    [property: JsonPropertyName("limits"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] CalendarEntityExecutionLimits? Limits = null,
+    [property: JsonPropertyName("authorizedCandidates"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] IReadOnlyList<CalendarAuthorizedCandidateResult>? AuthorizedCandidates = null);
+
+public sealed record CalendarEntityExecutionLimits(
+    [property: JsonPropertyName("resourcesInspected"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] int? ResourcesInspected = null,
+    [property: JsonPropertyName("calendarCount"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] int? CalendarCount = null,
+    [property: JsonPropertyName("occurrenceCount"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] int? OccurrenceCount = null,
+    [property: JsonPropertyName("byteCount"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] int? ByteCount = null);
+
+public sealed record CalendarAuthorizedCandidateResult(
+    [property: JsonPropertyName("calendar")] CalendarHref Calendar,
+    [property: JsonPropertyName("displayName")] string? DisplayName,
+    [property: JsonPropertyName("entityKinds")] CalendarEntityKinds EntityKinds)
+{
+    internal static CalendarAuthorizedCandidateResult FromDescriptor(CalendarDescriptor descriptor) => new(
+        new CalendarHref(descriptor.Href),
+        descriptor.DisplayName,
+        new CalendarEntityKinds(
+            CalendarEntityKindCapability.From(descriptor.EventSupport, descriptor.EventEvidence),
+            CalendarEntityKindCapability.From(descriptor.TodoSupport, descriptor.TodoEvidence)));
+}

--- a/tests/DotnetAgents.CalDav.Core.Tests.Unit/DependencyInjection/CalDavServiceCollectionExtensionsTests.cs
+++ b/tests/DotnetAgents.CalDav.Core.Tests.Unit/DependencyInjection/CalDavServiceCollectionExtensionsTests.cs
@@ -1,6 +1,8 @@
 using DotnetAgents.CalDav.Core.Abstractions;
 using DotnetAgents.CalDav.Core.Configuration;
 using DotnetAgents.CalDav.Core.DependencyInjection;
+using DotnetAgents.CalDav.Core.Internal;
+using DotnetAgents.CalDav.Core.Models;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Http;
 using Shouldly;
@@ -30,6 +32,93 @@ public sealed class CalDavServiceCollectionExtensionsTests
         handler.AllowAutoRedirect.ShouldBeFalse();
     }
 
+    [Fact]
+    public async Task AddCalDavTasks_RetriesTransientReadsAtMostThreeTotalAttempts()
+    {
+        var handler = new CountingUnavailableHandler();
+        using var provider = BuildProvider(handler);
+        var client = provider.GetRequiredService<ICalendarClient>();
+
+        await Should.ThrowAsync<HttpRequestException>(() => client.GetCalendarResourceAsync(
+            "https://cal.example/events/a.ics", CancellationToken.None));
+
+        handler.RequestCount.ShouldBe(3);
+        handler.Methods.ShouldAllBe(method => method == HttpMethod.Get);
+    }
+
+    [Fact]
+    public async Task AddCalDavTasks_RetriesTransientCalDavReportAtMostThreeTotalAttempts()
+    {
+        var handler = new CountingUnavailableHandler();
+        using var provider = BuildProvider(handler);
+        var client = provider.GetRequiredService<ICalendarClient>();
+
+        await Should.ThrowAsync<HttpRequestException>(() => client.QueryCalendarResourceHrefsAsync(
+            "https://cal.example/events/",
+            CalendarEntityKind.Event,
+            null,
+            null,
+            CancellationToken.None));
+
+        handler.RequestCount.ShouldBe(3);
+        handler.Methods.ShouldAllBe(method => method.Method == "REPORT");
+    }
+
+    [Fact]
+    public async Task AddCalDavTasks_RetriesTransientCalDavPropFindAtMostThreeTotalAttempts()
+    {
+        var handler = new CountingUnavailableHandler();
+        using var provider = BuildProvider(handler);
+        var client = provider.GetRequiredService<ICalendarClient>();
+
+        await Should.ThrowAsync<HttpRequestException>(() => client.GetCalendarsAsync(CancellationToken.None));
+
+        handler.RequestCount.ShouldBe(3);
+        handler.Methods.ShouldAllBe(method => method.Method == "PROPFIND");
+    }
+
+    [Fact]
+    public async Task AddCalDavTasks_DoesNotRetryMutations()
+    {
+        var handler = new CountingUnavailableHandler();
+        using var provider = BuildProvider(handler);
+        var client = provider.GetRequiredService<ICalDavClient>();
+
+        await Should.ThrowAsync<HttpRequestException>(() => client.DeleteTaskAsync(
+            "https://cal.example/tasks/a.ics", "r1", CancellationToken.None));
+
+        handler.RequestCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task AddCalDavTasks_CallerCancellationStopsReadWithoutRetry()
+    {
+        var handler = new CancelingHandler();
+        using var provider = BuildProvider(handler);
+        var client = provider.GetRequiredService<ICalendarClient>();
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+
+        await Should.ThrowAsync<OperationCanceledException>(() => client.GetCalendarResourceAsync(
+            "https://cal.example/events/a.ics", cancellation.Token));
+
+        handler.RequestCount.ShouldBeLessThanOrEqualTo(1);
+    }
+
+    private static ServiceProvider BuildProvider(HttpMessageHandler handler)
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddCalDavTasks(options =>
+        {
+            options.BaseUrl = "https://cal.example";
+            options.Username = "user";
+            options.Password = "password";
+        });
+        services.AddHttpClient<CalDavClient>().ConfigurePrimaryHttpMessageHandler(() => handler);
+        return services.BuildServiceProvider();
+    }
+
     private sealed class CapturingHandlerFilter(Action<HttpMessageHandler> capture) : IHttpMessageHandlerBuilderFilter
     {
         public Action<HttpMessageHandlerBuilder> Configure(Action<HttpMessageHandlerBuilder> next) => builder =>
@@ -37,5 +126,35 @@ public sealed class CalDavServiceCollectionExtensionsTests
             next(builder);
             capture(builder.PrimaryHandler);
         };
+    }
+
+    private sealed class CountingUnavailableHandler : HttpMessageHandler
+    {
+        public int RequestCount { get; private set; }
+        public List<HttpMethod> Methods { get; } = [];
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            RequestCount++;
+            Methods.Add(request.Method);
+            return Task.FromResult(new HttpResponseMessage(System.Net.HttpStatusCode.ServiceUnavailable));
+        }
+    }
+
+    private sealed class CancelingHandler : HttpMessageHandler
+    {
+        public int RequestCount { get; private set; }
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            RequestCount++;
+            var pending = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            await pending.Task.WaitAsync(cancellationToken);
+            return new HttpResponseMessage(System.Net.HttpStatusCode.OK);
+        }
     }
 }

--- a/tests/DotnetAgents.CalDav.Core.Tests.Unit/Internal/CalDavClientTests.cs
+++ b/tests/DotnetAgents.CalDav.Core.Tests.Unit/Internal/CalDavClientTests.cs
@@ -15,6 +15,356 @@ namespace DotnetAgents.CalDav.Core.Tests.Unit.Internal;
 
 public class CalDavClientTests
 {
+    [Fact]
+    public async Task QueryCalendarResourceHrefsAsync_UsesMinimalBoundedReportAndCanonicalizesCandidates()
+    {
+        HttpRequestMessage? captured = null;
+        var handler = new StubHttpMessageHandler(request =>
+        {
+            captured = request;
+            return new HttpResponseMessage(HttpStatusCode.MultiStatus)
+            {
+                Content = new StringContent(
+                    "<d:multistatus xmlns:d=\"DAV:\"><d:response><d:href>/calendars/user/events/a.ics</d:href><d:propstat><d:prop><d:getetag>\"r1\"</d:getetag></d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat></d:response></d:multistatus>",
+                    Encoding.UTF8,
+                    "application/xml")
+            };
+        });
+        var sut = CreateSut(handler);
+        var from = DateTimeOffset.Parse("2026-08-16T10:00:00Z");
+        var to = DateTimeOffset.Parse("2026-08-17T10:00:00Z");
+
+        var result = await sut.QueryCalendarResourceHrefsAsync(
+            "https://example.com/calendars/user/events/",
+            CalendarEntityKind.Event,
+            from,
+            to,
+            CancellationToken.None);
+
+        result.ShouldBe(["https://example.com/calendars/user/events/a.ics"]);
+        captured!.Method.Method.ShouldBe("REPORT");
+        captured.Headers.GetValues("Depth").ShouldBe(["1"]);
+        var body = await captured.Content!.ReadAsStringAsync(CancellationToken.None);
+        body.ShouldContain("name=\"VEVENT\"");
+        body.ShouldContain("start=\"20260816T100000Z\"");
+        body.ShouldContain("end=\"20260817T100000Z\"");
+        body.ShouldNotContain("calendar-data");
+    }
+
+    [Fact]
+    public async Task QueryCalendarResourceHrefsAsync_UsesSecondResolutionSupersetForFractionalBounds()
+    {
+        string? body = null;
+        var handler = new AsyncStubHttpMessageHandler(async request =>
+        {
+            body = await request.Content!.ReadAsStringAsync(CancellationToken.None);
+            return new HttpResponseMessage(HttpStatusCode.MultiStatus)
+            {
+                Content = new StringContent("<d:multistatus xmlns:d=\"DAV:\"/>")
+            };
+        });
+        var sut = CreateSut(handler);
+
+        await sut.QueryCalendarResourceHrefsAsync(
+            "https://example.com/calendars/user/events/",
+            CalendarEntityKind.Event,
+            DateTimeOffset.Parse("2026-08-16T10:00:00.1234567Z"),
+            DateTimeOffset.Parse("2026-08-16T11:00:00.0000001Z"),
+            CancellationToken.None);
+
+        body.ShouldNotBeNull();
+        body.ShouldContain("start=\"20260816T100000Z\"");
+        body.ShouldContain("end=\"20260816T110001Z\"");
+    }
+
+    [Fact]
+    public async Task QueryCalendarResourceHrefsAsync_FallsBackFromRejectedTimeRangeToKindOnlyReport()
+    {
+        var bodies = new List<string>();
+        var handler = new AsyncStubHttpMessageHandler(async request =>
+        {
+            bodies.Add(await request.Content!.ReadAsStringAsync(CancellationToken.None));
+            return bodies.Count == 1
+                ? new HttpResponseMessage(HttpStatusCode.Forbidden)
+                {
+                    Content = new StringContent(
+                        "<d:error xmlns:d=\"DAV:\" xmlns:c=\"urn:ietf:params:xml:ns:caldav\"><c:supported-filter/></d:error>")
+                }
+                : new HttpResponseMessage(HttpStatusCode.MultiStatus)
+                {
+                    Content = new StringContent(
+                        "<d:multistatus xmlns:d=\"DAV:\"><d:response><d:href>https://example.com/calendars/user/events/a.ics</d:href><d:status>HTTP/1.1 200 OK</d:status></d:response></d:multistatus>")
+                };
+        });
+        var sut = CreateSut(handler);
+
+        var result = await sut.QueryCalendarResourceHrefsAsync(
+            "https://example.com/calendars/user/events/",
+            CalendarEntityKind.Event,
+            DateTimeOffset.Parse("2026-08-16T10:00:00Z"),
+            DateTimeOffset.Parse("2026-08-16T11:00:00Z"),
+            CancellationToken.None);
+
+        result.ShouldBe(["https://example.com/calendars/user/events/a.ics"]);
+        bodies.Count.ShouldBe(2);
+        bodies[0].ShouldContain("time-range");
+        bodies[1].ShouldNotContain("time-range");
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("not xml")]
+    public async Task QueryCalendarResourceHrefsAsync_UnrelatedForbiddenPreservesHttpStatus(string responseBody)
+    {
+        var requestCount = 0;
+        var handler = new StubHttpMessageHandler(_ =>
+        {
+            requestCount++;
+            return new HttpResponseMessage(HttpStatusCode.Forbidden)
+            {
+                Content = new StringContent(responseBody)
+            };
+        });
+        var sut = CreateSut(handler);
+
+        var exception = await Should.ThrowAsync<HttpRequestException>(() =>
+            sut.QueryCalendarResourceHrefsAsync(
+                "https://example.com/calendars/user/events/",
+                CalendarEntityKind.Event,
+                DateTimeOffset.Parse("2026-08-16T10:00:00Z"),
+                DateTimeOffset.Parse("2026-08-16T11:00:00Z"),
+                CancellationToken.None));
+
+        exception.StatusCode.ShouldBe(HttpStatusCode.Forbidden);
+        requestCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task QueryCalendarResourceHrefsAsync_MandatoryMinimalReportUnsupportedFailsCapability()
+    {
+        var handler = new StubHttpMessageHandler(_ => new HttpResponseMessage(HttpStatusCode.Forbidden)
+        {
+            Content = new StringContent(
+                "<d:error xmlns:d=\"DAV:\" xmlns:c=\"urn:ietf:params:xml:ns:caldav\"><c:supported-filter/></d:error>")
+        });
+        var sut = CreateSut(handler);
+
+        await Should.ThrowAsync<CalendarDiscoveryUnsupportedCapabilityException>(() =>
+            sut.QueryCalendarResourceHrefsAsync(
+                "https://example.com/calendars/user/events/",
+                CalendarEntityKind.Event,
+                null,
+                null,
+                CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task QueryCalendarResourceHrefsAsync_FallbackMinimalReportUnsupportedFailsCapability()
+    {
+        var requestCount = 0;
+        var handler = new StubHttpMessageHandler(_ =>
+        {
+            requestCount++;
+            return new HttpResponseMessage(HttpStatusCode.Forbidden)
+            {
+                Content = new StringContent(
+                    "<d:error xmlns:d=\"DAV:\" xmlns:c=\"urn:ietf:params:xml:ns:caldav\"><c:supported-filter/></d:error>")
+            };
+        });
+        var sut = CreateSut(handler);
+
+        await Should.ThrowAsync<CalendarDiscoveryUnsupportedCapabilityException>(() =>
+            sut.QueryCalendarResourceHrefsAsync(
+                "https://example.com/calendars/user/events/",
+                CalendarEntityKind.Event,
+                DateTimeOffset.Parse("2026-08-16T10:00:00Z"),
+                DateTimeOffset.Parse("2026-08-16T11:00:00Z"),
+                CancellationToken.None));
+
+        requestCount.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task QueryCalendarResourceHrefsAsync_IgnoresSuccessfulCollectionSelfResponse()
+    {
+        var handler = new StubHttpMessageHandler(_ => new HttpResponseMessage(HttpStatusCode.MultiStatus)
+        {
+            Content = new StringContent(
+                "<d:multistatus xmlns:d=\"DAV:\"><d:response><d:href>/calendars/user/events/</d:href><d:status>HTTP/1.1 200 OK</d:status></d:response><d:response><d:href>/calendars/user/events/a.ics</d:href><d:status>HTTP/1.1 200 OK</d:status></d:response></d:multistatus>",
+                Encoding.UTF8,
+                "application/xml")
+        });
+        var sut = CreateSut(handler);
+
+        var result = await sut.QueryCalendarResourceHrefsAsync(
+            "https://example.com/calendars/user/events/",
+            CalendarEntityKind.Event,
+            null,
+            null,
+            CancellationToken.None);
+
+        result.ShouldBe(["https://example.com/calendars/user/events/a.ics"]);
+    }
+
+    [Theory]
+    [InlineData("https://other.example/calendars/user/events/a.ics")]
+    [InlineData("/calendars/user/events%2Fprivate/a.ics")]
+    [InlineData("/calendars/user/events/%2e%2e/private/a.ics")]
+    [InlineData("/calendars/user/events%5cprivate/a.ics")]
+    [InlineData("/calendars/user/events/%2e/a.ics")]
+    [InlineData("/calendars/user/events/%2E%2E/a.ics")]
+    [InlineData("/calendars/user/events/%2e%2E/private.ics")]
+    public async Task QueryCalendarResourceHrefsAsync_RejectsUnsafeReportCandidateBeforeAnyGet(string candidateHref)
+    {
+        var requests = new List<HttpRequestMessage>();
+        var handler = new StubHttpMessageHandler(request =>
+        {
+            requests.Add(request);
+            return new HttpResponseMessage(HttpStatusCode.MultiStatus)
+            {
+                Content = new StringContent(
+                    $"<d:multistatus xmlns:d=\"DAV:\"><d:response><d:href>{candidateHref}</d:href><d:status>HTTP/1.1 200 OK</d:status></d:response></d:multistatus>",
+                    Encoding.UTF8,
+                    "application/xml")
+            };
+        });
+        var sut = CreateSut(handler);
+
+        await Should.ThrowAsync<CalendarDiscoveryProtocolException>(() => sut.QueryCalendarResourceHrefsAsync(
+            "https://example.com/calendars/user/events/",
+            CalendarEntityKind.Event,
+            null,
+            null,
+            CancellationToken.None));
+
+        requests.ShouldHaveSingleItem().Method.Method.ShouldBe("REPORT");
+    }
+
+    [Fact]
+    public async Task QueryCalendarResourceHrefsAsync_RejectsCrossOriginCalendarBeforeNetwork()
+    {
+        var requests = new List<HttpRequestMessage>();
+        var sut = CreateSut(new StubHttpMessageHandler(request =>
+        {
+            requests.Add(request);
+            return new HttpResponseMessage(HttpStatusCode.MultiStatus);
+        }));
+
+        await Should.ThrowAsync<CalendarDiscoveryProtocolException>(() => sut.QueryCalendarResourceHrefsAsync(
+            "https://other.example/calendars/user/events/",
+            CalendarEntityKind.Event,
+            null,
+            null,
+            CancellationToken.None));
+
+        requests.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task QueryCalendarResourceHrefsAsync_RejectsSeeOtherWithoutFollowing()
+    {
+        var requests = new List<HttpRequestMessage>();
+        var sut = CreateSut(new StubHttpMessageHandler(request =>
+        {
+            requests.Add(request);
+            return new HttpResponseMessage(HttpStatusCode.RedirectMethod)
+            {
+                Headers = { Location = new Uri("/calendars/user/events/other/", UriKind.Relative) }
+            };
+        }));
+
+        await Should.ThrowAsync<CalendarDiscoveryProtocolException>(() => sut.QueryCalendarResourceHrefsAsync(
+            "https://example.com/calendars/user/events/",
+            CalendarEntityKind.Event,
+            null,
+            null,
+            CancellationToken.None));
+
+        requests.ShouldHaveSingleItem().Method.Method.ShouldBe("REPORT");
+    }
+
+    [Theory]
+    [InlineData(HttpStatusCode.MovedPermanently)]
+    [InlineData(HttpStatusCode.Redirect)]
+    [InlineData(HttpStatusCode.TemporaryRedirect)]
+    [InlineData(HttpStatusCode.PermanentRedirect)]
+    public async Task QueryCalendarResourceHrefsAsync_FollowsRedirectButRejectsCandidateOutsideAuthorizedCalendarIdentity(
+        HttpStatusCode statusCode)
+    {
+        var requests = new List<(HttpMethod Method, string Uri, string Body)>();
+        var handler = new AsyncStubHttpMessageHandler(async request =>
+        {
+            requests.Add((
+                request.Method,
+                request.RequestUri!.AbsoluteUri,
+                await request.Content!.ReadAsStringAsync(CancellationToken.None)));
+            if (requests.Count == 1)
+            {
+                return new HttpResponseMessage(statusCode)
+                {
+                    Headers = { Location = new Uri("/calendars/user/redirected/", UriKind.Relative) }
+                };
+            }
+            return new HttpResponseMessage(HttpStatusCode.MultiStatus)
+            {
+                Content = new StringContent(
+                    "<d:multistatus xmlns:d=\"DAV:\"><d:response><d:href>a.ics</d:href><d:status>HTTP/1.1 200 OK</d:status></d:response></d:multistatus>")
+            };
+        });
+        var sut = CreateSut(handler);
+
+        await Should.ThrowAsync<CalendarDiscoveryProtocolException>(() => sut.QueryCalendarResourceHrefsAsync(
+            "https://example.com/calendars/user/events/",
+            CalendarEntityKind.Event,
+            null,
+            null,
+            CancellationToken.None));
+
+        requests.Count.ShouldBe(2);
+        requests.ShouldAllBe(request => request.Method.Method == "REPORT");
+        requests[1].Uri.ShouldBe("https://example.com/calendars/user/redirected/");
+        requests[1].Body.ShouldBe(requests[0].Body);
+    }
+
+    [Fact]
+    public async Task QueryCalendarResourceHrefsAsync_RejectsOversizedContentLength()
+    {
+        var content = new ByteArrayContent(new byte[4 * 1024 * 1024 + 1]);
+        var sut = CreateSut(new StubHttpMessageHandler(_ => new HttpResponseMessage(HttpStatusCode.MultiStatus)
+        {
+            Content = content
+        }));
+
+        var exception = await Should.ThrowAsync<HttpRequestException>(() => sut.QueryCalendarResourceHrefsAsync(
+            "https://example.com/calendars/user/events/",
+            CalendarEntityKind.Event,
+            null,
+            null,
+            CancellationToken.None));
+
+        exception.StatusCode.ShouldBe(HttpStatusCode.RequestEntityTooLarge);
+    }
+
+    [Fact]
+    public async Task QueryCalendarResourceHrefsAsync_StopsUnknownLengthBodyAtLimitPlusOne()
+    {
+        var stream = new CountingNonSeekableStream(new byte[4 * 1024 * 1024 + 8192]);
+        var sut = CreateSut(new StubHttpMessageHandler(_ => new HttpResponseMessage(HttpStatusCode.MultiStatus)
+        {
+            Content = new StreamContent(stream)
+        }));
+
+        var exception = await Should.ThrowAsync<HttpRequestException>(() => sut.QueryCalendarResourceHrefsAsync(
+            "https://example.com/calendars/user/events/",
+            CalendarEntityKind.Event,
+            null,
+            null,
+            CancellationToken.None));
+
+        exception.StatusCode.ShouldBe(HttpStatusCode.RequestEntityTooLarge);
+        stream.BytesRead.ShouldBe(4 * 1024 * 1024 + 1);
+    }
+
     [Theory]
     [InlineData(null)]
     [InlineData("W/\"weak-revision\"")]
@@ -39,6 +389,88 @@ public class CalDavClientTests
         result.Code.ShouldBe(CalendarResourceReadCode.ConcurrencyUnavailable);
         result.EntityTag.ShouldBeNull();
         result.AuthoritativeUtf8.IsEmpty.ShouldBeTrue();
+    }
+
+    [Theory]
+    [InlineData(HttpStatusCode.MovedPermanently)]
+    [InlineData(HttpStatusCode.Redirect)]
+    [InlineData(HttpStatusCode.TemporaryRedirect)]
+    [InlineData(HttpStatusCode.PermanentRedirect)]
+    public async Task GetCalendarResourceAsync_FollowsBoundedSameOriginReadRedirects(HttpStatusCode statusCode)
+    {
+        var requests = new List<HttpRequestMessage>();
+        var handler = CreateSequencedHandler(
+            [
+                new HttpResponseMessage(statusCode)
+                {
+                    Headers = { Location = new Uri("/redirected/calendars/current.ics", UriKind.Relative) }
+                },
+                new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Headers = { ETag = new EntityTagHeaderValue("\"revision-2\"") },
+                    Content = new StringContent("BEGIN:VCALENDAR\r\nEND:VCALENDAR\r\n", Encoding.UTF8, "text/calendar")
+                }
+            ],
+            requests);
+        var sut = CreateSut(handler);
+
+        var result = await sut.GetCalendarResourceAsync(
+            "https://example.com/calendars/user/events/old.ics",
+            CancellationToken.None);
+
+        result.Code.ShouldBe(CalendarResourceReadCode.Success);
+        result.ResourceHref.ShouldBe("https://example.com/calendars/user/events/old.ics");
+        Encoding.UTF8.GetString(result.AuthoritativeUtf8.Span)
+            .ShouldBe("BEGIN:VCALENDAR\r\nEND:VCALENDAR\r\n");
+        requests.Count.ShouldBe(2);
+        requests.ShouldAllBe(request => request.Method == HttpMethod.Get);
+    }
+
+    [Theory]
+    [InlineData("https://other.example/calendars/user/events/a.ics")]
+    [InlineData("/calendars/user/events%2Fprivate/a.ics")]
+    [InlineData("/calendars/user/events/a.ics?secret=true")]
+    [InlineData("https://user:secret@example.com/calendars/user/events/a.ics")]
+    [InlineData("/calendars/user/events/a.ics#fragment")]
+    public async Task GetCalendarResourceAsync_RejectsUnsafeRedirectWithoutFollowingIt(string location)
+    {
+        var requests = new List<HttpRequestMessage>();
+        var handler = new StubHttpMessageHandler(request =>
+        {
+            requests.Add(request);
+            return new HttpResponseMessage(HttpStatusCode.PermanentRedirect)
+            {
+                Headers = { Location = new Uri(location, UriKind.RelativeOrAbsolute) }
+            };
+        });
+        var sut = CreateSut(handler);
+
+        await Should.ThrowAsync<CalendarDiscoveryProtocolException>(() => sut.GetCalendarResourceAsync(
+            "https://example.com/calendars/user/events/a.ics",
+            CancellationToken.None));
+
+        requests.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task GetCalendarResourceAsync_RejectsSeeOtherWithoutFollowingIt()
+    {
+        var requests = new List<HttpRequestMessage>();
+        var handler = new StubHttpMessageHandler(request =>
+        {
+            requests.Add(request);
+            return new HttpResponseMessage(HttpStatusCode.RedirectMethod)
+            {
+                Headers = { Location = new Uri("/calendars/user/events/other.ics", UriKind.Relative) }
+            };
+        });
+        var sut = CreateSut(handler);
+
+        await Should.ThrowAsync<CalendarDiscoveryProtocolException>(() => sut.GetCalendarResourceAsync(
+            "https://example.com/calendars/user/events/a.ics",
+            CancellationToken.None));
+
+        requests.Count.ShouldBe(1);
     }
 
     [Fact]

--- a/tests/DotnetAgents.CalDav.Core.Tests.Unit/Internal/Ical/CalendarContentDocumentTests.cs
+++ b/tests/DotnetAgents.CalDav.Core.Tests.Unit/Internal/Ical/CalendarContentDocumentTests.cs
@@ -295,7 +295,6 @@ public sealed class CalendarContentDocumentTests
 
     [Theory]
     [InlineData("u2", "RRULE:FREQ=DAILY;COUNT=2", "recurrence_override_uid_mismatch")]
-    [InlineData("u1", "", "recurrence_override_without_recurrence_set")]
     public void Project_RejectsInvalidRecurrenceOverrideSet(string overrideUid, string recurrence, string diagnostic)
     {
         var content = $"BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Example//EN\r\nBEGIN:VEVENT\r\nUID:u1\r\nDTSTAMP:20260815T120000Z\r\nDTSTART:20260816T090000Z\r\n{recurrence}\r\nEND:VEVENT\r\nBEGIN:VEVENT\r\nUID:{overrideUid}\r\nDTSTAMP:20260815T120000Z\r\nRECURRENCE-ID:20260817T090000Z\r\nDTSTART:20260817T100000Z\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n";
@@ -411,7 +410,6 @@ public sealed class CalendarContentDocumentTests
     [InlineData("VEVENT", "ORGANIZER:mailto:organizer@example.test")]
     [InlineData("VTODO", "PERCENT-COMPLETE:50")]
     [InlineData("VEVENT", "SEQUENCE:1")]
-    [InlineData("VEVENT", "RRULE:FREQ=DAILY")]
     public void Project_RejectsRepeatedRegisteredEntitySingletons(string component, string property)
     {
         var content = $"BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Example//EN\r\nBEGIN:{component}\r\nUID:u1\r\nDTSTAMP:20260815T120000Z\r\nDTSTART:20260816T090000Z\r\n{property}\r\n{property}\r\nEND:{component}\r\nEND:VCALENDAR\r\n";

--- a/tests/DotnetAgents.CalDav.Core.Tests.Unit/Internal/Xml/DavResponseParserTests.cs
+++ b/tests/DotnetAgents.CalDav.Core.Tests.Unit/Internal/Xml/DavResponseParserTests.cs
@@ -9,6 +9,39 @@ namespace DotnetAgents.CalDav.Core.Tests.Unit.Internal.Xml;
 public class DavResponseParserTests
 {
     [Fact]
+    public void ParseCalendarResourceHrefs_AcceptsOnlySuccessfulResponseOrGetEtagPropstatAndDeduplicates()
+    {
+        const string xml = """
+            <d:multistatus xmlns:d="DAV:">
+              <d:response><d:href>/cal/a.ics</d:href><d:status>HTTP/1.1 200 OK</d:status></d:response>
+              <d:response><d:href>/cal/a.ics</d:href><d:status>HTTP/1.1 200 OK</d:status></d:response>
+              <d:response><d:href>/cal/response-404.ics</d:href><d:status>HTTP/1.1 404 Not Found</d:status></d:response>
+              <d:response><d:href>/cal/response-403.ics</d:href><d:status>HTTP/1.1 403 Forbidden</d:status></d:response>
+              <d:response><d:href>/cal/etag-200.ics</d:href><d:propstat><d:prop><d:getetag>"r1"</d:getetag></d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat></d:response>
+              <d:response><d:href>/cal/etag-404.ics</d:href><d:propstat><d:prop><d:getetag/></d:prop><d:status>HTTP/1.1 404 Not Found</d:status></d:propstat></d:response>
+              <d:response><d:href>/cal/wrong-property.ics</d:href><d:propstat><d:prop><d:displayname>x</d:displayname></d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat><d:propstat><d:prop><d:getetag/></d:prop><d:status>HTTP/1.1 404 Not Found</d:status></d:propstat></d:response>
+            </d:multistatus>
+            """;
+
+        var result = DavResponseParser.ParseCalendarResourceHrefs(xml);
+
+        result.ShouldBe(["/cal/a.ics", "/cal/etag-200.ics"]);
+    }
+
+    [Theory]
+    [InlineData("<d:response><d:href>/cal/a.ics</d:href><d:status>not-http</d:status></d:response>")]
+    [InlineData("<d:response><d:href>/cal/a.ics</d:href><d:status>HTTP/banana 200 OK</d:status></d:response>")]
+    [InlineData("<d:response><d:href>/cal/a.ics</d:href><d:status>HTTP/1.x 200 OK</d:status></d:response>")]
+    [InlineData("<d:response><d:href>/cal/a.ics</d:href><d:propstat><d:prop><d:getetag/></d:prop><d:status>HTTP/1.1 two-hundred OK</d:status></d:propstat></d:response>")]
+    [InlineData("<d:response><d:status>HTTP/1.1 200 OK</d:status></d:response>")]
+    public void ParseCalendarResourceHrefs_RejectsMalformedSuccessfulResponse(string response)
+    {
+        var xml = $"<d:multistatus xmlns:d=\"DAV:\">{response}</d:multistatus>";
+
+        Should.Throw<System.Xml.XmlException>(() => DavResponseParser.ParseCalendarResourceHrefs(xml));
+    }
+
+    [Fact]
     public void ParseCalendars_RejectsDtdAndEntityDeclarations()
     {
         const string xml = "<!DOCTYPE multistatus [<!ENTITY xxe SYSTEM 'file:///etc/passwd'>]><multistatus xmlns='DAV:'>&xxe;</multistatus>";

--- a/tests/DotnetAgents.CalDav.Core.Tests.Unit/Services/CalendarServiceTests.cs
+++ b/tests/DotnetAgents.CalDav.Core.Tests.Unit/Services/CalendarServiceTests.cs
@@ -1,6 +1,9 @@
+using System.Net;
+using System.Net.Http.Headers;
 using System.Text.Json;
 using DotnetAgents.CalDav.Core.Abstractions;
 using DotnetAgents.CalDav.Core.Configuration;
+using DotnetAgents.CalDav.Core.Internal;
 using DotnetAgents.CalDav.Core.Models;
 using DotnetAgents.CalDav.Core.Services;
 using Microsoft.Extensions.Logging;
@@ -13,6 +16,1267 @@ namespace DotnetAgents.CalDav.Core.Tests.Unit.Services;
 
 public sealed class CalendarServiceTests
 {
+    [Fact]
+    public async Task QueryEntitiesAsync_DefaultScopeUsesOnlyTheRequestedIndependentDefault()
+    {
+        const string eventCalendar = "https://cal.example/events/";
+        const string todoCalendar = "https://cal.example/todos/";
+        const string eventHref = "https://cal.example/events/standup.ics";
+        var client = Substitute.For<ICalendarClient>();
+        var options = Options.Create(new CalDavOptions
+        {
+            BaseUrl = "https://cal.example",
+            DefaultEventCalendarName = "Events",
+            DefaultTodoCalendarName = "To-dos"
+        });
+        var sut = new CalendarService(client, options, Substitute.For<ILogger<CalendarService>>());
+        client.GetCalendarsAsync(Arg.Any<CancellationToken>()).Returns(
+        [
+            EntityCalendar(eventCalendar, "Events", EntityKindSupport.Advertised, EntityKindSupport.NotAdvertised),
+            EntityCalendar(todoCalendar, "To-dos", EntityKindSupport.NotAdvertised, EntityKindSupport.Advertised)
+        ]);
+        client.QueryCalendarResourceHrefsAsync(eventCalendar, CalendarEntityKind.Event, null, null, Arg.Any<CancellationToken>())
+            .Returns([eventHref]);
+        client.GetCalendarResourceAsync(eventHref, Arg.Any<CancellationToken>()).Returns(
+            CalendarResourceRead.Success(eventHref, "\"r1\"", Event("event-1", "20260816T090000Z", "Standup")));
+
+        var result = await sut.QueryEntitiesAsync(
+            new CalendarEntityQuery(CalendarEntityScope.Default, [CalendarEntityKind.Event]),
+            CancellationToken.None);
+
+        result.Code.ShouldBe(CalendarEntityQueryCode.Success);
+        result.Items.Select(item => item.ResourceHref).ShouldBe([eventHref]);
+        await client.Received(1).QueryCalendarResourceHrefsAsync(
+            eventCalendar,
+            CalendarEntityKind.Event,
+            null,
+            null,
+            Arg.Any<CancellationToken>());
+        await client.DidNotReceive().QueryCalendarResourceHrefsAsync(
+            todoCalendar,
+            Arg.Any<CalendarEntityKind>(),
+            Arg.Any<DateTimeOffset?>(),
+            Arg.Any<DateTimeOffset?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task QueryEntitiesAsync_DefaultScopeUnionsDistinctEventAndTodoDefaults()
+    {
+        const string eventCalendar = "https://cal.example/events/";
+        const string todoCalendar = "https://cal.example/todos/";
+        const string eventHref = "https://cal.example/events/standup.ics";
+        const string todoHref = "https://cal.example/todos/report.ics";
+        var client = Substitute.For<ICalendarClient>();
+        var sut = new CalendarService(
+            client,
+            Options.Create(new CalDavOptions
+            {
+                BaseUrl = "https://cal.example",
+                DefaultEventCalendarName = "Events",
+                DefaultTodoCalendarName = "To-dos"
+            }),
+            Substitute.For<ILogger<CalendarService>>());
+        client.GetCalendarsAsync(Arg.Any<CancellationToken>()).Returns(
+        [
+            EntityCalendar(eventCalendar, "Events", EntityKindSupport.Advertised, EntityKindSupport.NotAdvertised),
+            EntityCalendar(todoCalendar, "To-dos", EntityKindSupport.NotAdvertised, EntityKindSupport.Advertised)
+        ]);
+        client.QueryCalendarResourceHrefsAsync(eventCalendar, CalendarEntityKind.Event, null, null, Arg.Any<CancellationToken>())
+            .Returns([eventHref]);
+        client.QueryCalendarResourceHrefsAsync(todoCalendar, CalendarEntityKind.Todo, null, null, Arg.Any<CancellationToken>())
+            .Returns([todoHref]);
+        client.GetCalendarResourceAsync(eventHref, Arg.Any<CancellationToken>()).Returns(
+            CalendarResourceRead.Success(eventHref, "\"e1\"", Event("event-1", "20260816T090000Z", "Standup")));
+        client.GetCalendarResourceAsync(todoHref, Arg.Any<CancellationToken>()).Returns(
+            CalendarResourceRead.Success(todoHref, "\"t1\"", Todo("todo-1", "Report")));
+
+        var result = await sut.QueryEntitiesAsync(
+            new CalendarEntityQuery(CalendarEntityScope.Default, [CalendarEntityKind.Todo, CalendarEntityKind.Event]),
+            CancellationToken.None);
+
+        result.Code.ShouldBe(CalendarEntityQueryCode.Success);
+        result.Items.Select(item => item.ResourceHref).ShouldBe([eventHref, todoHref]);
+    }
+
+    [Fact]
+    public async Task QueryEntitiesAsync_SelectedNameDoesNotBroadenWhenKindIsNotAdvertised()
+    {
+        const string selectedCalendar = "https://cal.example/selected/";
+        const string otherCalendar = "https://cal.example/other/";
+        const string resourceHref = "https://cal.example/selected/event.ics";
+        var client = Substitute.For<ICalendarClient>();
+        var sut = new CalendarService(
+            client,
+            Options.Create(new CalDavOptions { BaseUrl = "https://cal.example" }),
+            Substitute.For<ILogger<CalendarService>>());
+        client.GetCalendarsAsync(Arg.Any<CancellationToken>()).Returns(
+        [
+            EntityCalendar(selectedCalendar, " Selected ", EntityKindSupport.NotAdvertised, EntityKindSupport.Advertised),
+            EntityCalendar(otherCalendar, "Other", EntityKindSupport.Advertised, EntityKindSupport.Advertised)
+        ]);
+        client.QueryCalendarResourceHrefsAsync(selectedCalendar, CalendarEntityKind.Event, null, null, Arg.Any<CancellationToken>())
+            .Returns([resourceHref]);
+        client.GetCalendarResourceAsync(resourceHref, Arg.Any<CancellationToken>()).Returns(
+            CalendarResourceRead.Success(resourceHref, "\"r1\"", Event("event-1", "20260816T090000Z", "Selected event")));
+
+        var result = await sut.QueryEntitiesAsync(
+            new CalendarEntityQuery(
+                CalendarEntityScope.Selected(new CalendarReference(Name: "selected")),
+                [CalendarEntityKind.Event]),
+            CancellationToken.None);
+
+        result.Code.ShouldBe(CalendarEntityQueryCode.Success);
+        result.Items.Select(item => item.ResourceHref).ShouldBe([resourceHref]);
+        result.Diagnostics.Select(item => item.Code).ShouldBe(["entity_kind_not_advertised"]);
+        await client.DidNotReceive().QueryCalendarResourceHrefsAsync(
+            otherCalendar,
+            Arg.Any<CalendarEntityKind>(),
+            Arg.Any<DateTimeOffset?>(),
+            Arg.Any<DateTimeOffset?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task QueryEntitiesAsync_SelectedNameWithSurroundingWhitespaceIsInvalidBeforeDiscovery()
+    {
+        var client = Substitute.For<ICalendarClient>();
+        var sut = new CalendarService(
+            client,
+            Options.Create(new CalDavOptions { BaseUrl = "https://cal.example" }),
+            Substitute.For<ILogger<CalendarService>>());
+
+        var result = await sut.QueryEntitiesAsync(
+            new CalendarEntityQuery(
+                CalendarEntityScope.Selected(new CalendarReference(Name: "  Work  ")),
+                [CalendarEntityKind.Event]),
+            CancellationToken.None);
+
+        result.Code.ShouldBe(CalendarEntityQueryCode.InvalidInput);
+        await client.DidNotReceive().GetCalendarsAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task QueryEntitiesAsync_UndefinedEntityKindIsInvalidBeforeDiscovery()
+    {
+        var client = Substitute.For<ICalendarClient>();
+        var sut = new CalendarService(
+            client,
+            Options.Create(new CalDavOptions { BaseUrl = "https://cal.example" }),
+            Substitute.For<ILogger<CalendarService>>());
+
+        var result = await sut.QueryEntitiesAsync(
+            new CalendarEntityQuery(CalendarEntityScope.All, [(CalendarEntityKind)999]),
+            CancellationToken.None);
+
+        result.Code.ShouldBe(CalendarEntityQueryCode.InvalidInput);
+        await client.DidNotReceive().GetCalendarsAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task QueryEntitiesAsync_SelectedNameDoesNotRevealOutOfScopeExistence()
+    {
+        var client = Substitute.For<ICalendarClient>();
+        var sut = new CalendarService(
+            client,
+            Options.Create(new CalDavOptions
+            {
+                BaseUrl = "https://cal.example",
+                CalendarHrefs = "https://cal.example/authorized/"
+            }),
+            Substitute.For<ILogger<CalendarService>>());
+        client.GetCalendarsAsync(Arg.Any<CancellationToken>()).Returns(
+        [
+            EntityCalendar("https://cal.example/authorized/", "Authorized", EntityKindSupport.Advertised, EntityKindSupport.NotAdvertised),
+            EntityCalendar("https://cal.example/private/", "Private", EntityKindSupport.Advertised, EntityKindSupport.NotAdvertised)
+        ]);
+
+        var existingOutsideScope = await sut.QueryEntitiesAsync(
+            new CalendarEntityQuery(
+                CalendarEntityScope.Selected(new CalendarReference(Name: "Private")),
+                [CalendarEntityKind.Event]),
+            CancellationToken.None);
+        var nonexistent = await sut.QueryEntitiesAsync(
+            new CalendarEntityQuery(
+                CalendarEntityScope.Selected(new CalendarReference(Name: "Missing")),
+                [CalendarEntityKind.Event]),
+            CancellationToken.None);
+
+        existingOutsideScope.Code.ShouldBe(CalendarEntityQueryCode.NotFound);
+        nonexistent.Code.ShouldBe(CalendarEntityQueryCode.NotFound);
+        existingOutsideScope.AuthorizedCandidates.ShouldBe(nonexistent.AuthorizedCandidates);
+    }
+
+    [Fact]
+    public async Task QueryEntitiesAsync_ExplicitAllUsesOnlyCompatibleOrUnknownCalendarsAndDeduplicatesCandidates()
+    {
+        const string advertised = "https://cal.example/a/";
+        const string unknown = "https://cal.example/b/";
+        const string excluded = "https://cal.example/c/";
+        const string firstHref = "https://cal.example/a/shared.ics";
+        const string secondHref = "https://cal.example/b/second.ics";
+        var client = Substitute.For<ICalendarClient>();
+        var sut = new CalendarService(
+            client,
+            Options.Create(new CalDavOptions { BaseUrl = "https://cal.example" }),
+            Substitute.For<ILogger<CalendarService>>());
+        client.GetCalendarsAsync(Arg.Any<CancellationToken>()).Returns(
+        [
+            EntityCalendar(excluded, "Excluded", EntityKindSupport.NotAdvertised, EntityKindSupport.Advertised),
+            EntityCalendar(unknown, "Unknown", EntityKindSupport.Unknown, EntityKindSupport.Advertised),
+            EntityCalendar(advertised, "Advertised", EntityKindSupport.Advertised, EntityKindSupport.Advertised)
+        ]);
+        client.QueryCalendarResourceHrefsAsync(advertised, CalendarEntityKind.Event, null, null, Arg.Any<CancellationToken>())
+            .Returns([firstHref, firstHref]);
+        client.QueryCalendarResourceHrefsAsync(unknown, CalendarEntityKind.Event, null, null, Arg.Any<CancellationToken>())
+            .Returns([secondHref]);
+        client.GetCalendarResourceAsync(firstHref, Arg.Any<CancellationToken>()).Returns(
+            CalendarResourceRead.Success(firstHref, "\"r1\"", Event("event-1", "20260816T090000Z", "First")));
+        client.GetCalendarResourceAsync(secondHref, Arg.Any<CancellationToken>()).Returns(
+            CalendarResourceRead.Success(secondHref, "\"r2\"", Event("event-2", "20260816T100000Z", "Second")));
+
+        var result = await sut.QueryEntitiesAsync(
+            new CalendarEntityQuery(CalendarEntityScope.All, [CalendarEntityKind.Event]),
+            CancellationToken.None);
+
+        result.Code.ShouldBe(CalendarEntityQueryCode.Success);
+        result.Items.Select(item => item.ResourceHref).ShouldBe([firstHref, secondHref]);
+        await client.Received(1).GetCalendarResourceAsync(firstHref, Arg.Any<CancellationToken>());
+        await client.DidNotReceive().QueryCalendarResourceHrefsAsync(
+            excluded,
+            CalendarEntityKind.Event,
+            Arg.Any<DateTimeOffset?>(),
+            Arg.Any<DateTimeOffset?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task QueryEntitiesAsync_CarriesSafeConfiguredScopeDiagnostics()
+    {
+        const string calendarHref = "https://cal.example/events/";
+        const string missingHref = "https://cal.example/missing/";
+        const string resourceHref = "https://cal.example/events/a.ics";
+        var client = Substitute.For<ICalendarClient>();
+        var sut = new CalendarService(
+            client,
+            Options.Create(new CalDavOptions
+            {
+                BaseUrl = "https://cal.example",
+                CalendarHrefs = $"{calendarHref},{calendarHref},{missingHref}"
+            }),
+            Substitute.For<ILogger<CalendarService>>());
+        client.GetCalendarsAsync(Arg.Any<CancellationToken>()).Returns(
+            [EntityCalendar(calendarHref, "Events", EntityKindSupport.Advertised, EntityKindSupport.NotAdvertised)]);
+        client.QueryCalendarResourceHrefsAsync(calendarHref, CalendarEntityKind.Event, null, null, Arg.Any<CancellationToken>())
+            .Returns([resourceHref]);
+        client.GetCalendarResourceAsync(resourceHref, Arg.Any<CancellationToken>())
+            .Returns(CalendarResourceRead.Success(resourceHref, "\"r1\"", Event("a", "20260816T100000Z", "A")));
+
+        var result = await sut.QueryEntitiesAsync(
+            new CalendarEntityQuery(CalendarEntityScope.All, [CalendarEntityKind.Event]),
+            CancellationToken.None);
+
+        result.Code.ShouldBe(CalendarEntityQueryCode.Success);
+        result.Diagnostics.Select(item => item.Code)
+            .ShouldBe(["duplicate_calendar_href", "calendar_href_not_found"]);
+        result.Diagnostics.ShouldAllBe(item => !item.Message.Contains(calendarHref, StringComparison.Ordinal)
+            && !item.Message.Contains(missingHref, StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task QueryEntitiesAsync_ResourceLimitReturnsNoPartialItemsBeforeAnyGet()
+    {
+        const string calendarHref = "https://cal.example/events/";
+        var client = Substitute.For<ICalendarClient>();
+        var sut = new CalendarService(
+            client,
+            Options.Create(new CalDavOptions
+            {
+                BaseUrl = "https://cal.example",
+                DefaultEventCalendarName = "Events"
+            }),
+            Substitute.For<ILogger<CalendarService>>());
+        client.GetCalendarsAsync(Arg.Any<CancellationToken>()).Returns(
+            [EntityCalendar(calendarHref, "Events", EntityKindSupport.Advertised, EntityKindSupport.NotAdvertised)]);
+        client.QueryCalendarResourceHrefsAsync(calendarHref, CalendarEntityKind.Event, null, null, Arg.Any<CancellationToken>())
+            .Returns(Enumerable.Range(0, 5001).Select(index => $"{calendarHref}{index:D4}.ics").ToArray());
+
+        var result = await sut.QueryEntitiesAsync(
+            new CalendarEntityQuery(CalendarEntityScope.Default, [CalendarEntityKind.Event]),
+            CancellationToken.None);
+
+        result.Code.ShouldBe(CalendarEntityQueryCode.LimitExhausted);
+        result.Items.ShouldBeEmpty();
+        await client.DidNotReceive().GetCalendarResourceAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task QueryEntitiesAsync_ReturnsMixedCandidateAsOpaqueInsteadOfPartialOrSilentNonMatch()
+    {
+        const string calendarHref = "https://cal.example/mixed/";
+        const string resourceHref = "https://cal.example/mixed/mixed.ics";
+        var client = Substitute.For<ICalendarClient>();
+        var sut = new CalendarService(
+            client,
+            Options.Create(new CalDavOptions { BaseUrl = "https://cal.example", DefaultEventCalendarName = "Mixed" }),
+            Substitute.For<ILogger<CalendarService>>());
+        client.GetCalendarsAsync(Arg.Any<CancellationToken>()).Returns(
+            [EntityCalendar(calendarHref, "Mixed", EntityKindSupport.Advertised, EntityKindSupport.Advertised)]);
+        client.QueryCalendarResourceHrefsAsync(calendarHref, CalendarEntityKind.Event, null, null, Arg.Any<CancellationToken>())
+            .Returns([resourceHref]);
+        client.GetCalendarResourceAsync(resourceHref, Arg.Any<CancellationToken>()).Returns(
+            CalendarResourceRead.Success(resourceHref, "\"r1\"", Mixed("event-1", "todo-1")));
+
+        var result = await sut.QueryEntitiesAsync(
+            new CalendarEntityQuery(CalendarEntityScope.Default, [CalendarEntityKind.Event]),
+            CancellationToken.None);
+
+        result.Code.ShouldBe(CalendarEntityQueryCode.Success);
+        result.Items.ShouldHaveSingleItem().Projection.Kind.ShouldBe(CalendarResourceProjectionKind.Opaque);
+        result.Diagnostics.Select(item => item.Code).ShouldContain("opaque_filter_unresolved");
+        result.Items[0].Diagnostics.Select(item => item.Code).ShouldBe(["mixed_entity_kinds"]);
+    }
+
+    [Fact]
+    public async Task QueryEntitiesAsync_EventWindowUsesHalfOpenOverlapBoundariesLocally()
+    {
+        const string calendarHref = "https://cal.example/events/";
+        var endingAtFrom = $"{calendarHref}ending.ics";
+        var overlapping = $"{calendarHref}overlap.ics";
+        var startingAtTo = $"{calendarHref}starting.ics";
+        var client = Substitute.For<ICalendarClient>();
+        var sut = new CalendarService(
+            client,
+            Options.Create(new CalDavOptions { BaseUrl = "https://cal.example", DefaultEventCalendarName = "Events" }),
+            Substitute.For<ILogger<CalendarService>>());
+        client.GetCalendarsAsync(Arg.Any<CancellationToken>()).Returns(
+            [EntityCalendar(calendarHref, "Events", EntityKindSupport.Advertised, EntityKindSupport.NotAdvertised)]);
+        var from = DateTimeOffset.Parse("2026-08-16T10:00:00Z");
+        var to = DateTimeOffset.Parse("2026-08-16T11:00:00Z");
+        client.QueryCalendarResourceHrefsAsync(calendarHref, CalendarEntityKind.Event, from, to, Arg.Any<CancellationToken>())
+            .Returns([endingAtFrom, overlapping, startingAtTo]);
+        client.GetCalendarResourceAsync(endingAtFrom, Arg.Any<CancellationToken>()).Returns(
+            CalendarResourceRead.Success(endingAtFrom, "\"r1\"", EventWithEnd("ending", "20260816T090000Z", "20260816T100000Z")));
+        client.GetCalendarResourceAsync(overlapping, Arg.Any<CancellationToken>()).Returns(
+            CalendarResourceRead.Success(overlapping, "\"r2\"", EventWithEnd("overlap", "20260816T095959Z", "20260816T100001Z")));
+        client.GetCalendarResourceAsync(startingAtTo, Arg.Any<CancellationToken>()).Returns(
+            CalendarResourceRead.Success(startingAtTo, "\"r3\"", EventWithEnd("starting", "20260816T110000Z", "20260816T120000Z")));
+
+        var result = await sut.QueryEntitiesAsync(
+            new CalendarEntityQuery(CalendarEntityScope.Default, [CalendarEntityKind.Event], from, to),
+            CancellationToken.None);
+
+        result.Code.ShouldBe(CalendarEntityQueryCode.Success);
+        result.Items.Select(item => item.ResourceHref).ShouldBe([overlapping]);
+    }
+
+    [Fact]
+    public async Task QueryEntitiesAsync_TodoWindowUsesDuePointAndSpanBoundariesLocally()
+    {
+        const string calendarHref = "https://cal.example/todos/";
+        var dueAtFrom = $"{calendarHref}due-from.ics";
+        var dueAtTo = $"{calendarHref}due-to.ics";
+        var spanEndingAtFrom = $"{calendarHref}span-ending.ics";
+        var client = Substitute.For<ICalendarClient>();
+        var sut = new CalendarService(
+            client,
+            Options.Create(new CalDavOptions { BaseUrl = "https://cal.example", DefaultTodoCalendarName = "To-dos" }),
+            Substitute.For<ILogger<CalendarService>>());
+        client.GetCalendarsAsync(Arg.Any<CancellationToken>()).Returns(
+            [EntityCalendar(calendarHref, "To-dos", EntityKindSupport.NotAdvertised, EntityKindSupport.Advertised)]);
+        var from = DateTimeOffset.Parse("2026-08-16T10:00:00Z");
+        var to = DateTimeOffset.Parse("2026-08-16T11:00:00Z");
+        client.QueryCalendarResourceHrefsAsync(calendarHref, CalendarEntityKind.Todo, from, to, Arg.Any<CancellationToken>())
+            .Returns([dueAtFrom, dueAtTo, spanEndingAtFrom]);
+        client.GetCalendarResourceAsync(dueAtFrom, Arg.Any<CancellationToken>()).Returns(
+            CalendarResourceRead.Success(dueAtFrom, "\"r1\"", TodoWithTiming("due-from", null, "20260816T100000Z")));
+        client.GetCalendarResourceAsync(dueAtTo, Arg.Any<CancellationToken>()).Returns(
+            CalendarResourceRead.Success(dueAtTo, "\"r2\"", TodoWithTiming("due-to", null, "20260816T110000Z")));
+        client.GetCalendarResourceAsync(spanEndingAtFrom, Arg.Any<CancellationToken>()).Returns(
+            CalendarResourceRead.Success(spanEndingAtFrom, "\"r3\"", TodoWithTiming("span", "20260816T090000Z", "20260816T100000Z")));
+
+        var result = await sut.QueryEntitiesAsync(
+            new CalendarEntityQuery(CalendarEntityScope.Default, [CalendarEntityKind.Todo], from, to),
+            CancellationToken.None);
+
+        result.Code.ShouldBe(CalendarEntityQueryCode.Success);
+        result.Items.Select(item => item.ResourceHref).ShouldBe([dueAtFrom]);
+    }
+
+    [Theory]
+    [InlineData("20260816", "VALUE", "DATE")]
+    [InlineData("20260816T100000", null, null)]
+    [InlineData("20260816T100000", "TZID", "Mars/Olympus")]
+    public async Task QueryEntitiesAsync_UnresolvedTemporalKindsRemainVisibleWithDiagnostic(
+        string rawStart,
+        string? parameterName,
+        string? parameterValue)
+    {
+        const string calendarHref = "https://cal.example/events/";
+        const string resourceHref = "https://cal.example/events/unresolved.ics";
+        var parameter = parameterName is null ? string.Empty : $";{parameterName}={parameterValue}";
+        var client = Substitute.For<ICalendarClient>();
+        var sut = new CalendarService(
+            client,
+            Options.Create(new CalDavOptions { BaseUrl = "https://cal.example", DefaultEventCalendarName = "Events" }),
+            Substitute.For<ILogger<CalendarService>>());
+        client.GetCalendarsAsync(Arg.Any<CancellationToken>()).Returns(
+            [EntityCalendar(calendarHref, "Events", EntityKindSupport.Advertised, EntityKindSupport.NotAdvertised)]);
+        var from = DateTimeOffset.Parse("2026-08-16T09:00:00Z");
+        var to = DateTimeOffset.Parse("2026-08-16T11:00:00Z");
+        client.QueryCalendarResourceHrefsAsync(calendarHref, CalendarEntityKind.Event, from, to, Arg.Any<CancellationToken>())
+            .Returns([resourceHref]);
+        client.GetCalendarResourceAsync(resourceHref, Arg.Any<CancellationToken>()).Returns(
+            CalendarResourceRead.Success(resourceHref, "\"r1\"", EventWithRawStart("unresolved", parameter, rawStart)));
+
+        var result = await sut.QueryEntitiesAsync(
+            new CalendarEntityQuery(CalendarEntityScope.Default, [CalendarEntityKind.Event], from, to),
+            CancellationToken.None);
+
+        result.Code.ShouldBe(CalendarEntityQueryCode.TemporalUnresolved);
+        result.Items.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task QueryEntitiesAsync_EvaluatesUtcEventRecurrenceAndExclusionsLocally()
+    {
+        const string calendarHref = "https://cal.example/events/";
+        var included = $"{calendarHref}included.ics";
+        var excluded = $"{calendarHref}excluded.ics";
+        var client = Substitute.For<ICalendarClient>();
+        var sut = new CalendarService(
+            client,
+            Options.Create(new CalDavOptions { BaseUrl = "https://cal.example", DefaultEventCalendarName = "Events" }),
+            Substitute.For<ILogger<CalendarService>>());
+        client.GetCalendarsAsync(Arg.Any<CancellationToken>()).Returns(
+            [EntityCalendar(calendarHref, "Events", EntityKindSupport.Advertised, EntityKindSupport.NotAdvertised)]);
+        var from = DateTimeOffset.Parse("2026-08-16T10:30:00Z");
+        var to = DateTimeOffset.Parse("2026-08-16T10:45:00Z");
+        client.QueryCalendarResourceHrefsAsync(calendarHref, CalendarEntityKind.Event, from, to, Arg.Any<CancellationToken>())
+            .Returns([included, excluded]);
+        client.GetCalendarResourceAsync(included, Arg.Any<CancellationToken>()).Returns(
+            CalendarResourceRead.Success(included, "\"r1\"", RecurringEvent("included", null)));
+        client.GetCalendarResourceAsync(excluded, Arg.Any<CancellationToken>()).Returns(
+            CalendarResourceRead.Success(excluded, "\"r2\"", RecurringEvent("excluded", "20260816T100000Z")));
+
+        var result = await sut.QueryEntitiesAsync(
+            new CalendarEntityQuery(CalendarEntityScope.Default, [CalendarEntityKind.Event], from, to),
+            CancellationToken.None);
+
+        result.Code.ShouldBe(CalendarEntityQueryCode.Success);
+        result.Items.Select(item => item.ResourceHref).ShouldBe([included]);
+    }
+
+    [Fact]
+    public async Task QueryEntitiesAsync_EvaluatesUtcTodoRecurrenceEffectiveSpanLocally()
+    {
+        const string calendarHref = "https://cal.example/todos/";
+        var resourceHref = $"{calendarHref}recurring.ics";
+        var client = Substitute.For<ICalendarClient>();
+        var sut = new CalendarService(
+            client,
+            Options.Create(new CalDavOptions { BaseUrl = "https://cal.example", DefaultTodoCalendarName = "To-dos" }),
+            Substitute.For<ILogger<CalendarService>>());
+        client.GetCalendarsAsync(Arg.Any<CancellationToken>()).Returns(
+            [EntityCalendar(calendarHref, "To-dos", EntityKindSupport.NotAdvertised, EntityKindSupport.Advertised)]);
+        var from = DateTimeOffset.Parse("2026-08-16T10:15:00Z");
+        var to = DateTimeOffset.Parse("2026-08-16T10:20:00Z");
+        client.QueryCalendarResourceHrefsAsync(calendarHref, CalendarEntityKind.Todo, from, to, Arg.Any<CancellationToken>())
+            .Returns([resourceHref]);
+        client.GetCalendarResourceAsync(resourceHref, Arg.Any<CancellationToken>()).Returns(
+            CalendarResourceRead.Success(resourceHref, "\"r1\"", RecurringTodo("todo")));
+
+        var result = await sut.QueryEntitiesAsync(
+            new CalendarEntityQuery(CalendarEntityScope.Default, [CalendarEntityKind.Todo], from, to),
+            CancellationToken.None);
+
+        result.Code.ShouldBe(CalendarEntityQueryCode.Success);
+        result.Items.ShouldHaveSingleItem();
+    }
+
+    [Theory]
+    [InlineData(2000, CalendarEntityQueryCode.Success, 1, null)]
+    [InlineData(2001, CalendarEntityQueryCode.LimitExhausted, 0, 2001)]
+    public async Task QueryEntitiesAsync_EnforcesExactPerEntityOccurrenceBoundary(
+        int occurrenceCount,
+        CalendarEntityQueryCode expectedCode,
+        int expectedItems,
+        int? expectedObservedCount)
+    {
+        const string calendarHref = "https://cal.example/events/";
+        var resourceHref = $"{calendarHref}recurring.ics";
+        var client = Substitute.For<ICalendarClient>();
+        var sut = new CalendarService(
+            client,
+            Options.Create(new CalDavOptions { BaseUrl = "https://cal.example", DefaultEventCalendarName = "Events" }),
+            Substitute.For<ILogger<CalendarService>>());
+        client.GetCalendarsAsync(Arg.Any<CancellationToken>()).Returns(
+            [EntityCalendar(calendarHref, "Events", EntityKindSupport.Advertised, EntityKindSupport.NotAdvertised)]);
+        var from = DateTimeOffset.Parse("2026-08-15T12:00:00Z");
+        var to = DateTimeOffset.Parse("2026-08-15T13:00:00Z");
+        client.QueryCalendarResourceHrefsAsync(calendarHref, CalendarEntityKind.Event, from, to, Arg.Any<CancellationToken>())
+            .Returns([resourceHref]);
+        client.GetCalendarResourceAsync(resourceHref, Arg.Any<CancellationToken>()).Returns(
+            CalendarResourceRead.Success(resourceHref, "\"r1\"", RecurringEventWithRule(
+                "recurring", $"RRULE:FREQ=SECONDLY;COUNT={occurrenceCount}\r\n")));
+
+        var result = await sut.QueryEntitiesAsync(
+            new CalendarEntityQuery(CalendarEntityScope.Default, [CalendarEntityKind.Event], from, to),
+            CancellationToken.None);
+
+        result.Code.ShouldBe(expectedCode);
+        result.Items.Count.ShouldBe(expectedItems);
+        result.Limits?.OccurrenceCount.ShouldBe(expectedObservedCount);
+    }
+
+    [Theory]
+    [InlineData(5000, CalendarEntityQueryCode.Success, 3, null)]
+    [InlineData(5001, CalendarEntityQueryCode.LimitExhausted, 0, 5001)]
+    public async Task QueryEntitiesAsync_EnforcesExactTotalOccurrenceBoundary(
+        int totalOccurrences,
+        CalendarEntityQueryCode expectedCode,
+        int expectedItems,
+        int? expectedObservedCount)
+    {
+        var result = await QueryRecurringCountsAsync(
+            2000,
+            2000,
+            totalOccurrences - 4000);
+
+        result.Code.ShouldBe(expectedCode);
+        result.Items.Count.ShouldBe(expectedItems);
+        result.Limits?.OccurrenceCount.ShouldBe(expectedObservedCount);
+    }
+
+    [Theory]
+    [InlineData("20531231T100000Z", CalendarEntityQueryCode.Success)]
+    [InlineData("20540101T100000Z", CalendarEntityQueryCode.LimitExhausted)]
+    public async Task QueryEntitiesAsync_EnforcesExactUnmatchedIncrementBoundaryWithoutFabricatingOccurrenceCount(
+        string until,
+        CalendarEntityQueryCode expectedCode)
+    {
+        var result = await QuerySingleEventAsync(
+            $"DTSTART:20260816T100000Z\r\nDURATION:PT1H\r\nRRULE:FREQ=DAILY;BYMONTH=2;BYMONTHDAY=30;UNTIL={until}\r\n",
+            "2026-08-16T10:00:00Z",
+            "2026-08-16T11:00:00Z");
+
+        result.Code.ShouldBe(expectedCode);
+        result.Items.ShouldBeEmpty();
+        result.Limits.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task QueryEntitiesAsync_MixedOpaqueResourceRemainsTruthfulUnderTemporalFilter()
+    {
+        const string calendarHref = "https://cal.example/events/";
+        var resourceHref = $"{calendarHref}opaque.ics";
+        var client = Substitute.For<ICalendarClient>();
+        var sut = new CalendarService(
+            client,
+            Options.Create(new CalDavOptions { BaseUrl = "https://cal.example", DefaultEventCalendarName = "Events" }),
+            Substitute.For<ILogger<CalendarService>>());
+        client.GetCalendarsAsync(Arg.Any<CancellationToken>()).Returns(
+            [EntityCalendar(calendarHref, "Events", EntityKindSupport.Advertised, EntityKindSupport.NotAdvertised)]);
+        var from = DateTimeOffset.Parse("2026-08-15T12:00:00Z");
+        var to = DateTimeOffset.Parse("2026-08-15T13:00:00Z");
+        client.QueryCalendarResourceHrefsAsync(calendarHref, CalendarEntityKind.Event, from, to, Arg.Any<CancellationToken>())
+            .Returns([resourceHref]);
+        client.GetCalendarResourceAsync(resourceHref, Arg.Any<CancellationToken>()).Returns(
+            CalendarResourceRead.Success(resourceHref, "\"r1\"", Mixed("event", "todo")));
+
+        var result = await sut.QueryEntitiesAsync(
+            new CalendarEntityQuery(CalendarEntityScope.Default, [CalendarEntityKind.Event], from, to),
+            CancellationToken.None);
+
+        result.Code.ShouldBe(CalendarEntityQueryCode.Success);
+        result.Items.ShouldHaveSingleItem().Projection.Kind.ShouldBe(CalendarResourceProjectionKind.Opaque);
+        result.Diagnostics.Select(item => item.Code).ShouldContain("opaque_filter_unresolved");
+    }
+
+    [Fact]
+    public async Task QueryEntitiesAsync_ProjectableMultipleRRuleIsListableButWindowIsUnevaluable()
+    {
+        const string calendarHref = "https://cal.example/events/";
+        var resourceHref = $"{calendarHref}multiple.ics";
+        var client = Substitute.For<ICalendarClient>();
+        var sut = new CalendarService(
+            client,
+            Options.Create(new CalDavOptions { BaseUrl = "https://cal.example", DefaultEventCalendarName = "Events" }),
+            Substitute.For<ILogger<CalendarService>>());
+        client.GetCalendarsAsync(Arg.Any<CancellationToken>()).Returns(
+            [EntityCalendar(calendarHref, "Events", EntityKindSupport.Advertised, EntityKindSupport.NotAdvertised)]);
+        var from = DateTimeOffset.Parse("2026-08-15T12:00:00Z");
+        var to = DateTimeOffset.Parse("2026-08-15T13:00:00Z");
+        client.QueryCalendarResourceHrefsAsync(calendarHref, CalendarEntityKind.Event, from, to, Arg.Any<CancellationToken>())
+            .Returns([resourceHref]);
+        client.QueryCalendarResourceHrefsAsync(calendarHref, CalendarEntityKind.Event, null, null, Arg.Any<CancellationToken>())
+            .Returns([resourceHref]);
+        client.GetCalendarResourceAsync(resourceHref, Arg.Any<CancellationToken>()).Returns(
+            CalendarResourceRead.Success(resourceHref, "\"r1\"", RecurringEventWithRule(
+                "multiple", "RRULE:FREQ=DAILY;COUNT=3\r\nRRULE:FREQ=WEEKLY;COUNT=3\r\n")));
+
+        var windowed = await sut.QueryEntitiesAsync(
+            new CalendarEntityQuery(CalendarEntityScope.Default, [CalendarEntityKind.Event], from, to),
+            CancellationToken.None);
+        var listed = await sut.QueryEntitiesAsync(
+            new CalendarEntityQuery(CalendarEntityScope.Default, [CalendarEntityKind.Event]),
+            CancellationToken.None);
+
+        windowed.Code.ShouldBe(CalendarEntityQueryCode.RecurrenceUnevaluable);
+        windowed.Items.ShouldBeEmpty();
+        listed.Code.ShouldBe(CalendarEntityQueryCode.Success);
+        listed.Items.ShouldHaveSingleItem().Projection.Kind.ShouldBe(CalendarResourceProjectionKind.Event);
+        listed.Items[0].CalendarProperties.Count(property => property.Name == "RRULE").ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task QueryEntitiesAsync_RRuleOnOverrideIsUnevaluable()
+    {
+        var result = await QuerySingleEventAsync(
+            "DTSTART:20260816T100000Z\r\n"
+            + "END:VEVENT\r\n"
+            + "BEGIN:VEVENT\r\nUID:temporal\r\nDTSTAMP:20260815T120000Z\r\n"
+            + "RECURRENCE-ID:20260817T100000Z\r\nDTSTART:20260817T110000Z\r\n"
+            + "RRULE:FREQ=DAILY;COUNT=2\r\n",
+            "2026-08-16T10:00:00Z",
+            "2026-08-18T12:00:00Z");
+
+        result.Code.ShouldBe(CalendarEntityQueryCode.RecurrenceUnevaluable);
+        result.Items.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task QueryEntitiesAsync_RRuleOnMasterAndOverrideIsUnevaluable()
+    {
+        var result = await QuerySingleEventAsync(
+            "DTSTART:20260816T100000Z\r\nRRULE:FREQ=DAILY;COUNT=2\r\n"
+            + "END:VEVENT\r\n"
+            + "BEGIN:VEVENT\r\nUID:temporal\r\nDTSTAMP:20260815T120000Z\r\n"
+            + "RECURRENCE-ID:20260817T100000Z\r\nDTSTART:20260817T110000Z\r\n"
+            + "RRULE:FREQ=DAILY;COUNT=2\r\n",
+            "2026-08-16T10:00:00Z",
+            "2026-08-18T12:00:00Z");
+
+        result.Code.ShouldBe(CalendarEntityQueryCode.RecurrenceUnevaluable);
+        result.Items.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task QueryEntitiesAsync_ThisAndFutureOverrideIsListableButWindowIsUnevaluable()
+    {
+        const string bytesText = "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Example//EN\r\nX-UNRELATED:keep\r\n"
+            + "BEGIN:VTIMEZONE\r\nTZID:Custom/Office\r\nBEGIN:STANDARD\r\nDTSTART:20200101T000000\r\n"
+            + "TZOFFSETFROM:+0200\r\nTZOFFSETTO:+0200\r\nEND:STANDARD\r\nEND:VTIMEZONE\r\n"
+            + "BEGIN:VEVENT\r\nUID:ranged\r\nDTSTAMP:20260815T120000Z\r\nDTSTART;TZID=Custom/Office:20260816T100000\r\nRRULE:FREQ=DAILY;COUNT=3\r\nEND:VEVENT\r\n"
+            + "BEGIN:VEVENT\r\nUID:ranged\r\nDTSTAMP:20260815T120000Z\r\nRECURRENCE-ID;RANGE=THISANDFUTURE;TZID=Custom/Office:20260817T100000\r\n"
+            + "DTSTART;TZID=Custom/Office:20260817T110000\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n";
+        const string calendarHref = "https://cal.example/events/";
+        const string resourceHref = "https://cal.example/events/ranged.ics";
+        var bytes = System.Text.Encoding.UTF8.GetBytes(bytesText);
+        var client = Substitute.For<ICalendarClient>();
+        var sut = new CalendarService(
+            client,
+            Options.Create(new CalDavOptions { BaseUrl = "https://cal.example", DefaultEventCalendarName = "Events" }),
+            Substitute.For<ILogger<CalendarService>>());
+        client.GetCalendarsAsync(Arg.Any<CancellationToken>()).Returns(
+            [EntityCalendar(calendarHref, "Events", EntityKindSupport.Advertised, EntityKindSupport.NotAdvertised)]);
+        client.QueryCalendarResourceHrefsAsync(calendarHref, CalendarEntityKind.Event, Arg.Any<DateTimeOffset?>(), Arg.Any<DateTimeOffset?>(), Arg.Any<CancellationToken>())
+            .Returns([resourceHref]);
+        client.GetCalendarResourceAsync(resourceHref, Arg.Any<CancellationToken>())
+            .Returns(CalendarResourceRead.Success(resourceHref, "\"r1\"", bytes));
+
+        var windowed = await sut.QueryEntitiesAsync(new CalendarEntityQuery(
+            CalendarEntityScope.Default,
+            [CalendarEntityKind.Event],
+            DateTimeOffset.Parse("2026-08-17T09:00:00Z"),
+            DateTimeOffset.Parse("2026-08-17T10:00:00Z")), CancellationToken.None);
+        var listed = await sut.QueryEntitiesAsync(
+            new CalendarEntityQuery(CalendarEntityScope.Default, [CalendarEntityKind.Event]),
+            CancellationToken.None);
+
+        windowed.Code.ShouldBe(CalendarEntityQueryCode.RecurrenceUnevaluable);
+        windowed.Items.ShouldBeEmpty();
+        listed.Code.ShouldBe(CalendarEntityQueryCode.Success);
+        listed.Items.ShouldHaveSingleItem().AuthoritativeUtf8.ToArray().ShouldBe(bytes);
+    }
+
+    [Fact]
+    public async Task QueryEntitiesAsync_ExdateOnlyRecurrenceSuppressesTheMasterStart()
+    {
+        var result = await QuerySingleEventAsync(
+            "DTSTART:20260816T100000Z\r\nEXDATE:20260816T100000Z\r\n",
+            "2026-08-16T10:00:00Z",
+            "2026-08-16T10:01:00Z");
+
+        result.Code.ShouldBe(CalendarEntityQueryCode.Success);
+        result.Items.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task QueryEntitiesAsync_CompleteOverrideUsesItsMovedEffectiveSpanWithoutRule()
+    {
+        var result = await QuerySingleEventAsync(
+            "DTSTART:20260816T060000Z\r\nDURATION:PT30M\r\nEND:VEVENT\r\n"
+            + "BEGIN:VEVENT\r\nUID:temporal\r\nDTSTAMP:20260815T120000Z\r\n"
+            + "RECURRENCE-ID:20260816T060000Z\r\nDTSTART:20260816T093000Z\r\nDURATION:PT1H\r\n",
+            "2026-08-16T10:00:00Z",
+            "2026-08-16T10:01:00Z");
+
+        result.Code.ShouldBe(CalendarEntityQueryCode.Success);
+        result.Items.ShouldHaveSingleItem();
+    }
+
+    [Fact]
+    public async Task QueryEntitiesAsync_CommaSeparatedPeriodAndExdateRemainEvaluable()
+    {
+        var result = await QuerySingleEventAsync(
+            "DTSTART:20260816T060000Z\r\nDURATION:PT30M\r\n"
+            + "RDATE;VALUE=PERIOD:20260816T070000Z/20260816T073000Z,20260816T080000Z/PT2H30M\r\n"
+            + "EXDATE:20260816T060000Z,20260817T060000Z\r\n",
+            "2026-08-16T10:00:00Z",
+            "2026-08-16T10:01:00Z");
+
+        result.Code.ShouldBe(CalendarEntityQueryCode.Success);
+        result.Items.ShouldHaveSingleItem();
+    }
+
+    [Fact]
+    public async Task QueryEntitiesAsync_ResolvesRecognizedIanaZoneAcrossDst()
+    {
+        var result = await QuerySingleEventAsync(
+            "DTSTART;TZID=Europe/Zurich:20260329T033000\r\nDURATION:PT30M\r\n",
+            "2026-03-29T01:30:00Z",
+            "2026-03-29T01:31:00Z");
+
+        result.Code.ShouldBe(CalendarEntityQueryCode.Success);
+        result.Items.ShouldHaveSingleItem();
+    }
+
+    [Theory]
+    [InlineData("20260329T023000")]
+    [InlineData("20261025T023000")]
+    public async Task QueryEntitiesAsync_IanaGapOrOverlapIsUnresolved(string localStart)
+    {
+        var result = await QuerySingleEventAsync(
+            $"DTSTART;TZID=Europe/Zurich:{localStart}\r\nDURATION:PT30M\r\n",
+            "2026-03-01T00:00:00Z",
+            "2026-11-01T00:00:00Z");
+
+        result.Code.ShouldBe(CalendarEntityQueryCode.TemporalUnresolved);
+        result.Items.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task QueryEntitiesAsync_DoesNotAcceptWindowsZoneAliasAsIana()
+    {
+        var result = await QuerySingleEventAsync(
+            "DTSTART;TZID=Central Standard Time:20260816T100000\r\nDURATION:PT30M\r\n",
+            "2026-08-16T15:00:00Z",
+            "2026-08-16T16:00:00Z");
+
+        result.Code.ShouldBe(CalendarEntityQueryCode.TemporalUnresolved);
+        result.Items.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task QueryEntitiesAsync_InvalidLocalDefinitionNeverFallsBackToSameIanaId()
+    {
+        var result = await QuerySingleEventAsync(
+            "DTSTART;TZID=Europe/Zurich:20260816T100000\r\nDURATION:PT30M\r\n",
+            "2026-08-16T08:00:00Z",
+            "2026-08-16T09:00:00Z",
+            "BEGIN:VTIMEZONE\r\nTZID:Europe/Zurich\r\nBEGIN:STANDARD\r\n"
+            + "DTSTART:20200101T000000\r\nEND:STANDARD\r\nEND:VTIMEZONE\r\n");
+
+        result.Code.ShouldBe(CalendarEntityQueryCode.TemporalUnresolved);
+        result.Items.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task QueryEntitiesAsync_ResourceLocalTimeZoneOverridesExternalZoneDatabase()
+    {
+        var result = await QuerySingleEventAsync(
+            "DTSTART;TZID=Custom/Office:20260816T100000\r\nDURATION:PT30M\r\n",
+            "2026-08-16T07:00:00Z",
+            "2026-08-16T07:01:00Z",
+            "BEGIN:VTIMEZONE\r\nTZID:Custom/Office\r\nBEGIN:STANDARD\r\n"
+            + "DTSTART:20200101T000000\r\nTZOFFSETFROM:+0300\r\nTZOFFSETTO:+0300\r\n"
+            + "END:STANDARD\r\nEND:VTIMEZONE\r\n");
+
+        result.Code.ShouldBe(CalendarEntityQueryCode.Success);
+        result.Items.ShouldHaveSingleItem();
+    }
+
+    [Fact]
+    public async Task QueryEntitiesAsync_RecurringResourceLocalZoneIsUnevaluableWhenExpansionCannotStayStrict()
+    {
+        var result = await QuerySingleEventAsync(
+            "DTSTART;TZID=Custom/Office:20260815T100000\r\nDURATION:PT30M\r\nRRULE:FREQ=DAILY;COUNT=2\r\n",
+            "2026-08-16T08:00:00Z",
+            "2026-08-16T08:01:00Z",
+            "BEGIN:VTIMEZONE\r\nTZID:Custom/Office\r\nBEGIN:STANDARD\r\n"
+            + "DTSTART:20200101T000000\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0200\r\n"
+            + "END:STANDARD\r\nEND:VTIMEZONE\r\n");
+
+        result.Code.ShouldBe(CalendarEntityQueryCode.RecurrenceUnevaluable);
+        result.Items.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task QueryEntitiesAsync_RecurringResourceLocalZoneAcrossDstDoesNotCoerce()
+    {
+        var result = await QuerySingleEventAsync(
+            "DTSTART;TZID=Custom/Dst:20260328T100000\r\nDURATION:PT30M\r\nRRULE:FREQ=DAILY;COUNT=3\r\n",
+            "2026-03-30T08:00:00Z",
+            "2026-03-30T08:01:00Z",
+            "BEGIN:VTIMEZONE\r\nTZID:Custom/Dst\r\nBEGIN:STANDARD\r\n"
+            + "DTSTART:20251026T030000\r\nRRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU\r\n"
+            + "TZOFFSETFROM:+0200\r\nTZOFFSETTO:+0100\r\nEND:STANDARD\r\n"
+            + "BEGIN:DAYLIGHT\r\nDTSTART:20260329T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU\r\n"
+            + "TZOFFSETFROM:+0100\r\nTZOFFSETTO:+0200\r\nEND:DAYLIGHT\r\nEND:VTIMEZONE\r\n");
+
+        result.Code.ShouldBe(CalendarEntityQueryCode.RecurrenceUnevaluable);
+        result.Items.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task QueryEntitiesAsync_ResourceLocalRdateTransitionSupportsNonHourOffset()
+    {
+        var result = await QuerySingleEventAsync(
+            "DTSTART;TZID=Custom/Shift:20260816T100000\r\nDURATION:PT30M\r\n",
+            "2026-08-16T06:30:00Z",
+            "2026-08-16T06:31:00Z",
+            "BEGIN:VTIMEZONE\r\nTZID:Custom/Shift\r\nBEGIN:STANDARD\r\n"
+            + "DTSTART:20200101T000000\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0200\r\nEND:STANDARD\r\n"
+            + "BEGIN:DAYLIGHT\r\nDTSTART:20260816T020000\r\nRDATE:20260816T020000\r\n"
+            + "TZOFFSETFROM:+0200\r\nTZOFFSETTO:+0330\r\nEND:DAYLIGHT\r\nEND:VTIMEZONE\r\n");
+
+        result.Code.ShouldBe(CalendarEntityQueryCode.Success);
+        result.Items.ShouldHaveSingleItem();
+    }
+
+    [Fact]
+    public async Task QueryEntitiesAsync_ResourceLocalOffsetBeyondDateTimeOffsetRangeRemainsEvaluable()
+    {
+        var result = await QuerySingleEventAsync(
+            "DTSTART;TZID=Custom/FarEast:20260816T100000\r\nDURATION:PT30M\r\n",
+            "2026-08-15T19:00:00Z",
+            "2026-08-15T19:01:00Z",
+            "BEGIN:VTIMEZONE\r\nTZID:Custom/FarEast\r\nBEGIN:STANDARD\r\n"
+            + "DTSTART:20200101T000000\r\nTZOFFSETFROM:+1500\r\nTZOFFSETTO:+1500\r\n"
+            + "END:STANDARD\r\nEND:VTIMEZONE\r\n");
+
+        result.Code.ShouldBe(CalendarEntityQueryCode.Success);
+        result.Items.ShouldHaveSingleItem();
+    }
+
+    [Fact]
+    public async Task QueryEntitiesAsync_ConflictingLocalTransitionsAreUnresolved()
+    {
+        var result = await QuerySingleEventAsync(
+            "DTSTART;TZID=Custom/Conflict:20260816T100000\r\nDURATION:PT30M\r\n",
+            "2026-08-16T07:00:00Z",
+            "2026-08-16T09:00:00Z",
+            "BEGIN:VTIMEZONE\r\nTZID:Custom/Conflict\r\nBEGIN:STANDARD\r\n"
+            + "DTSTART:20200101T000000\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0200\r\nEND:STANDARD\r\n"
+            + "BEGIN:DAYLIGHT\r\nDTSTART:20260816T020000\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0300\r\n"
+            + "END:DAYLIGHT\r\nEND:VTIMEZONE\r\n");
+
+        result.Code.ShouldBe(CalendarEntityQueryCode.TemporalUnresolved);
+        result.Items.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task QueryEntitiesAsync_IncompleteLocalObservanceInvalidatesWholeZone()
+    {
+        var result = await QuerySingleEventAsync(
+            "DTSTART;TZID=Custom/Partial:20260816T100000\r\nDURATION:PT30M\r\n",
+            "2026-08-16T08:00:00Z",
+            "2026-08-16T09:00:00Z",
+            "BEGIN:VTIMEZONE\r\nTZID:Custom/Partial\r\nBEGIN:STANDARD\r\n"
+            + "DTSTART:20200101T000000\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0200\r\nEND:STANDARD\r\n"
+            + "BEGIN:DAYLIGHT\r\nDTSTART:20260816T020000\r\nEND:DAYLIGHT\r\nEND:VTIMEZONE\r\n");
+
+        result.Code.ShouldBe(CalendarEntityQueryCode.TemporalUnresolved);
+        result.Items.ShouldBeEmpty();
+    }
+
+    [Theory]
+    [InlineData("DTSTART:20260329T020000\r\nRRULE:FREQ=YEARLY;COUNT=3;BYMONTH=3;BYDAY=-1SU\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0200\r\n", "20260329T023000")]
+    [InlineData("DTSTART:20261025T030000\r\nRRULE:FREQ=YEARLY;UNTIL=20281025T030000Z;BYMONTH=10;BYDAY=-1SU\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0100\r\n", "20261025T023000")]
+    public async Task QueryEntitiesAsync_LocalTimeZoneGapOrOverlapIsUnresolved(
+        string observance,
+        string localStart)
+    {
+        var result = await QuerySingleEventAsync(
+            $"DTSTART;TZID=Custom/Dst:{localStart}\r\nDURATION:PT30M\r\n",
+            "2026-03-01T00:00:00Z",
+            "2026-11-01T00:00:00Z",
+            $"BEGIN:VTIMEZONE\r\nTZID:Custom/Dst\r\nBEGIN:DAYLIGHT\r\n{observance}END:DAYLIGHT\r\nEND:VTIMEZONE\r\n");
+
+        result.Code.ShouldBe(CalendarEntityQueryCode.TemporalUnresolved);
+        result.Items.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task QueryEntitiesAsync_DuplicateResourceLocalTimeZoneIdIsUnresolved()
+    {
+        const string zone = "BEGIN:VTIMEZONE\r\nTZID:Custom/Duplicate\r\nBEGIN:STANDARD\r\n"
+            + "DTSTART:20200101T000000\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0200\r\n"
+            + "END:STANDARD\r\nEND:VTIMEZONE\r\n";
+        var result = await QuerySingleEventAsync(
+            "DTSTART;TZID=Custom/Duplicate:20260816T100000\r\nDURATION:PT30M\r\n",
+            "2026-08-16T08:00:00Z",
+            "2026-08-16T08:01:00Z",
+            zone + zone);
+
+        result.Code.ShouldBe(CalendarEntityQueryCode.TemporalUnresolved);
+        result.Items.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task QueryEntitiesAsync_ReportCandidateThatDisappearsIsDiagnosedWithoutInventingSnapshot()
+    {
+        const string calendarHref = "https://cal.example/events/";
+        var vanished = $"{calendarHref}vanished.ics";
+        var current = $"{calendarHref}current.ics";
+        var client = Substitute.For<ICalendarClient>();
+        var sut = new CalendarService(
+            client,
+            Options.Create(new CalDavOptions { BaseUrl = "https://cal.example", DefaultEventCalendarName = "Events" }),
+            Substitute.For<ILogger<CalendarService>>());
+        client.GetCalendarsAsync(Arg.Any<CancellationToken>()).Returns(
+            [EntityCalendar(calendarHref, "Events", EntityKindSupport.Advertised, EntityKindSupport.NotAdvertised)]);
+        client.QueryCalendarResourceHrefsAsync(calendarHref, CalendarEntityKind.Event, null, null, Arg.Any<CancellationToken>())
+            .Returns([vanished, current]);
+        client.GetCalendarResourceAsync(vanished, Arg.Any<CancellationToken>()).Returns(
+            new CalendarResourceRead(CalendarResourceReadCode.NotFound));
+        client.GetCalendarResourceAsync(current, Arg.Any<CancellationToken>()).Returns(
+            CalendarResourceRead.Success(current, "\"new-revision\"", Event("current", "20260816T100000Z", "Current")));
+
+        var result = await sut.QueryEntitiesAsync(
+            new CalendarEntityQuery(CalendarEntityScope.Default, [CalendarEntityKind.Event]),
+            CancellationToken.None);
+
+        result.Items.ShouldHaveSingleItem().EntityTag.ShouldBe("\"new-revision\"");
+        result.Diagnostics.Select(item => item.Code).ShouldContain("resource_disappeared_during_query");
+    }
+
+    [Fact]
+    public async Task QueryEntitiesAsync_PreservesDistinctAuthorizedCandidateIdentitiesAcrossRedirectAliases()
+    {
+        const string calendarHref = "https://cal.example/events/";
+        var first = $"{calendarHref}old-a.ics";
+        var second = $"{calendarHref}old-b.ics";
+        var bytes = Event("current", "20260816T100000Z", "Current");
+        var client = Substitute.For<ICalendarClient>();
+        var sut = new CalendarService(
+            client,
+            Options.Create(new CalDavOptions { BaseUrl = "https://cal.example", DefaultEventCalendarName = "Events" }),
+            Substitute.For<ILogger<CalendarService>>());
+        client.GetCalendarsAsync(Arg.Any<CancellationToken>()).Returns(
+            [EntityCalendar(calendarHref, "Events", EntityKindSupport.Advertised, EntityKindSupport.NotAdvertised)]);
+        client.QueryCalendarResourceHrefsAsync(calendarHref, CalendarEntityKind.Event, null, null, Arg.Any<CancellationToken>())
+            .Returns([first, second]);
+        client.GetCalendarResourceAsync(first, Arg.Any<CancellationToken>()).Returns(
+            CalendarResourceRead.Success(first, "\"r1\"", bytes));
+        client.GetCalendarResourceAsync(second, Arg.Any<CancellationToken>()).Returns(
+            CalendarResourceRead.Success(second, "\"r1\"", bytes));
+
+        var result = await sut.QueryEntitiesAsync(
+            new CalendarEntityQuery(CalendarEntityScope.Default, [CalendarEntityKind.Event]),
+            CancellationToken.None);
+
+        result.Items.Select(item => item.ResourceHref).ShouldBe([first, second]);
+        await client.Received(1).GetCalendarResourceAsync(first, Arg.Any<CancellationToken>());
+        await client.Received(1).GetCalendarResourceAsync(second, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task QueryRedirectedSnapshot_UsesAuthorizedCandidateIdentityForCoherentDirectReread()
+    {
+        const string calendarHref = "https://cal.example/events/";
+        const string candidateHref = "https://cal.example/events/standup.ics";
+        const string redirectHref = "https://cal.example/redirected/current.ics";
+        var content = Event("standup", "20260816T100000Z", "Standup");
+        var requests = new List<Uri>();
+        var handler = new RedirectHttpMessageHandler(request =>
+        {
+            requests.Add(request.RequestUri!);
+            if (request.RequestUri!.AbsoluteUri == candidateHref)
+            {
+                return new HttpResponseMessage(HttpStatusCode.PermanentRedirect)
+                {
+                    Headers = { Location = new Uri(redirectHref) }
+                };
+            }
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Headers = { ETag = new EntityTagHeaderValue("\"revision-1\"") },
+                Content = new ByteArrayContent(content)
+            };
+        });
+        var options = Options.Create(new CalDavOptions
+        {
+            BaseUrl = "https://cal.example",
+            CalendarHrefs = calendarHref,
+            DefaultEventCalendarName = "Events"
+        });
+        using var httpClient = new HttpClient(handler);
+        var transport = new CalDavClient(httpClient, options, Substitute.For<ILogger<CalDavClient>>());
+        var client = new RedirectQueryCalendarClient(
+            transport,
+            EntityCalendar(calendarHref, "Events", EntityKindSupport.Advertised, EntityKindSupport.NotAdvertised),
+            candidateHref);
+        var sut = new CalendarService(client, options, Substitute.For<ILogger<CalendarService>>());
+
+        var query = await sut.QueryEntitiesAsync(
+            new CalendarEntityQuery(CalendarEntityScope.Default, [CalendarEntityKind.Event]),
+            CancellationToken.None);
+        var snapshot = query.Items.ShouldHaveSingleItem();
+        var reread = await sut.GetResourceAsync(snapshot.ResourceHref, CancellationToken.None);
+
+        snapshot.ResourceHref.ShouldBe(candidateHref);
+        snapshot.EntityTag.ShouldBe("\"revision-1\"");
+        reread.Code.ShouldBe(CalendarResourceReadCode.Success);
+        reread.Snapshot!.ResourceHref.ShouldBe(candidateHref);
+        reread.Snapshot.EntityTag.ShouldBe(snapshot.EntityTag);
+        reread.Snapshot.AuthoritativeUtf8.ToArray().ShouldBe(snapshot.AuthoritativeUtf8.ToArray());
+        requests.Select(uri => uri.AbsoluteUri).ShouldBe(
+            [candidateHref, redirectHref, candidateHref, redirectHref]);
+    }
+
+    [Fact]
+    public async Task QueryReportRedirectOutsideCalendarIdentity_FailsClosedAndCannotBeDirectlyReread()
+    {
+        const string calendarHref = "https://cal.example/events/";
+        const string redirectedCalendarHref = "https://cal.example/redirected/";
+        const string redirectedResourceHref = "https://cal.example/redirected/a.ics";
+        var requests = new List<HttpRequestMessage>();
+        var handler = new RedirectHttpMessageHandler(request =>
+        {
+            requests.Add(request);
+            if (request.RequestUri!.AbsoluteUri == calendarHref)
+            {
+                return new HttpResponseMessage(HttpStatusCode.PermanentRedirect)
+                {
+                    Headers = { Location = new Uri(redirectedCalendarHref) }
+                };
+            }
+            return new HttpResponseMessage(HttpStatusCode.MultiStatus)
+            {
+                Content = new StringContent(
+                    "<d:multistatus xmlns:d=\"DAV:\"><d:response><d:href>a.ics</d:href><d:status>HTTP/1.1 200 OK</d:status></d:response></d:multistatus>")
+            };
+        });
+        var options = Options.Create(new CalDavOptions
+        {
+            BaseUrl = "https://cal.example",
+            CalendarHrefs = calendarHref,
+            DefaultEventCalendarName = "Events"
+        });
+        using var httpClient = new HttpClient(handler);
+        var transport = new CalDavClient(httpClient, options, Substitute.For<ILogger<CalDavClient>>());
+        var client = new DelegatingQueryCalendarClient(
+            transport,
+            EntityCalendar(calendarHref, "Events", EntityKindSupport.Advertised, EntityKindSupport.NotAdvertised));
+        var sut = new CalendarService(client, options, Substitute.For<ILogger<CalendarService>>());
+
+        await Should.ThrowAsync<CalendarDiscoveryProtocolException>(() => sut.QueryEntitiesAsync(
+            new CalendarEntityQuery(CalendarEntityScope.Default, [CalendarEntityKind.Event]),
+            CancellationToken.None));
+        var directRead = await sut.GetResourceAsync(redirectedResourceHref, CancellationToken.None);
+
+        directRead.Code.ShouldBe(CalendarResourceReadCode.OutsideScope);
+        requests.Count.ShouldBe(2);
+        requests.ShouldAllBe(request => request.Method.Method == "REPORT");
+    }
+
+    [Fact]
+    public async Task QueryEntitiesAsync_WeakCandidateRevisionFailsWholeQueryWithoutPartialItems()
+    {
+        const string calendarHref = "https://cal.example/events/";
+        var current = $"{calendarHref}current.ics";
+        var weak = $"{calendarHref}weak.ics";
+        var client = Substitute.For<ICalendarClient>();
+        var sut = new CalendarService(
+            client,
+            Options.Create(new CalDavOptions { BaseUrl = "https://cal.example", DefaultEventCalendarName = "Events" }),
+            Substitute.For<ILogger<CalendarService>>());
+        client.GetCalendarsAsync(Arg.Any<CancellationToken>()).Returns(
+            [EntityCalendar(calendarHref, "Events", EntityKindSupport.Advertised, EntityKindSupport.NotAdvertised)]);
+        client.QueryCalendarResourceHrefsAsync(calendarHref, CalendarEntityKind.Event, null, null, Arg.Any<CancellationToken>())
+            .Returns([current, weak]);
+        client.GetCalendarResourceAsync(current, Arg.Any<CancellationToken>()).Returns(
+            CalendarResourceRead.Success(current, "\"r1\"", Event("current", "20260816T100000Z", "Current")));
+        client.GetCalendarResourceAsync(weak, Arg.Any<CancellationToken>()).Returns(
+            new CalendarResourceRead(CalendarResourceReadCode.ConcurrencyUnavailable));
+
+        var result = await sut.QueryEntitiesAsync(
+            new CalendarEntityQuery(CalendarEntityScope.Default, [CalendarEntityKind.Event]),
+            CancellationToken.None);
+
+        result.Code.ShouldBe(CalendarEntityQueryCode.ConcurrencyUnavailable);
+        result.Items.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task QueryEntitiesAsync_OversizedCandidateCarriesTruthfulObservedByteCount()
+    {
+        const string calendarHref = "https://cal.example/events/";
+        const string resourceHref = "https://cal.example/events/large.ics";
+        var client = Substitute.For<ICalendarClient>();
+        var sut = new CalendarService(
+            client,
+            Options.Create(new CalDavOptions { BaseUrl = "https://cal.example", DefaultEventCalendarName = "Events" }),
+            Substitute.For<ILogger<CalendarService>>());
+        client.GetCalendarsAsync(Arg.Any<CancellationToken>()).Returns(
+            [EntityCalendar(calendarHref, "Events", EntityKindSupport.Advertised, EntityKindSupport.NotAdvertised)]);
+        client.QueryCalendarResourceHrefsAsync(calendarHref, CalendarEntityKind.Event, null, null, Arg.Any<CancellationToken>())
+            .Returns([resourceHref]);
+        client.GetCalendarResourceAsync(resourceHref, Arg.Any<CancellationToken>()).Returns(
+            new CalendarResourceRead(CalendarResourceReadCode.PayloadTooLarge, ObservedByteCount: 4_194_305));
+
+        var result = await sut.QueryEntitiesAsync(
+            new CalendarEntityQuery(CalendarEntityScope.Default, [CalendarEntityKind.Event]),
+            CancellationToken.None);
+
+        result.Code.ShouldBe(CalendarEntityQueryCode.PayloadTooLarge);
+        result.Items.ShouldBeEmpty();
+        result.Limits.ShouldBe(new CalendarEntityQueryExecutionLimits(ByteCount: 4_194_305));
+    }
+
+    [Fact]
+    public async Task QueryEntitiesAsync_StopsBeforeDirectGetWhenDeadlineExpiresAfterReport()
+    {
+        const string calendarHref = "https://cal.example/events/";
+        const string resourceHref = "https://cal.example/events/a.ics";
+        using var cancellation = new CancellationTokenSource();
+        var client = Substitute.For<ICalendarClient>();
+        var sut = new CalendarService(
+            client,
+            Options.Create(new CalDavOptions { BaseUrl = "https://cal.example", DefaultEventCalendarName = "Events" }),
+            Substitute.For<ILogger<CalendarService>>());
+        client.GetCalendarsAsync(Arg.Any<CancellationToken>()).Returns(
+            [EntityCalendar(calendarHref, "Events", EntityKindSupport.Advertised, EntityKindSupport.NotAdvertised)]);
+        client.QueryCalendarResourceHrefsAsync(
+                calendarHref,
+                CalendarEntityKind.Event,
+                null,
+                null,
+                Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                cancellation.Cancel();
+                return Task.FromResult<IReadOnlyList<string>>([resourceHref]);
+            });
+
+        await Should.ThrowAsync<OperationCanceledException>(() => sut.QueryEntitiesAsync(
+            new CalendarEntityQuery(CalendarEntityScope.Default, [CalendarEntityKind.Event]),
+            cancellation.Token));
+
+        await client.DidNotReceive().GetCalendarResourceAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task QueryEntitiesAsync_CallerCancellationBeforeTemporalExpansionPropagatesWithNoItems()
+    {
+        const string calendarHref = "https://cal.example/events/";
+        const string resourceHref = "https://cal.example/events/recurring.ics";
+        var enteredRead = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseRead = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var cancellation = new CancellationTokenSource();
+        var client = Substitute.For<ICalendarClient>();
+        var sut = new CalendarService(
+            client,
+            Options.Create(new CalDavOptions { BaseUrl = "https://cal.example", DefaultEventCalendarName = "Events" }),
+            Substitute.For<ILogger<CalendarService>>());
+        client.GetCalendarsAsync(Arg.Any<CancellationToken>()).Returns(
+            [EntityCalendar(calendarHref, "Events", EntityKindSupport.Advertised, EntityKindSupport.NotAdvertised)]);
+        var from = DateTimeOffset.Parse("2026-08-15T12:00:00Z");
+        var to = DateTimeOffset.Parse("2026-08-15T13:00:00Z");
+        client.QueryCalendarResourceHrefsAsync(calendarHref, CalendarEntityKind.Event, from, to, Arg.Any<CancellationToken>())
+            .Returns([resourceHref]);
+        client.GetCalendarResourceAsync(resourceHref, Arg.Any<CancellationToken>()).Returns(async _ =>
+        {
+            enteredRead.TrySetResult();
+            await releaseRead.Task;
+            return CalendarResourceRead.Success(
+                resourceHref,
+                "\"r1\"",
+                RecurringEventWithRule("recurring", "RRULE:FREQ=SECONDLY;COUNT=2000\r\n"));
+        });
+
+        var pending = sut.QueryEntitiesAsync(
+            new CalendarEntityQuery(CalendarEntityScope.Default, [CalendarEntityKind.Event], from, to),
+            cancellation.Token);
+        await enteredRead.Task;
+        cancellation.Cancel();
+        releaseRead.TrySetResult();
+
+        await Should.ThrowAsync<OperationCanceledException>(() => pending);
+    }
+
+    [Theory]
+    [InlineData("https://other.example/events/", CalendarEntityQueryCode.UnsafeScope)]
+    [InlineData("https://user:secret@cal.example/events/", CalendarEntityQueryCode.UnsafeScope)]
+    [InlineData("https://cal.example/events/#fragment", CalendarEntityQueryCode.UnsafeScope)]
+    [InlineData("https://cal.example/events/?private=true", CalendarEntityQueryCode.UnsafeScope)]
+    [InlineData("https://cal.example/events%2Fprivate/", CalendarEntityQueryCode.UnsafeScope)]
+    [InlineData("https://cal.example/events/%2e%2e/private/", CalendarEntityQueryCode.UnsafeScope)]
+    [InlineData("https://cal.example/events\\private/", CalendarEntityQueryCode.UnsafeScope)]
+    [InlineData("https://cal.example/private/", CalendarEntityQueryCode.OutsideScope)]
+    public async Task QueryEntitiesAsync_PrevalidatesSelectedHrefBeforeDiscovery(
+        string href,
+        CalendarEntityQueryCode expectedCode)
+    {
+        var client = Substitute.For<ICalendarClient>();
+        var sut = new CalendarService(
+            client,
+            Options.Create(new CalDavOptions
+            {
+                BaseUrl = "https://cal.example",
+                CalendarHrefs = "https://cal.example/events/"
+            }),
+            Substitute.For<ILogger<CalendarService>>());
+
+        var result = await sut.QueryEntitiesAsync(
+            new CalendarEntityQuery(
+                CalendarEntityScope.Selected(new CalendarReference(Href: href)),
+                [CalendarEntityKind.Event]),
+            CancellationToken.None);
+
+        result.Code.ShouldBe(expectedCode);
+        await client.DidNotReceive().GetCalendarsAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task QueryEntitiesAsync_FiltersActualKindBeforeTemporalDiagnostics()
+    {
+        const string calendarHref = "https://cal.example/mixed/";
+        const string resourceHref = "https://cal.example/mixed/todo.ics";
+        var client = Substitute.For<ICalendarClient>();
+        var sut = new CalendarService(
+            client,
+            Options.Create(new CalDavOptions { BaseUrl = "https://cal.example", DefaultEventCalendarName = "Mixed" }),
+            Substitute.For<ILogger<CalendarService>>());
+        client.GetCalendarsAsync(Arg.Any<CancellationToken>()).Returns(
+            [EntityCalendar(calendarHref, "Mixed", EntityKindSupport.Advertised, EntityKindSupport.Advertised)]);
+        var from = DateTimeOffset.Parse("2026-08-16T09:00:00Z");
+        var to = DateTimeOffset.Parse("2026-08-16T11:00:00Z");
+        client.QueryCalendarResourceHrefsAsync(calendarHref, CalendarEntityKind.Event, from, to, Arg.Any<CancellationToken>())
+            .Returns([resourceHref]);
+        client.GetCalendarResourceAsync(resourceHref, Arg.Any<CancellationToken>()).Returns(
+            CalendarResourceRead.Success(resourceHref, "\"r1\"", TodoWithTiming("todo", "20260816T100000", "20260816T103000")));
+
+        var result = await sut.QueryEntitiesAsync(
+            new CalendarEntityQuery(CalendarEntityScope.Default, [CalendarEntityKind.Event], from, to),
+            CancellationToken.None);
+
+        result.Items.ShouldBeEmpty();
+        result.Diagnostics.Select(item => item.Code).ShouldNotContain("temporal_filter_unresolved");
+    }
+
     [Fact]
     public async Task GetResourceAsync_ReturnsOneRevisionCoherentEventSnapshot()
     {
@@ -342,4 +1606,161 @@ public sealed class CalendarServiceTests
             EventSupport = EntityKindSupport.Advertised,
             TodoSupport = todoSupport
         };
+
+    private static CalendarDescriptor EntityCalendar(
+        string href,
+        string displayName,
+        EntityKindSupport eventSupport,
+        EntityKindSupport todoSupport) => new()
+        {
+            Href = href,
+            DisplayName = displayName,
+            DisplayNameProvenance = DisplayNameProvenance.DavDisplayName,
+            EventSupport = eventSupport,
+            TodoSupport = todoSupport
+        };
+
+    private static byte[] Event(string uid, string start, string summary) => System.Text.Encoding.UTF8.GetBytes(
+        $"BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Example//EN\r\nBEGIN:VEVENT\r\nUID:{uid}\r\nDTSTAMP:20260815T120000Z\r\nDTSTART:{start}\r\nSUMMARY:{summary}\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n");
+
+    private static byte[] EventWithEnd(string uid, string start, string end) => System.Text.Encoding.UTF8.GetBytes(
+        $"BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Example//EN\r\nBEGIN:VEVENT\r\nUID:{uid}\r\nDTSTAMP:20260815T120000Z\r\nDTSTART:{start}\r\nDTEND:{end}\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n");
+
+    private static byte[] Todo(string uid, string summary) => System.Text.Encoding.UTF8.GetBytes(
+        $"BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Example//EN\r\nBEGIN:VTODO\r\nUID:{uid}\r\nDTSTAMP:20260815T120000Z\r\nSUMMARY:{summary}\r\nEND:VTODO\r\nEND:VCALENDAR\r\n");
+
+    private static byte[] TodoWithTiming(string uid, string? start, string due)
+    {
+        var startLine = start is null ? string.Empty : $"DTSTART:{start}\r\n";
+        return System.Text.Encoding.UTF8.GetBytes(
+            $"BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Example//EN\r\nBEGIN:VTODO\r\nUID:{uid}\r\nDTSTAMP:20260815T120000Z\r\n{startLine}DUE:{due}\r\nEND:VTODO\r\nEND:VCALENDAR\r\n");
+    }
+
+    private static byte[] EventWithRawStart(string uid, string parameter, string start) => System.Text.Encoding.UTF8.GetBytes(
+        $"BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Example//EN\r\nBEGIN:VEVENT\r\nUID:{uid}\r\nDTSTAMP:20260815T120000Z\r\nDTSTART{parameter}:{start}\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n");
+
+    private static byte[] RecurringEvent(string uid, string? exceptionDate)
+    {
+        var exceptionLine = exceptionDate is null ? string.Empty : $"EXDATE:{exceptionDate}\r\n";
+        return System.Text.Encoding.UTF8.GetBytes(
+            $"BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Example//EN\r\nBEGIN:VEVENT\r\nUID:{uid}\r\nDTSTAMP:20260815T120000Z\r\nDTSTART:20260814T100000Z\r\nDURATION:PT1H\r\nRRULE:FREQ=DAILY;COUNT=4\r\n{exceptionLine}END:VEVENT\r\nEND:VCALENDAR\r\n");
+    }
+
+    private static byte[] RecurringTodo(string uid) => System.Text.Encoding.UTF8.GetBytes(
+        $"BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Example//EN\r\nBEGIN:VTODO\r\nUID:{uid}\r\nDTSTAMP:20260815T120000Z\r\nDTSTART:20260815T100000Z\r\nDUE:20260815T103000Z\r\nRRULE:FREQ=DAILY;COUNT=2\r\nEND:VTODO\r\nEND:VCALENDAR\r\n");
+
+    private static byte[] RecurringEventWithRule(string uid, string recurrenceLines) => System.Text.Encoding.UTF8.GetBytes(
+        $"BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Example//EN\r\nBEGIN:VEVENT\r\nUID:{uid}\r\nDTSTAMP:20260815T120000Z\r\nDTSTART:20260815T120000Z\r\nDURATION:PT1S\r\n{recurrenceLines}END:VEVENT\r\nEND:VCALENDAR\r\n");
+
+    private static byte[] Mixed(string eventUid, string todoUid) => System.Text.Encoding.UTF8.GetBytes(
+        $"BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Example//EN\r\nBEGIN:VEVENT\r\nUID:{eventUid}\r\nDTSTAMP:20260815T120000Z\r\nDTSTART:20260816T090000Z\r\nEND:VEVENT\r\nBEGIN:VTODO\r\nUID:{todoUid}\r\nDTSTAMP:20260815T120000Z\r\nEND:VTODO\r\nEND:VCALENDAR\r\n");
+
+    private static async Task<CalendarEntityQueryResult> QuerySingleEventAsync(
+        string temporalLines,
+        string from,
+        string to,
+        string calendarLines = "")
+    {
+        const string calendarHref = "https://cal.example/events/";
+        const string resourceHref = "https://cal.example/events/temporal.ics";
+        var client = Substitute.For<ICalendarClient>();
+        var sut = new CalendarService(
+            client,
+            Options.Create(new CalDavOptions { BaseUrl = "https://cal.example", DefaultEventCalendarName = "Events" }),
+            Substitute.For<ILogger<CalendarService>>());
+        client.GetCalendarsAsync(Arg.Any<CancellationToken>()).Returns(
+            [EntityCalendar(calendarHref, "Events", EntityKindSupport.Advertised, EntityKindSupport.NotAdvertised)]);
+        var start = DateTimeOffset.Parse(from);
+        var end = DateTimeOffset.Parse(to);
+        client.QueryCalendarResourceHrefsAsync(calendarHref, CalendarEntityKind.Event, start, end, Arg.Any<CancellationToken>())
+            .Returns([resourceHref]);
+        var bytes = System.Text.Encoding.UTF8.GetBytes(
+            $"BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Example//EN\r\n{calendarLines}"
+            + $"BEGIN:VEVENT\r\nUID:temporal\r\nDTSTAMP:20260815T120000Z\r\n{temporalLines}END:VEVENT\r\nEND:VCALENDAR\r\n");
+        client.GetCalendarResourceAsync(resourceHref, Arg.Any<CancellationToken>())
+            .Returns(CalendarResourceRead.Success(resourceHref, "\"r1\"", bytes));
+        return await sut.QueryEntitiesAsync(
+            new CalendarEntityQuery(CalendarEntityScope.Default, [CalendarEntityKind.Event], start, end),
+            CancellationToken.None);
+    }
+
+    private static async Task<CalendarEntityQueryResult> QueryRecurringCountsAsync(params int[] occurrenceCounts)
+    {
+        const string calendarHref = "https://cal.example/events/";
+        var hrefs = occurrenceCounts.Select((_, index) => $"{calendarHref}{index}.ics").ToArray();
+        var client = Substitute.For<ICalendarClient>();
+        var sut = new CalendarService(
+            client,
+            Options.Create(new CalDavOptions { BaseUrl = "https://cal.example", DefaultEventCalendarName = "Events" }),
+            Substitute.For<ILogger<CalendarService>>());
+        client.GetCalendarsAsync(Arg.Any<CancellationToken>()).Returns(
+            [EntityCalendar(calendarHref, "Events", EntityKindSupport.Advertised, EntityKindSupport.NotAdvertised)]);
+        var from = DateTimeOffset.Parse("2026-08-15T12:00:00Z");
+        var to = DateTimeOffset.Parse("2026-08-15T13:00:00Z");
+        client.QueryCalendarResourceHrefsAsync(calendarHref, CalendarEntityKind.Event, from, to, Arg.Any<CancellationToken>())
+            .Returns(hrefs);
+        for (var index = 0; index < hrefs.Length; index++)
+        {
+            var resourceIndex = index;
+            client.GetCalendarResourceAsync(hrefs[index], Arg.Any<CancellationToken>()).Returns(
+                CalendarResourceRead.Success(
+                    hrefs[index],
+                    $"\"r{index}\"",
+                    RecurringEventWithRule(
+                        $"recurring-{index}",
+                        $"RRULE:FREQ=SECONDLY;COUNT={occurrenceCounts[resourceIndex]}\r\n")));
+        }
+        return await sut.QueryEntitiesAsync(
+            new CalendarEntityQuery(CalendarEntityScope.Default, [CalendarEntityKind.Event], from, to),
+            CancellationToken.None);
+    }
+
+    private sealed class RedirectQueryCalendarClient(
+        ICalendarClient transport,
+        CalendarDescriptor calendar,
+        string candidateHref) : ICalendarClient
+    {
+        public Task<IReadOnlyList<CalendarDescriptor>> GetCalendarsAsync(CancellationToken cancellationToken) =>
+            Task.FromResult<IReadOnlyList<CalendarDescriptor>>([calendar]);
+
+        public Task<IReadOnlyList<string>> QueryCalendarResourceHrefsAsync(
+            string calendarHref,
+            CalendarEntityKind entityKind,
+            DateTimeOffset? from,
+            DateTimeOffset? to,
+            CancellationToken cancellationToken) => Task.FromResult<IReadOnlyList<string>>([candidateHref]);
+
+        public Task<CalendarResourceRead> GetCalendarResourceAsync(string href, CancellationToken cancellationToken) =>
+            transport.GetCalendarResourceAsync(href, cancellationToken);
+    }
+
+    private sealed class DelegatingQueryCalendarClient(
+        ICalendarClient transport,
+        CalendarDescriptor calendar) : ICalendarClient
+    {
+        public Task<IReadOnlyList<CalendarDescriptor>> GetCalendarsAsync(CancellationToken cancellationToken) =>
+            Task.FromResult<IReadOnlyList<CalendarDescriptor>>([calendar]);
+
+        public Task<IReadOnlyList<string>> QueryCalendarResourceHrefsAsync(
+            string calendarHref,
+            CalendarEntityKind entityKind,
+            DateTimeOffset? from,
+            DateTimeOffset? to,
+            CancellationToken cancellationToken) => transport.QueryCalendarResourceHrefsAsync(
+                calendarHref,
+                entityKind,
+                from,
+                to,
+                cancellationToken);
+
+        public Task<CalendarResourceRead> GetCalendarResourceAsync(string href, CancellationToken cancellationToken) =>
+            transport.GetCalendarResourceAsync(href, cancellationToken);
+    }
+
+    private sealed class RedirectHttpMessageHandler(Func<HttpRequestMessage, HttpResponseMessage> handler) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken) => Task.FromResult(handler(request));
+    }
 }

--- a/tests/DotnetAgents.CalDav.IntegrationTests/CalendarMcpRawStdioTests.cs
+++ b/tests/DotnetAgents.CalDav.IntegrationTests/CalendarMcpRawStdioTests.cs
@@ -1,0 +1,147 @@
+using System.Diagnostics;
+using System.Text.Json;
+using DotnetAgents.CalDav.Mcp.Tools;
+using Shouldly;
+using Xunit;
+
+namespace DotnetAgents.CalDav.IntegrationTests;
+
+/// <summary>Exercises raw JSON evidence that the SDK's dictionary client cannot represent.</summary>
+public sealed class CalendarMcpRawStdioTests
+{
+    [Fact]
+    public async Task CalendarEntityQuery_NormalInvalidArgumentsReturnTypedInvalidInputBeforeNetwork()
+    {
+        const string request = """
+            {"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"calendar_entities.query","arguments":{"scope":{"mode":"default"},"entityKinds":["event"],"unknown":true}}}
+            """;
+
+        var result = await InvokeRawAsync(request);
+
+        AssertTypedError(result, "invalid_input", "schemaLexicalDiscriminator");
+    }
+
+    [Fact]
+    public async Task CalendarEntityQuery_SelectedNameWithInternalSpacesReachesTheService()
+    {
+        const string request = """
+            {"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"calendar_entities.query","arguments":{"scope":{"mode":"selected","calendar":{"by":"name","name":"No such authorized calendar"}},"entityKinds":["todo"]}}}
+            """;
+
+        var result = await InvokeRawAsync(request);
+
+        AssertTypedError(result, "upstream_unavailable", "execution");
+    }
+
+    [Fact]
+    public async Task CalendarEntityQuery_RootDuplicateArgumentsReturnTypedInvalidInputBeforeNetwork()
+    {
+        const string request = """
+            {"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"calendar_entities.query","arguments":{"scope":{"mode":"default"},"scope":{"mode":"all"},"entityKinds":["event"]}}}
+            """;
+
+        var result = await InvokeRawAsync(request);
+
+        AssertTypedError(result, "invalid_input", "schemaLexicalDiscriminator");
+    }
+
+    [Fact]
+    public async Task CalendarEntityQuery_OversizedDuplicateArgumentsPreferPayloadAdmissionFailure()
+    {
+        var padding = new string('x', CalendarEntityTools.MaximumArgumentBytes);
+        var request = "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/call\",\"params\":{\"name\":\"calendar_entities.query\",\"arguments\":{\"scope\":{\"mode\":\"default\"},\"scope\":{\"mode\":\"all\"},\"entityKinds\":[\"event\"],\"padding\":\""
+            + padding
+            + "\"}}}";
+
+        var result = await InvokeRawAsync(request);
+
+        AssertTypedError(result, "payload_too_large", "admissionAndPayload");
+    }
+
+    private static async Task<JsonElement> InvokeRawAsync(string toolRequest)
+    {
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+        using var process = StartServer();
+        try
+        {
+            await process.StandardInput.WriteLineAsync(
+                "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":\"2026-07-28\",\"capabilities\":{},\"clientInfo\":{\"name\":\"raw-test\",\"version\":\"1\"}}}");
+            await process.StandardInput.FlushAsync(timeout.Token);
+            _ = await ReadResponseAsync(process, 1, timeout.Token);
+            await process.StandardInput.WriteLineAsync(
+                "{\"jsonrpc\":\"2.0\",\"method\":\"notifications/initialized\"}");
+            await process.StandardInput.WriteLineAsync(toolRequest);
+            await process.StandardInput.FlushAsync(timeout.Token);
+            var response = await ReadResponseAsync(process, 2, timeout.Token);
+            process.StandardInput.Close();
+            await process.WaitForExitAsync(timeout.Token);
+            (await process.StandardError.ReadToEndAsync(timeout.Token)).ShouldBeEmpty();
+            return response.GetProperty("result").Clone();
+        }
+        finally
+        {
+            if (!process.HasExited)
+                process.Kill(entireProcessTree: true);
+        }
+    }
+
+    private static Process StartServer()
+    {
+        var startInfo = new ProcessStartInfo("dotnet", GetServerAssemblyPath())
+        {
+            WorkingDirectory = AppContext.BaseDirectory,
+            RedirectStandardInput = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false
+        };
+        startInfo.Environment["CALDAV_URL"] = "http://127.0.0.1:1";
+        startInfo.Environment["CALDAV_USERNAME"] = "test";
+        startInfo.Environment["CALDAV_PASSWORD"] = "test";
+        startInfo.Environment["CALDAV_CALENDAR_HREFS"] = "http://127.0.0.1:1/calendars/test/";
+        return Process.Start(startInfo)!;
+    }
+
+    private static async Task<JsonElement> ReadResponseAsync(
+        Process process,
+        int expectedId,
+        CancellationToken cancellationToken)
+    {
+        while (await process.StandardOutput.ReadLineAsync(cancellationToken) is { } line)
+        {
+            using var document = JsonDocument.Parse(line);
+            if (document.RootElement.TryGetProperty("id", out var id) && id.GetInt32() == expectedId)
+                return document.RootElement.Clone();
+        }
+        throw new InvalidOperationException("The MCP server closed stdout before returning the expected response.");
+    }
+
+    private static void AssertTypedError(JsonElement result, string code, string phase)
+    {
+        result.GetProperty("isError").GetBoolean().ShouldBeTrue();
+        var structured = result.GetProperty("structuredContent");
+        structured.GetProperty("code").GetString().ShouldBe(code);
+        structured.GetProperty("phase").GetString().ShouldBe(phase);
+        structured.TryGetProperty("items", out _).ShouldBeFalse();
+    }
+
+    private static string GetServerAssemblyPath()
+    {
+        var directory = AppContext.BaseDirectory;
+        while (directory is not null)
+        {
+            var candidate = Path.Combine(
+                directory,
+                "src",
+                "DotnetAgents.CalDav.Mcp",
+                "bin",
+                "Release",
+                "net10.0",
+                "DotnetAgents.CalDav.Mcp.dll");
+            if (File.Exists(candidate))
+                return candidate;
+            directory = Directory.GetParent(directory)?.FullName;
+        }
+        throw new FileNotFoundException("Could not locate the built MCP server assembly.");
+    }
+}

--- a/tests/DotnetAgents.CalDav.IntegrationTests/CalendarMcpStdioIntegrationTests.cs
+++ b/tests/DotnetAgents.CalDav.IntegrationTests/CalendarMcpStdioIntegrationTests.cs
@@ -49,6 +49,7 @@ public sealed class CalendarMcpStdioIntegrationTests
         listedTools.Tools.Select(tool => tool.Name).ShouldBe(
         [
             "calendars.list",
+            "calendar_entities.query",
             "calendar_resources.get",
             "list_task_lists",
             "show_tasks",
@@ -70,6 +71,133 @@ public sealed class CalendarMcpStdioIntegrationTests
         structured.GetProperty("items").GetArrayLength().ShouldBe(1);
         structured.GetProperty("items")[0].GetProperty("calendar").GetProperty("href").GetString()
             .ShouldBe($"{_fixture.BaseUrl}{_fixture.TaskListHref}");
+        stderr.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task CalendarEntityQuery_ReturnsSchemaValidSnapshotsAndTypedFailureOverStdio()
+    {
+        var stderr = new ConcurrentQueue<string>();
+        await using var client = await CreateClientAsync(stderr, exposeExact: false);
+        var tools = await client.ListToolsAsync(new ListToolsRequestParams(), TestContext.Current.CancellationToken);
+        var advertised = tools.Tools.Single(tool => tool.Name == "calendar_entities.query");
+        var selectedScope = new Dictionary<string, object?>
+        {
+            ["mode"] = "selected",
+            ["calendar"] = new Dictionary<string, object?>
+            {
+                ["by"] = "href",
+                ["href"] = $"{_fixture.BaseUrl}{_fixture.TaskListHref}"
+            }
+        };
+
+        var success = await client.CallToolAsync(
+            "calendar_entities.query",
+            new Dictionary<string, object?>
+            {
+                ["scope"] = selectedScope,
+                ["entityKinds"] = new[] { "todo" },
+                ["pageSize"] = 1
+            },
+            cancellationToken: TestContext.Current.CancellationToken);
+        var failure = await client.CallToolAsync(
+            "calendar_entities.query",
+            new Dictionary<string, object?>
+            {
+                ["scope"] = new Dictionary<string, object?>
+                {
+                    ["mode"] = "selected",
+                    ["calendar"] = new Dictionary<string, object?>
+                    {
+                        ["by"] = "name",
+                        ["name"] = "No such authorized calendar"
+                    }
+                },
+                ["entityKinds"] = new[] { "todo" }
+            },
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        success.IsError.ShouldBe(false);
+        var structured = success.StructuredContent!.Value;
+        structured.EnumerateObject().Select(property => property.Name)
+            .ShouldBe(["outcome", "items", "diagnostics", "pagination"]);
+        structured.GetProperty("outcome").GetString().ShouldBe("success");
+        structured.GetProperty("items").GetArrayLength().ShouldBe(1);
+        structured.GetProperty("items")[0].GetProperty("resourceRevision").GetProperty("entityTag").GetString()
+            .ShouldStartWith("\"");
+        structured.GetProperty("pagination").GetProperty("mode").GetString().ShouldBe("non_snapshot");
+        structured.GetProperty("diagnostics").ValueKind.ShouldBe(System.Text.Json.JsonValueKind.Array);
+        advertised.OutputSchema.ShouldNotBeNull();
+        advertised.OutputSchema.Value.GetProperty("oneOf").GetArrayLength().ShouldBe(2);
+        advertised.InputSchema.GetProperty("additionalProperties").GetBoolean().ShouldBeFalse();
+        failure.IsError.ShouldBe(true);
+        var error = failure.StructuredContent!.Value;
+        error.EnumerateObject().Select(property => property.Name)
+            .ShouldBe(["code", "category", "message", "retryable", "phase", "authorizedCandidates"]);
+        error.GetProperty("code").GetString().ShouldBe("not_found");
+        error.GetProperty("category").GetString().ShouldBe("selection");
+        error.GetProperty("message").GetString().ShouldNotBeNullOrWhiteSpace();
+        error.GetProperty("retryable").GetBoolean().ShouldBeFalse();
+        error.GetProperty("phase").GetString().ShouldBe("selectionDiscoveryCapability");
+        var candidate = error.GetProperty("authorizedCandidates").EnumerateArray().ShouldHaveSingleItem();
+        candidate.EnumerateObject().Select(property => property.Name)
+            .ShouldBe(["calendar", "displayName", "entityKinds"]);
+        candidate.GetProperty("calendar").GetProperty("href").GetString()
+            .ShouldBe($"{_fixture.BaseUrl}{_fixture.TaskListHref}");
+        candidate.GetProperty("displayName").GetString().ShouldBe("Tasks");
+        candidate.GetProperty("entityKinds").EnumerateObject().Select(property => property.Name)
+            .ShouldBe(["event", "todo"]);
+        error.TryGetProperty("items", out _).ShouldBeFalse();
+        stderr.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task CalendarEntityQuery_InvalidRawShapesReturnTypedErrorsWithoutNetwork()
+    {
+        var stderr = new ConcurrentQueue<string>();
+        await using var client = await CreateClientAsync(
+            stderr,
+            exposeExact: false,
+            baseUrl: "http://127.0.0.1:1");
+        using var duplicateScope = System.Text.Json.JsonDocument.Parse("""{"mode":"default","mode":"all"}""");
+        var invalidArguments = new Dictionary<string, object?>[]
+        {
+            new()
+            {
+                ["scope"] = new Dictionary<string, object?> { ["mode"] = "default" },
+                ["entityKinds"] = new[] { "event" },
+                ["unknown"] = true
+            },
+            new()
+            {
+                ["scope"] = new Dictionary<string, object?> { ["mode"] = "default", ["unknown"] = true },
+                ["entityKinds"] = new[] { "event" }
+            },
+            new() { ["scope"] = new Dictionary<string, object?> { ["mode"] = "default" } },
+            new()
+            {
+                ["scope"] = new Dictionary<string, object?> { ["mode"] = "default" },
+                ["entityKinds"] = "event"
+            },
+            new()
+            {
+                ["scope"] = duplicateScope.RootElement,
+                ["entityKinds"] = new[] { "event" }
+            }
+        };
+
+        for (var index = 0; index < invalidArguments.Length; index++)
+        {
+            var arguments = invalidArguments[index];
+            var result = await client.CallToolAsync(
+                "calendar_entities.query",
+                arguments,
+                cancellationToken: TestContext.Current.CancellationToken);
+            result.IsError.ShouldBe(true);
+            result.StructuredContent.ShouldNotBeNull($"invalid argument case {index}");
+            result.StructuredContent!.Value.GetProperty("code").GetString().ShouldBe("invalid_input");
+            result.StructuredContent.Value.GetProperty("phase").GetString().ShouldBe("schemaLexicalDiscriminator");
+        }
         stderr.ShouldBeEmpty();
     }
 
@@ -118,6 +246,7 @@ public sealed class CalendarMcpStdioIntegrationTests
         tools.Tools.Select(tool => tool.Name).ShouldBe(
         [
             "calendars.list",
+            "calendar_entities.query",
             "calendar_resources.get",
             "calendar_resources.exact_get",
             "list_task_lists",
@@ -137,9 +266,17 @@ public sealed class CalendarMcpStdioIntegrationTests
         stderr.ShouldBeEmpty();
     }
 
-    private async Task<McpClient> CreateClientAsync(ConcurrentQueue<string> stderr, bool exposeExact)
+    private async Task<McpClient> CreateClientAsync(
+        ConcurrentQueue<string> stderr,
+        bool exposeExact,
+        string? baseUrl = null)
     {
         var environment = CreateEnvironment();
+        if (baseUrl is not null)
+        {
+            environment["CALDAV_URL"] = baseUrl;
+            environment["CALDAV_CALENDAR_HREFS"] = $"{baseUrl}/calendars/test/";
+        }
         environment["CALDAV_EXPOSE_EXACT_TOOLS"] = exposeExact ? "true" : "false";
         var transport = new StdioClientTransport(new StdioClientTransportOptions
         {

--- a/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/CalDavHostBuilderTests.cs
+++ b/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/CalDavHostBuilderTests.cs
@@ -195,6 +195,7 @@ public class CalDavHostBuilderTests
         registeredToolTypes.ShouldBe(
         [
             typeof(DotnetAgents.CalDav.Mcp.Tools.CalendarTools),
+            typeof(DotnetAgents.CalDav.Mcp.Tools.CalendarEntityTools),
             typeof(DotnetAgents.CalDav.Mcp.Tools.CalendarResourceTools),
             typeof(DotnetAgents.CalDav.Mcp.Tools.TaskListTools),
             typeof(DotnetAgents.CalDav.Mcp.Tools.ChatTaskTools)
@@ -218,6 +219,41 @@ public class CalDavHostBuilderTests
         outputSchema["$defs"]!.AsObject().ShouldContainKey("errorOutcome");
         tool.ProtocolTool.Meta!["cache"]!["ttlMs"]!.GetValue<int>().ShouldBe(0);
         tool.ProtocolTool.Meta!["cache"]!["cacheScope"]!.GetValue<string>().ShouldBe("private");
+    }
+
+    [Fact]
+    public void BuildHost_AdvertisesFrozenEntityQuerySchemasAndPrivateCacheHint()
+    {
+        var builder = CalDavHostBuilder.CreateBuilder();
+        builder.Services.ConfigureCalDav(ValidOptions);
+        using var host = builder.Build();
+
+        var options = host.Services.GetRequiredService<IOptions<ModelContextProtocol.Server.McpServerOptions>>().Value;
+        options.ToolCollection!.TryGetPrimitive("calendar_entities.query", out var tool).ShouldBeTrue();
+
+        var inputSchema = JsonNode.Parse(tool!.ProtocolTool.InputSchema.GetRawText())!.AsObject();
+        var outputSchema = JsonNode.Parse(tool.ProtocolTool.OutputSchema!.Value.GetRawText())!.AsObject();
+        inputSchema["additionalProperties"]!.GetValue<bool>().ShouldBeFalse();
+        inputSchema["required"]!.AsArray().Select(item => item!.GetValue<string>())
+            .ShouldBe(["scope", "entityKinds"]);
+        outputSchema["oneOf"]!.AsArray().Count.ShouldBe(2);
+        outputSchema["$defs"]!.AsObject().ShouldContainKey("entityQuerySuccess");
+        outputSchema["$defs"]!.AsObject().ShouldContainKey("errorOutcome");
+        tool.ProtocolTool.Meta!["cache"]!["ttlMs"]!.GetValue<int>().ShouldBe(5000);
+        tool.ProtocolTool.Meta!["cache"]!["cacheScope"]!.GetValue<string>().ShouldBe("private");
+    }
+
+    [Fact]
+    public void BuildHost_ActivatesCalendarEntityToolsThroughTheSdkConstructionPath()
+    {
+        var builder = CalDavHostBuilder.CreateBuilder();
+        builder.Services.ConfigureCalDav(ValidOptions);
+        using var host = builder.Build();
+
+        host.Services.GetRequiredService<DotnetAgents.CalDav.Mcp.Tools.CalendarEntityTools>()
+            .ShouldNotBeNull();
+        ActivatorUtilities.CreateInstance<DotnetAgents.CalDav.Mcp.Tools.CalendarEntityTools>(host.Services)
+            .ShouldNotBeNull();
     }
 
     [Fact]
@@ -257,6 +293,7 @@ public class CalDavHostBuilderTests
         tools.ShouldBe(
         [
             "calendars.list",
+            "calendar_entities.query",
             "calendar_resources.get",
             "list_task_lists",
             "show_tasks",
@@ -294,6 +331,7 @@ public class CalDavHostBuilderTests
         tools.ShouldBe(
         [
             "calendars.list",
+            "calendar_entities.query",
             "calendar_resources.get",
             "list_task_lists",
             "show_tasks",

--- a/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/CalendarEntityToolsTests.cs
+++ b/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/CalendarEntityToolsTests.cs
@@ -1,0 +1,976 @@
+using System.Text;
+using System.Net;
+using System.Text.Json;
+using System.Xml;
+using DotnetAgents.CalDav.Core.Abstractions;
+using DotnetAgents.CalDav.Core.Configuration;
+using DotnetAgents.CalDav.Core.Models;
+using DotnetAgents.CalDav.Core.Services;
+using DotnetAgents.CalDav.Mcp.Tools;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using ModelContextProtocol.Protocol;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace DotnetAgents.CalDav.Mcp.Tests.Unit;
+
+public sealed class CalendarEntityToolsTests
+{
+    private static readonly DateTimeOffset Now = new(2026, 8, 15, 12, 0, 0, TimeSpan.Zero);
+
+    [Theory]
+    [InlineData(0, "invalid_input")]
+    [InlineData(1, "payload_too_large")]
+    public async Task QueryRawAsync_EnforcesExactArgumentByteBoundary(int extraByte, string expectedCode)
+    {
+        var service = Substitute.For<ICalendarService>();
+        var sut = CreateTool(service, new MutableTimeProvider(Now));
+        var arguments = ArgumentsWithSerializedSize(CalendarEntityTools.MaximumArgumentBytes + extraByte);
+
+        var result = await sut.QueryRawAsync(arguments, CancellationToken.None);
+
+        JsonSerializer.SerializeToUtf8Bytes(arguments).Length.ShouldBe(CalendarEntityTools.MaximumArgumentBytes + extraByte);
+        result.StructuredContent!.Value.GetProperty("code").GetString().ShouldBe(expectedCode);
+        await service.DidNotReceive().QueryEntitiesAsync(Arg.Any<CalendarEntityQuery>(), Arg.Any<CancellationToken>());
+    }
+
+    [Theory]
+    [InlineData(0, false)]
+    [InlineData(1, true)]
+    public void EnsureBoundedResult_EnforcesExactHumanReadableByteBoundary(int extraByte, bool rejected)
+    {
+        var result = ResultWithHumanReadableSize(CalendarEntityTools.MaximumHumanReadableBytes + extraByte);
+
+        var bounded = CalendarEntityTools.EnsureBoundedResult(result);
+
+        CalendarEntityTools.MeasureHumanReadableResult(result)
+            .ShouldBe(CalendarEntityTools.MaximumHumanReadableBytes + extraByte);
+        bounded.IsError.ShouldBe(rejected);
+        if (rejected)
+            bounded.StructuredContent!.Value.GetProperty("code").GetString().ShouldBe("payload_too_large");
+    }
+
+    [Theory]
+    [InlineData(0, false)]
+    [InlineData(1, true)]
+    public void EnsureBoundedResult_EnforcesExactStructuredByteBoundary(int extraByte, bool rejected)
+    {
+        var result = ResultWithStructuredSize(CalendarEntityTools.MaximumStructuredResultBytes + extraByte);
+
+        var bounded = CalendarEntityTools.EnsureBoundedResult(result);
+
+        CalendarEntityTools.MeasureResult(result)
+            .ShouldBe(CalendarEntityTools.MaximumStructuredResultBytes + extraByte);
+        bounded.IsError.ShouldBe(rejected);
+        if (rejected)
+            bounded.StructuredContent!.Value.GetProperty("code").GetString().ShouldBe("payload_too_large");
+    }
+
+    [Theory]
+    [InlineData(CalendarEntityQueryCode.InvalidInput, "invalid_input")]
+    [InlineData(CalendarEntityQueryCode.UnsafeScope, "invalid_input")]
+    [InlineData(CalendarEntityQueryCode.NotFound, "not_found")]
+    [InlineData(CalendarEntityQueryCode.Ambiguous, "ambiguous")]
+    [InlineData(CalendarEntityQueryCode.OutsideScope, "outside_scope")]
+    [InlineData(CalendarEntityQueryCode.EntityKindMismatch, "entity_kind_mismatch")]
+    [InlineData(CalendarEntityQueryCode.UnsupportedCapability, "unsupported_capability")]
+    [InlineData(CalendarEntityQueryCode.ConcurrencyUnavailable, "concurrency_unavailable")]
+    [InlineData(CalendarEntityQueryCode.LimitExhausted, "limit_exhausted")]
+    [InlineData(CalendarEntityQueryCode.PayloadTooLarge, "payload_too_large")]
+    [InlineData(CalendarEntityQueryCode.UpstreamProtocolError, "upstream_protocol_error")]
+    [InlineData(CalendarEntityQueryCode.TemporalUnresolved, "temporal_unresolved")]
+    [InlineData(CalendarEntityQueryCode.RecurrenceUnevaluable, "recurrence_unevaluable")]
+    public async Task QueryAsync_MapsEveryDomainFailure(CalendarEntityQueryCode domainCode, string expectedCode)
+    {
+        var service = Substitute.For<ICalendarService>();
+        service.QueryEntitiesAsync(Arg.Any<CalendarEntityQuery>(), Arg.Any<CancellationToken>())
+            .Returns(CalendarEntityQueryResult.Failure(domainCode));
+        var sut = CreateTool(service, new MutableTimeProvider(Now));
+
+        var result = await sut.QueryCoreAsync(
+            new CalendarEntityScopeArgument("all"), ["event"], CancellationToken.None);
+
+        result.IsError.ShouldBe(true);
+        result.StructuredContent!.Value.GetProperty("code").GetString().ShouldBe(expectedCode);
+        result.StructuredContent.Value.TryGetProperty("items", out _).ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task QueryAsync_RejectsInvalidTypedShapeVariantsBeforeService()
+    {
+        var service = Substitute.For<ICalendarService>();
+        var sut = CreateTool(service, new MutableTimeProvider(Now));
+        var validFrom = new CalendarEntityUtcArgument("utcDateTime", "2026-08-15T12:00:00Z");
+        var validTo = new CalendarEntityUtcArgument("utcDateTime", "2026-08-15T13:00:00Z");
+        var calls = new Task<ModelContextProtocol.Protocol.CallToolResult>[]
+        {
+            sut.QueryCoreAsync(new CalendarEntityScopeArgument("default", new CalendarEntityReferenceArgument("name", "x")), ["event"], CancellationToken.None),
+            sut.QueryCoreAsync(new CalendarEntityScopeArgument("all", new CalendarEntityReferenceArgument("name", "x")), ["event"], CancellationToken.None),
+            sut.QueryCoreAsync(new CalendarEntityScopeArgument("bad"), ["event"], CancellationToken.None),
+            sut.QueryCoreAsync(new CalendarEntityScopeArgument("selected"), ["event"], CancellationToken.None),
+            sut.QueryCoreAsync(new CalendarEntityScopeArgument("selected", new CalendarEntityReferenceArgument("bad", "x")), ["event"], CancellationToken.None),
+            sut.QueryCoreAsync(new CalendarEntityScopeArgument("selected", new CalendarEntityReferenceArgument("name")), ["event"], CancellationToken.None),
+            sut.QueryCoreAsync(new CalendarEntityScopeArgument("selected", new CalendarEntityReferenceArgument("name", " x ")), ["event"], CancellationToken.None),
+            sut.QueryCoreAsync(new CalendarEntityScopeArgument("selected", new CalendarEntityReferenceArgument("name", "x", "https://cal.example/x/")), ["event"], CancellationToken.None),
+            sut.QueryCoreAsync(new CalendarEntityScopeArgument("selected", new CalendarEntityReferenceArgument("href")), ["event"], CancellationToken.None),
+            sut.QueryCoreAsync(new CalendarEntityScopeArgument("selected", new CalendarEntityReferenceArgument("href", "x", "https://cal.example/x/")), ["event"], CancellationToken.None),
+            sut.QueryCoreAsync(new CalendarEntityScopeArgument("all"), [], CancellationToken.None),
+            sut.QueryCoreAsync(new CalendarEntityScopeArgument("all"), ["event", "todo", "event"], CancellationToken.None),
+            sut.QueryCoreAsync(new CalendarEntityScopeArgument("all"), ["event", "event"], CancellationToken.None),
+            sut.QueryCoreAsync(new CalendarEntityScopeArgument("all"), ["journal"], CancellationToken.None),
+            sut.QueryCoreAsync(new CalendarEntityScopeArgument("all"), ["event"], CancellationToken.None, from: validFrom),
+            sut.QueryCoreAsync(new CalendarEntityScopeArgument("all"), ["event"], CancellationToken.None, to: validTo),
+            sut.QueryCoreAsync(new CalendarEntityScopeArgument("all"), ["event"], CancellationToken.None, new CalendarEntityUtcArgument("date", validFrom.Value), validTo),
+            sut.QueryCoreAsync(new CalendarEntityScopeArgument("all"), ["event"], CancellationToken.None, new CalendarEntityUtcArgument("utcDateTime", "bad"), validTo),
+            sut.QueryCoreAsync(new CalendarEntityScopeArgument("all"), ["event"], CancellationToken.None, new CalendarEntityUtcArgument("utcDateTime", "2026-08-15T12:00:00.xZ"), validTo),
+            sut.QueryCoreAsync(new CalendarEntityScopeArgument("all"), ["event"], CancellationToken.None, pageSize: 0),
+            sut.QueryCoreAsync(new CalendarEntityScopeArgument("all"), ["event"], CancellationToken.None, pageSize: 201),
+            sut.QueryCoreAsync(new CalendarEntityScopeArgument("all"), ["event"], CancellationToken.None, cursor: new string('a', 2049))
+        };
+
+        foreach (var call in calls)
+        {
+            var result = await call;
+            result.IsError.ShouldBe(true);
+            result.StructuredContent!.Value.GetProperty("code").GetString().ShouldBe("invalid_input");
+        }
+        await service.DidNotReceive().QueryEntitiesAsync(Arg.Any<CalendarEntityQuery>(), Arg.Any<CancellationToken>());
+    }
+
+    [Theory]
+    [InlineData("null")]
+    [InlineData("{}")]
+    [InlineData("{\"scope\":null,\"entityKinds\":[\"event\"]}")]
+    [InlineData("{\"scope\":{\"mode\":1},\"entityKinds\":[\"event\"]}")]
+    [InlineData("{\"scope\":{\"mode\":\"selected\",\"calendar\":1},\"entityKinds\":[\"event\"]}")]
+    [InlineData("{\"scope\":{\"mode\":\"selected\",\"calendar\":{\"by\":1,\"name\":\"x\"}},\"entityKinds\":[\"event\"]}")]
+    [InlineData("{\"scope\":{\"mode\":\"selected\",\"calendar\":{\"by\":\"name\",\"href\":\"x\"}},\"entityKinds\":[\"event\"]}")]
+    [InlineData("{\"scope\":{\"mode\":\"default\"},\"entityKinds\":null}")]
+    [InlineData("{\"scope\":{\"mode\":\"default\"},\"entityKinds\":[\"event\"],\"from\":null}")]
+    [InlineData("{\"scope\":{\"mode\":\"default\"},\"entityKinds\":[\"event\"],\"to\":null}")]
+    [InlineData("{\"scope\":{\"mode\":\"default\"},\"entityKinds\":[\"event\"],\"pageSize\":null}")]
+    [InlineData("{\"scope\":{\"mode\":\"default\"},\"entityKinds\":[\"event\"],\"cursor\":null}")]
+    [InlineData("{\"scope\":{\"mode\":\"default\"},\"entityKinds\":[\"event\"],\"from\":{\"kind\":\"utcDateTime\"}}")]
+    public async Task QueryRawAsync_RejectsInvalidRawShapes(string json)
+    {
+        var service = Substitute.For<ICalendarService>();
+        var sut = CreateTool(service, new MutableTimeProvider(Now));
+        var arguments = json == "null"
+            ? null
+            : JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(json);
+
+        var result = await sut.QueryRawAsync(arguments, CancellationToken.None);
+
+        result.IsError.ShouldBe(true);
+        result.StructuredContent!.Value.GetProperty("code").GetString().ShouldBe("invalid_input");
+        await service.DidNotReceive().QueryEntitiesAsync(Arg.Any<CalendarEntityQuery>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task QueryRawAsync_AcceptsCompleteFrozenShapeAndDeserializesOptionalValues()
+    {
+        var service = Substitute.For<ICalendarService>();
+        CalendarEntityQuery? observed = null;
+        service.QueryEntitiesAsync(Arg.Do<CalendarEntityQuery>(query => observed = query), Arg.Any<CancellationToken>())
+            .Returns(CalendarEntityQueryResult.Success([]));
+        var sut = CreateTool(service, new MutableTimeProvider(Now));
+        var arguments = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(
+            "{\"scope\":{\"mode\":\"selected\",\"calendar\":{\"by\":\"href\",\"href\":\"https://cal.example/a/\"}},"
+            + "\"entityKinds\":[\"event\",\"todo\"],"
+            + "\"from\":{\"kind\":\"utcDateTime\",\"value\":\"2026-08-15T12:00:00Z\"},"
+            + "\"to\":{\"kind\":\"utcDateTime\",\"value\":\"2026-08-15T13:00:00Z\"},"
+            + "\"pageSize\":25}");
+
+        var result = await sut.QueryRawAsync(arguments, CancellationToken.None);
+
+        result.IsError.ShouldBe(false);
+        observed.ShouldNotBeNull();
+        observed.EntityKinds.ShouldBe([CalendarEntityKind.Event, CalendarEntityKind.Todo]);
+        observed.Scope.Calendar!.Href.ShouldBe("https://cal.example/a/");
+    }
+
+    [Fact]
+    public async Task QueryRawAsync_AcceptsSelectedNameWithInternalSpaces()
+    {
+        var service = Substitute.For<ICalendarService>();
+        CalendarEntityQuery? observed = null;
+        service.QueryEntitiesAsync(Arg.Do<CalendarEntityQuery>(query => observed = query), Arg.Any<CancellationToken>())
+            .Returns(CalendarEntityQueryResult.Failure(CalendarEntityQueryCode.NotFound));
+        var sut = CreateTool(service, new MutableTimeProvider(Now));
+        var arguments = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(
+            "{\"scope\":{\"mode\":\"selected\",\"calendar\":{\"by\":\"name\",\"name\":\"No such authorized calendar\"}},"
+            + "\"entityKinds\":[\"todo\"]}");
+
+        var result = await sut.QueryRawAsync(arguments, CancellationToken.None);
+
+        result.StructuredContent!.Value.GetProperty("code").GetString().ShouldBe("not_found");
+        observed.ShouldNotBeNull();
+        observed.Scope.Calendar!.Name.ShouldBe("No such authorized calendar");
+    }
+
+    [Fact]
+    public async Task QueryRawAsync_RejectsOversizedRawBodyBeforeShapeOrService()
+    {
+        var service = Substitute.For<ICalendarService>();
+        var sut = CreateTool(service, new MutableTimeProvider(Now));
+        var arguments = new Dictionary<string, JsonElement>
+        {
+            ["oversized"] = JsonSerializer.SerializeToElement(new string('x', 270_000))
+        };
+
+        var result = await sut.QueryRawAsync(arguments, CancellationToken.None);
+
+        result.StructuredContent!.Value.GetProperty("code").GetString().ShouldBe("payload_too_large");
+        await service.DidNotReceive().QueryEntitiesAsync(Arg.Any<CalendarEntityQuery>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task QueryAsync_PaginatesByCanonicalCalendarAndResourceKey()
+    {
+        var service = Substitute.For<ICalendarService>();
+        service.QueryEntitiesAsync(Arg.Any<CalendarEntityQuery>(), Arg.Any<CancellationToken>())
+            .Returns(CalendarEntityQueryResult.Success([
+                Snapshot("https://cal.example/a/", "https://cal.example/a/1.ics"),
+                Snapshot("https://cal.example/a/", "https://cal.example/a/2.ics"),
+                Snapshot("https://cal.example/b/", "https://cal.example/b/1.ics")
+            ]));
+        var sut = CreateTool(service, new MutableTimeProvider(Now));
+
+        var first = await sut.QueryCoreAsync(
+            new CalendarEntityScopeArgument("all"),
+            ["event"],
+            CancellationToken.None,
+            pageSize: 2);
+
+        first.IsError.ShouldBe(false);
+        var firstItems = first.StructuredContent!.Value.GetProperty("items");
+        firstItems.GetArrayLength().ShouldBe(2);
+        var cursor = first.StructuredContent.Value.GetProperty("pagination").GetProperty("nextCursor").GetString();
+        cursor.ShouldNotBeNullOrEmpty();
+        cursor.Length.ShouldBeLessThanOrEqualTo(CalendarEntityCursorProtector.MaximumCursorCharacters);
+
+        service.QueryEntitiesAsync(Arg.Any<CalendarEntityQuery>(), Arg.Any<CancellationToken>())
+            .Returns(CalendarEntityQueryResult.Success([
+                Snapshot("https://cal.example/0/", "https://cal.example/0/new.ics"),
+                Snapshot("https://cal.example/a/", "https://cal.example/a/1.ics"),
+                Snapshot("https://cal.example/a/", "https://cal.example/a/2.ics"),
+                Snapshot("https://cal.example/b/", "https://cal.example/b/1.ics")
+            ]));
+
+        var second = await sut.QueryCoreAsync(
+            new CalendarEntityScopeArgument("all"),
+            ["event"],
+            CancellationToken.None,
+            pageSize: 2,
+            cursor: cursor);
+
+        var secondItems = second.StructuredContent!.Value.GetProperty("items");
+        secondItems.GetArrayLength().ShouldBe(1);
+        secondItems[0].GetProperty("resourceRevision").GetProperty("href").GetString()
+            .ShouldBe("https://cal.example/b/1.ics");
+        second.StructuredContent.Value.GetProperty("pagination").GetProperty("nextCursor").ValueKind
+            .ShouldBe(System.Text.Json.JsonValueKind.Null);
+    }
+
+    [Fact]
+    public async Task QueryAsync_ProjectsEverySafeDiagnosticSeverity()
+    {
+        var service = Substitute.For<ICalendarService>();
+        service.QueryEntitiesAsync(Arg.Any<CalendarEntityQuery>(), Arg.Any<CancellationToken>())
+            .Returns(CalendarEntityQueryResult.Success(
+                [Snapshot("https://cal.example/a/", "https://cal.example/a/1.ics")],
+                [
+                    new CalendarResourceDiagnostic("info", "Info", CalendarResourceDiagnosticSeverity.Info),
+                    new CalendarResourceDiagnostic("warning", "Warning", CalendarResourceDiagnosticSeverity.Warning),
+                    new CalendarResourceDiagnostic("error", "Error", CalendarResourceDiagnosticSeverity.Error)
+                ]));
+        var sut = CreateTool(service, new MutableTimeProvider(Now));
+
+        var result = await sut.QueryCoreAsync(
+            new CalendarEntityScopeArgument(
+                "selected",
+                new CalendarEntityReferenceArgument("href", Href: "https://cal.example/a/")),
+            ["event", "todo"],
+            CancellationToken.None,
+            new CalendarEntityUtcArgument("utcDateTime", "2026-08-15T12:00:00Z"),
+            new CalendarEntityUtcArgument("utcDateTime", "2026-08-15T13:00:00Z"));
+
+        result.IsError.ShouldBe(false);
+        result.StructuredContent!.Value.GetProperty("diagnostics")
+            .EnumerateArray().Select(item => item.GetProperty("severity").GetString())
+            .ShouldBe(["info", "warning", "error"]);
+    }
+
+    [Fact]
+    public async Task QueryAsync_ProjectsAllAuthorizedCapabilityStates()
+    {
+        var service = Substitute.For<ICalendarService>();
+        service.QueryEntitiesAsync(Arg.Any<CalendarEntityQuery>(), Arg.Any<CancellationToken>())
+            .Returns(CalendarEntityQueryResult.Failure(
+                CalendarEntityQueryCode.NotFound,
+                [new CalendarDescriptor
+                {
+                    Href = "https://cal.example/a/",
+                    DisplayNameProvenance = DisplayNameProvenance.Missing,
+                    EventSupport = EntityKindSupport.NotAdvertised,
+                    TodoSupport = EntityKindSupport.Advertised,
+                    TodoEvidence = [new CapabilityEvidence("supported-calendar-component-set", "VTODO")]
+                }]));
+        var sut = CreateTool(service, new MutableTimeProvider(Now));
+
+        var result = await sut.QueryCoreAsync(
+            new CalendarEntityScopeArgument("all"), ["todo"], CancellationToken.None);
+
+        var kinds = result.StructuredContent!.Value.GetProperty("authorizedCandidates")[0].GetProperty("entityKinds");
+        kinds.GetProperty("event").GetProperty("state").GetString().ShouldBe("not_advertised");
+        kinds.GetProperty("todo").GetProperty("state").GetString().ShouldBe("advertised");
+    }
+
+    [Fact]
+    public async Task QueryAsync_RejectsTamperedRestartedMismatchedExpiredAndNonCanonicalCursorsBeforeService()
+    {
+        var service = Substitute.For<ICalendarService>();
+        service.QueryEntitiesAsync(Arg.Any<CalendarEntityQuery>(), Arg.Any<CancellationToken>())
+            .Returns(CalendarEntityQueryResult.Success([
+                Snapshot("https://cal.example/a/", "https://cal.example/a/1.ics"),
+                Snapshot("https://cal.example/a/", "https://cal.example/a/2.ics")
+            ]));
+        var time = new MutableTimeProvider(Now);
+        var sut = CreateTool(service, time);
+        var first = await sut.QueryCoreAsync(
+            new CalendarEntityScopeArgument("all"), ["event"], CancellationToken.None, pageSize: 1);
+        var cursor = first.StructuredContent!.Value.GetProperty("pagination").GetProperty("nextCursor").GetString()!;
+        service.ClearReceivedCalls();
+
+        var invalidCalls = new[]
+        {
+            sut.QueryCoreAsync(new CalendarEntityScopeArgument("all"), ["event"], CancellationToken.None, pageSize: 1,
+                cursor: cursor[..^1] + (cursor[^1] == 'A' ? "B" : "A")),
+            sut.QueryCoreAsync(new CalendarEntityScopeArgument("all"), ["todo"], CancellationToken.None, pageSize: 1, cursor: cursor),
+            sut.QueryCoreAsync(new CalendarEntityScopeArgument("all"), ["event"], CancellationToken.None, pageSize: 2, cursor: cursor),
+            sut.QueryCoreAsync(new CalendarEntityScopeArgument("all"), ["event"], CancellationToken.None, pageSize: 1, cursor: cursor + "=")
+        };
+        foreach (var call in invalidCalls)
+            AssertInvalidCursor(await call);
+
+        var restarted = CreateTool(service, time);
+        AssertInvalidCursor(await restarted.QueryCoreAsync(
+            new CalendarEntityScopeArgument("all"), ["event"], CancellationToken.None, pageSize: 1, cursor: cursor));
+
+        time.Advance(TimeSpan.FromMinutes(10));
+        AssertInvalidCursor(await sut.QueryCoreAsync(
+            new CalendarEntityScopeArgument("all"), ["event"], CancellationToken.None, pageSize: 1, cursor: cursor));
+
+        await service.DidNotReceive().QueryEntitiesAsync(Arg.Any<CalendarEntityQuery>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public void CursorProtector_UsesUniqueBoundedNonCredentialBearingTokens()
+    {
+        var options = CreateOptions();
+        var protector = new CalendarEntityCursorProtector(
+            new MutableTimeProvider(Now),
+            options,
+            Enumerable.Range(0, 64).Select(value => (byte)value).ToArray());
+
+        var first = protector.Protect("query", "https://cal.example/a/", "https://cal.example/a/1.ics");
+        var second = protector.Protect("query", "https://cal.example/a/", "https://cal.example/a/1.ics");
+
+        first.ShouldNotBe(second);
+        first.Length.ShouldBeLessThanOrEqualTo(2048);
+        first.ShouldNotContain("user");
+        first.ShouldNotContain("password");
+        first.ShouldNotContain("cal.example");
+        protector.TryUnprotect(first, "query", out var continuation, out var expired).ShouldBeTrue();
+        expired.ShouldBeFalse();
+        continuation.ShouldBe(new CalendarEntityContinuation(
+            "https://cal.example/a/", "https://cal.example/a/1.ics"));
+    }
+
+    [Fact]
+    public void CursorProtector_BindsCredentialFieldsWithoutDelimiterCollisions()
+    {
+        var key = Enumerable.Range(0, 64).Select(value => (byte)value).ToArray();
+        var first = new CalendarEntityCursorProtector(
+            new MutableTimeProvider(Now),
+            CreateOptions(username: "alpha\u001fbeta", password: "gamma"),
+            key);
+        var redistributed = new CalendarEntityCursorProtector(
+            new MutableTimeProvider(Now),
+            CreateOptions(username: "alpha", password: "beta\u001fgamma"),
+            key);
+        var cursor = first.Protect("query", "https://cal.example/a/", "https://cal.example/a/1.ics");
+
+        redistributed.TryUnprotect(cursor, "query", out _, out _).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void CursorProtector_RejectsNonCanonicalAlternatePadBitsForSameBytes()
+    {
+        var protector = new CalendarEntityCursorProtector(
+            new MutableTimeProvider(Now),
+            CreateOptions(),
+            Enumerable.Range(0, 64).Select(value => (byte)value).ToArray());
+        var query = "query";
+        var canonical = protector.Protect(query, "https://cal.example/a/", "https://cal.example/a/1.ics");
+        while (canonical.Length % 4 == 0)
+        {
+            query += "x";
+            canonical = protector.Protect(query, "https://cal.example/a/", "https://cal.example/a/1.ics");
+        }
+        var alternate = WithAlternatePadBits(canonical);
+
+        Convert.FromBase64String(ToPaddedBase64(canonical))
+            .ShouldBe(Convert.FromBase64String(ToPaddedBase64(alternate)));
+        protector.TryUnprotect(alternate, query, out _, out _).ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task QueryAsync_RejectsOversizedNormalArgumentsBeforeService()
+    {
+        var service = Substitute.For<ICalendarService>();
+        var sut = CreateTool(service, new MutableTimeProvider(Now));
+
+        var result = await sut.QueryCoreAsync(
+            new CalendarEntityScopeArgument("selected", new CalendarEntityReferenceArgument("name", new string('a', 270_000))),
+            ["event"],
+            CancellationToken.None);
+
+        result.IsError.ShouldBe(true);
+        result.StructuredContent!.Value.GetProperty("code").GetString().ShouldBe("payload_too_large");
+        await service.DidNotReceive().QueryEntitiesAsync(Arg.Any<CalendarEntityQuery>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task QueryAsync_PreservesHigherPrecisionUtcBoundsForSecondResolutionTruth()
+    {
+        var service = Substitute.For<ICalendarService>();
+        CalendarEntityQuery? observed = null;
+        service.QueryEntitiesAsync(Arg.Do<CalendarEntityQuery>(query => observed = query), Arg.Any<CancellationToken>())
+            .Returns(CalendarEntityQueryResult.Success([]));
+        var sut = CreateTool(service, new MutableTimeProvider(Now));
+
+        var result = await sut.QueryCoreAsync(
+            new CalendarEntityScopeArgument("all"),
+            ["event"],
+            CancellationToken.None,
+            new CalendarEntityUtcArgument("utcDateTime", "2026-08-15T12:00:00.0000000001Z"),
+            new CalendarEntityUtcArgument("utcDateTime", "2026-08-15T12:00:01.123456789Z"));
+
+        result.IsError.ShouldBe(false);
+        observed.ShouldNotBeNull();
+        observed.From!.Value.Ticks.ShouldBe(DateTimeOffset.Parse("2026-08-15T12:00:00Z").Ticks + 1);
+        observed.To!.Value.Ticks.ShouldBe(DateTimeOffset.Parse("2026-08-15T12:00:01Z").Ticks + 1_234_568);
+    }
+
+    [Fact]
+    public async Task QueryAsync_RejectsSelectedNameRequiringSilentTrimmingBeforeService()
+    {
+        var service = Substitute.For<ICalendarService>();
+        CalendarEntityQuery? observed = null;
+        service.QueryEntitiesAsync(Arg.Do<CalendarEntityQuery>(query => observed = query), Arg.Any<CancellationToken>())
+            .Returns(CalendarEntityQueryResult.Success([]));
+        var sut = CreateTool(service, new MutableTimeProvider(Now));
+
+        var result = await sut.QueryCoreAsync(
+            new CalendarEntityScopeArgument(
+                "selected",
+                new CalendarEntityReferenceArgument("name", Name: "  Work  ")),
+            ["event"],
+            CancellationToken.None);
+
+        result.IsError.ShouldBe(true);
+        result.StructuredContent!.Value.GetProperty("code").GetString().ShouldBe("invalid_input");
+        observed.ShouldBeNull();
+    }
+
+    [Theory]
+    [InlineData("9999-12-31T23:59:59.99999999Z")]
+    public async Task QueryAsync_HandlesExtremeArbitraryPrecisionBoundsWithoutException(string lexical)
+    {
+        var service = Substitute.For<ICalendarService>();
+        service.QueryEntitiesAsync(Arg.Any<CalendarEntityQuery>(), Arg.Any<CancellationToken>())
+            .Returns(CalendarEntityQueryResult.Success([]));
+        var sut = CreateTool(service, new MutableTimeProvider(Now));
+
+        var result = await sut.QueryCoreAsync(
+            new CalendarEntityScopeArgument("all"),
+            ["event"],
+            CancellationToken.None,
+            new CalendarEntityUtcArgument("utcDateTime", lexical),
+            new CalendarEntityUtcArgument("utcDateTime", "9999-12-31T23:59:59Z"));
+
+        result.IsError.ShouldBe(true);
+        result.StructuredContent!.Value.GetProperty("code").GetString().ShouldBe("invalid_input");
+    }
+
+    [Fact]
+    public async Task QueryAsync_ReturnsNoItemsWhenOneSnapshotCannotFitPage()
+    {
+        var service = Substitute.For<ICalendarService>();
+        service.QueryEntitiesAsync(Arg.Any<CalendarEntityQuery>(), Arg.Any<CancellationToken>())
+            .Returns(CalendarEntityQueryResult.Success([
+                Snapshot("https://cal.example/a/", "https://cal.example/a/1.ics", new byte[3_200_000])
+            ]));
+        var sut = CreateTool(service, new MutableTimeProvider(Now));
+
+        var result = await sut.QueryCoreAsync(
+            new CalendarEntityScopeArgument("all"), ["event"], CancellationToken.None);
+
+        result.IsError.ShouldBe(true);
+        result.StructuredContent!.Value.GetProperty("code").GetString().ShouldBe("payload_too_large");
+        result.StructuredContent.Value.TryGetProperty("items", out _).ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task QueryAsync_MapsObservedResourceByteLimitExactly()
+    {
+        var service = Substitute.For<ICalendarService>();
+        service.QueryEntitiesAsync(Arg.Any<CalendarEntityQuery>(), Arg.Any<CancellationToken>())
+            .Returns(CalendarEntityQueryResult.Failure(
+                CalendarEntityQueryCode.PayloadTooLarge,
+                limits: new CalendarEntityQueryExecutionLimits(ByteCount: 4_194_305)));
+        var sut = CreateTool(service, new MutableTimeProvider(Now));
+
+        var result = await sut.QueryCoreAsync(
+            new CalendarEntityScopeArgument("all"), ["event"], CancellationToken.None);
+
+        result.IsError.ShouldBe(true);
+        result.StructuredContent!.Value.GetProperty("code").GetString().ShouldBe("payload_too_large");
+        var limits = result.StructuredContent.Value.GetProperty("limits");
+        limits.EnumerateObject().Select(property => property.Name).ShouldBe(["byteCount"]);
+        limits.GetProperty("byteCount").GetInt32().ShouldBe(4_194_305);
+        result.StructuredContent.Value.TryGetProperty("items", out _).ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task QueryAsync_BoundsHugeAuthorizedCandidateFailureWithoutLeakingValue()
+    {
+        var service = Substitute.For<ICalendarService>();
+        var unsafeValue = new string('x', 4_300_000);
+        service.QueryEntitiesAsync(Arg.Any<CalendarEntityQuery>(), Arg.Any<CancellationToken>())
+            .Returns(CalendarEntityQueryResult.Failure(
+                CalendarEntityQueryCode.Ambiguous,
+                [new CalendarDescriptor
+                {
+                    Href = "https://cal.example/a/",
+                    DisplayName = unsafeValue,
+                    DisplayNameProvenance = DisplayNameProvenance.DavDisplayName,
+                    EventSupport = EntityKindSupport.Advertised,
+                    TodoSupport = EntityKindSupport.Unknown,
+                    EventEvidence = [new CapabilityEvidence("server", unsafeValue)]
+                }]));
+        var sut = CreateTool(service, new MutableTimeProvider(Now));
+
+        var result = await sut.QueryCoreAsync(
+            new CalendarEntityScopeArgument("all"), ["event"], CancellationToken.None);
+
+        result.IsError.ShouldBe(true);
+        result.StructuredContent!.Value.GetProperty("code").GetString().ShouldBe("payload_too_large");
+        result.StructuredContent.Value.TryGetProperty("authorizedCandidates", out _).ShouldBeFalse();
+        result.StructuredContent.Value.TryGetProperty("items", out _).ShouldBeFalse();
+        result.StructuredContent.Value.GetProperty("limits").GetProperty("byteCount").GetInt32()
+            .ShouldBeGreaterThan(4 * 1024 * 1024);
+        result.StructuredContent.Value.ToString().ShouldNotContain(unsafeValue[..100]);
+    }
+
+    [Fact]
+    public async Task QueryAsync_ReturnsTypedZeroItemFailureWhenContinuationCannotFit()
+    {
+        var service = Substitute.For<ICalendarService>();
+        var longCalendar = "https://cal.example/" + new string('a', 1800) + "/";
+        service.QueryEntitiesAsync(Arg.Any<CalendarEntityQuery>(), Arg.Any<CancellationToken>())
+            .Returns(CalendarEntityQueryResult.Success([
+                Snapshot(longCalendar, longCalendar + "1.ics"),
+                Snapshot(longCalendar, longCalendar + "2.ics")
+            ]));
+        var sut = CreateTool(service, new MutableTimeProvider(Now));
+
+        var result = await sut.QueryCoreAsync(
+            new CalendarEntityScopeArgument("all"), ["event"], CancellationToken.None, pageSize: 1);
+
+        result.IsError.ShouldBe(true);
+        result.StructuredContent!.Value.GetProperty("code").GetString().ShouldBe("payload_too_large");
+        result.StructuredContent.Value.TryGetProperty("items", out _).ShouldBeFalse();
+    }
+
+    [Theory]
+    [InlineData(HttpStatusCode.Unauthorized, "upstream_unauthorized", "upstream", false, "execution")]
+    [InlineData(HttpStatusCode.Forbidden, "upstream_forbidden", "upstream", false, "execution")]
+    [InlineData(HttpStatusCode.TooManyRequests, "upstream_rate_limited", "upstream", true, "execution")]
+    [InlineData(HttpStatusCode.MethodNotAllowed, "unsupported_capability", "capabilityAndProjection", false, "selectionDiscoveryCapability")]
+    [InlineData(HttpStatusCode.NotImplemented, "unsupported_capability", "capabilityAndProjection", false, "selectionDiscoveryCapability")]
+    [InlineData(HttpStatusCode.RequestEntityTooLarge, "payload_too_large", "limitsAndAdmission", false, "admissionAndPayload")]
+    [InlineData(HttpStatusCode.Conflict, "conflict", "state", false, "execution")]
+    [InlineData(HttpStatusCode.PreconditionFailed, "conflict", "state", false, "execution")]
+    [InlineData(HttpStatusCode.RequestTimeout, "upstream_unavailable", "upstream", true, "execution")]
+    [InlineData(HttpStatusCode.InsufficientStorage, "upstream_unavailable", "upstream", false, "execution")]
+    [InlineData(HttpStatusCode.ServiceUnavailable, "upstream_unavailable", "upstream", true, "execution")]
+    [InlineData(HttpStatusCode.BadRequest, "upstream_protocol_error", "upstream", false, "execution")]
+    public async Task QueryAsync_MapsExpectedUpstreamStatusesWithoutPartialItems(
+        HttpStatusCode status,
+        string code,
+        string category,
+        bool retryable,
+        string phase)
+    {
+        var service = Substitute.For<ICalendarService>();
+        service.QueryEntitiesAsync(Arg.Any<CalendarEntityQuery>(), Arg.Any<CancellationToken>())
+            .Returns<Task<CalendarEntityQueryResult>>(_ => throw new HttpRequestException("secret", null, status));
+        var sut = CreateTool(service, new MutableTimeProvider(Now));
+
+        var result = await sut.QueryCoreAsync(
+            new CalendarEntityScopeArgument("all"), ["event"], CancellationToken.None);
+
+        result.IsError.ShouldBe(true);
+        result.StructuredContent!.Value.GetProperty("code").GetString().ShouldBe(code);
+        result.StructuredContent.Value.GetProperty("category").GetString().ShouldBe(category);
+        result.StructuredContent.Value.GetProperty("retryable").GetBoolean().ShouldBe(retryable);
+        result.StructuredContent.Value.GetProperty("phase").GetString().ShouldBe(phase);
+        result.StructuredContent.Value.TryGetProperty("items", out _).ShouldBeFalse();
+        var message = result.StructuredContent.Value.GetProperty("message").GetString();
+        message.ShouldNotBeNull();
+        message.ShouldNotContain("secret");
+    }
+
+    [Fact]
+    public async Task QueryAsync_MapsExpectedExecutionExceptions()
+    {
+        var cases = new (Exception Exception, string Code)[]
+        {
+            (new HttpRequestException("secret"), "upstream_unavailable"),
+            (new TimeoutException("secret"), "upstream_unavailable"),
+            (new XmlException("secret"), "upstream_protocol_error"),
+            (new CalendarDiscoveryProtocolException("secret"), "upstream_protocol_error"),
+            (new CalendarDiscoveryUnsupportedCapabilityException("secret"), "unsupported_capability"),
+            (new CalendarDiscoveryLimitException(257), "limit_exhausted")
+        };
+        foreach (var testCase in cases)
+        {
+            var service = Substitute.For<ICalendarService>();
+            service.QueryEntitiesAsync(Arg.Any<CalendarEntityQuery>(), Arg.Any<CancellationToken>())
+                .Returns<Task<CalendarEntityQueryResult>>(_ => throw testCase.Exception);
+            var sut = CreateTool(service, new MutableTimeProvider(Now));
+
+            var result = await sut.QueryCoreAsync(
+                new CalendarEntityScopeArgument("all"), ["event"], CancellationToken.None);
+
+            result.IsError.ShouldBe(true);
+            result.StructuredContent!.Value.GetProperty("code").GetString().ShouldBe(testCase.Code);
+            result.StructuredContent.Value.ToString().ShouldNotContain("secret");
+        }
+    }
+
+    [Fact]
+    public async Task QueryAsync_CompleteReadDeadlineCancelsServiceAndMapsSafeRetryableFailure()
+    {
+        var service = Substitute.For<ICalendarService>();
+        service.QueryEntitiesAsync(Arg.Any<CalendarEntityQuery>(), Arg.Any<CancellationToken>())
+            .Returns(call => WaitForCancellation(call.ArgAt<CancellationToken>(1)));
+        var time = new MutableTimeProvider(Now);
+        var sut = CreateTool(service, time);
+
+        var pending = sut.QueryCoreAsync(
+            new CalendarEntityScopeArgument("all"), ["event"], CancellationToken.None);
+        time.Advance(TimeSpan.FromSeconds(30));
+        var result = await pending;
+
+        result.IsError.ShouldBe(true);
+        result.StructuredContent!.Value.GetProperty("code").GetString().ShouldBe("limit_exhausted");
+        result.StructuredContent.Value.GetProperty("category").GetString().ShouldBe("limitsAndAdmission");
+        result.StructuredContent.Value.GetProperty("phase").GetString().ShouldBe("execution");
+        result.StructuredContent.Value.GetProperty("retryable").GetBoolean().ShouldBeFalse();
+        result.StructuredContent.Value.TryGetProperty("items", out _).ShouldBeFalse();
+        var message = result.StructuredContent.Value.GetProperty("message").GetString();
+        message.ShouldNotBeNull();
+        message.ShouldNotContain("OperationCanceledException");
+        await service.Received(1).QueryEntitiesAsync(Arg.Any<CalendarEntityQuery>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task QueryAsync_DeadlineBeforeRecurrenceFilteringReturnsTypedZeroItemLimit()
+    {
+        const string calendarHref = "https://cal.example/events/";
+        const string resourceHref = "https://cal.example/events/recurring.ics";
+        var enteredRead = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseRead = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var client = Substitute.For<ICalendarClient>();
+        var service = new CalendarService(
+            client,
+            Options.Create(new CalDavOptions { BaseUrl = "https://cal.example" }),
+            Substitute.For<ILogger<CalendarService>>());
+        client.GetCalendarsAsync(Arg.Any<CancellationToken>()).Returns(
+        [
+            new CalendarDescriptor
+            {
+                Href = calendarHref,
+                DisplayName = "Events",
+                DisplayNameProvenance = DisplayNameProvenance.DavDisplayName,
+                EventSupport = EntityKindSupport.Advertised,
+                TodoSupport = EntityKindSupport.NotAdvertised
+            }
+        ]);
+        var from = DateTimeOffset.Parse("2026-08-15T12:00:00Z");
+        var to = DateTimeOffset.Parse("2026-08-15T13:00:00Z");
+        client.QueryCalendarResourceHrefsAsync(calendarHref, CalendarEntityKind.Event, from, to, Arg.Any<CancellationToken>())
+            .Returns([resourceHref]);
+        client.GetCalendarResourceAsync(resourceHref, Arg.Any<CancellationToken>()).Returns(async _ =>
+        {
+            enteredRead.TrySetResult();
+            await releaseRead.Task;
+            return CalendarResourceRead.Success(
+                resourceHref,
+                "\"r1\"",
+                Encoding.UTF8.GetBytes(
+                    "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Example//EN\r\n"
+                    + "BEGIN:VEVENT\r\nUID:recurring\r\nDTSTAMP:20260815T120000Z\r\n"
+                    + "DTSTART:20260815T120000Z\r\nDURATION:PT1S\r\nRRULE:FREQ=SECONDLY;COUNT=2000\r\n"
+                    + "END:VEVENT\r\nEND:VCALENDAR\r\n"));
+        });
+        var time = new MutableTimeProvider(Now);
+        var sut = CreateTool(service, time);
+
+        var pending = sut.QueryCoreAsync(
+            new CalendarEntityScopeArgument("all"),
+            ["event"],
+            CancellationToken.None,
+            new CalendarEntityUtcArgument("utcDateTime", "2026-08-15T12:00:00Z"),
+            new CalendarEntityUtcArgument("utcDateTime", "2026-08-15T13:00:00Z"));
+        await enteredRead.Task;
+        time.Advance(TimeSpan.FromSeconds(30));
+        releaseRead.TrySetResult();
+        var result = await pending;
+
+        result.IsError.ShouldBe(true);
+        result.StructuredContent!.Value.GetProperty("code").GetString().ShouldBe("limit_exhausted");
+        result.StructuredContent.Value.GetProperty("category").GetString().ShouldBe("limitsAndAdmission");
+        result.StructuredContent.Value.GetProperty("phase").GetString().ShouldBe("execution");
+        result.StructuredContent.Value.TryGetProperty("items", out _).ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task QueryAsync_DeadlineDuringPageConstructionReturnsNoItems()
+    {
+        var service = Substitute.For<ICalendarService>();
+        service.QueryEntitiesAsync(Arg.Any<CalendarEntityQuery>(), Arg.Any<CancellationToken>())
+            .Returns(CalendarEntityQueryResult.Success([
+                Snapshot("https://cal.example/a/", "https://cal.example/a/1.ics")
+            ]));
+        var time = new SequencedTimeProvider(Now, Now, Now.AddSeconds(30));
+        var sut = CreateTool(service, time);
+
+        var result = await sut.QueryCoreAsync(
+            new CalendarEntityScopeArgument("all"), ["event"], CancellationToken.None);
+
+        result.IsError.ShouldBe(true);
+        result.StructuredContent!.Value.GetProperty("code").GetString().ShouldBe("limit_exhausted");
+        result.StructuredContent.Value.GetProperty("category").GetString().ShouldBe("limitsAndAdmission");
+        result.StructuredContent.Value.GetProperty("phase").GetString().ShouldBe("execution");
+        result.StructuredContent.Value.TryGetProperty("items", out _).ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task QueryAsync_CallerCancellationPropagatesWithoutTypedDeadlineMapping()
+    {
+        var service = Substitute.For<ICalendarService>();
+        service.QueryEntitiesAsync(Arg.Any<CalendarEntityQuery>(), Arg.Any<CancellationToken>())
+            .Returns(call => WaitForCancellation(call.ArgAt<CancellationToken>(1)));
+        var sut = CreateTool(service, new MutableTimeProvider(Now));
+        using var cancellation = new CancellationTokenSource();
+
+        var pending = sut.QueryCoreAsync(
+            new CalendarEntityScopeArgument("all"), ["event"], cancellation.Token);
+        cancellation.Cancel();
+
+        await Should.ThrowAsync<OperationCanceledException>(() => pending);
+        await service.Received(1).QueryEntitiesAsync(Arg.Any<CalendarEntityQuery>(), Arg.Any<CancellationToken>());
+    }
+
+    private static CalendarEntityTools CreateTool(ICalendarService service, TimeProvider timeProvider) => new(
+        service,
+        new CalendarEntityCursorProtector(timeProvider, CreateOptions()),
+        timeProvider);
+
+    private static IOptions<CalDavOptions> CreateOptions(
+        string username = "user",
+        string password = "password") => Options.Create(new CalDavOptions
+        {
+            BaseUrl = "https://cal.example",
+            Username = username,
+            Password = password
+        });
+
+    private static CalendarResourceSnapshot Snapshot(
+        string calendarHref,
+        string resourceHref,
+        byte[]? bytes = null)
+    {
+        bytes ??= Encoding.UTF8.GetBytes("BEGIN:VCALENDAR\r\nEND:VCALENDAR\r\n");
+        return new CalendarResourceSnapshot(
+            calendarHref,
+            resourceHref,
+            "\"r1\"",
+            bytes,
+            [],
+            new CalendarResourceProjection(CalendarResourceProjectionKind.Event, "u1", "summary"),
+            []);
+    }
+
+    private static void AssertInvalidCursor(ModelContextProtocol.Protocol.CallToolResult result)
+    {
+        result.IsError.ShouldBe(true);
+        result.StructuredContent!.Value.GetProperty("code").GetString().ShouldBe("invalid_input");
+        var message = result.StructuredContent.Value.GetProperty("message").GetString();
+        message.ShouldNotBeNull();
+        message.ShouldNotContain("Exception");
+    }
+
+    private static Dictionary<string, JsonElement> ArgumentsWithSerializedSize(int targetBytes)
+    {
+        var arguments = new Dictionary<string, JsonElement>
+        {
+            ["scope"] = JsonSerializer.SerializeToElement(new { mode = "default" }),
+            ["entityKinds"] = JsonSerializer.SerializeToElement(new[] { "event" }),
+            ["unknown"] = JsonSerializer.SerializeToElement(string.Empty)
+        };
+        var overhead = JsonSerializer.SerializeToUtf8Bytes(arguments).Length;
+        arguments["unknown"] = JsonSerializer.SerializeToElement(new string('x', targetBytes - overhead));
+        return arguments;
+    }
+
+    private static CallToolResult ResultWithHumanReadableSize(int targetBytes)
+    {
+        var result = new CallToolResult
+        {
+            IsError = false,
+            StructuredContent = JsonSerializer.SerializeToElement(new { diagnostics = Array.Empty<object>() }),
+            Content = [new TextContentBlock { Text = string.Empty }]
+        };
+        var overhead = CalendarEntityTools.MeasureHumanReadableResult(result);
+        result.Content = [new TextContentBlock { Text = new string('x', targetBytes - overhead) }];
+        return result;
+    }
+
+    private static CallToolResult ResultWithStructuredSize(int targetBytes)
+    {
+        var result = new CallToolResult
+        {
+            IsError = false,
+            StructuredContent = JsonSerializer.SerializeToElement(new { padding = string.Empty }),
+            Content = [new TextContentBlock { Text = "ok" }]
+        };
+        var overhead = CalendarEntityTools.MeasureResult(result);
+        result.StructuredContent = JsonSerializer.SerializeToElement(
+            new { padding = new string('x', targetBytes - overhead) });
+        return result;
+    }
+
+    private static async Task<CalendarEntityQueryResult> WaitForCancellation(CancellationToken cancellationToken)
+    {
+        var pending = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        await pending.Task.WaitAsync(cancellationToken);
+        return CalendarEntityQueryResult.Success([]);
+    }
+
+    private static string WithAlternatePadBits(string value)
+    {
+        const string alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+        var index = alphabet.IndexOf(value[^1], StringComparison.Ordinal);
+        var alternateIndex = value.Length % 4 == 2 ? index ^ 1 : index ^ 1;
+        return value[..^1] + alphabet[alternateIndex];
+    }
+
+    private static string ToPaddedBase64(string value)
+    {
+        var standard = value.Replace('-', '+').Replace('_', '/');
+        return standard + new string('=', (4 - standard.Length % 4) % 4);
+    }
+
+    private sealed class MutableTimeProvider(DateTimeOffset utcNow) : TimeProvider
+    {
+        private readonly List<ManualTimer> _timers = [];
+
+        public override DateTimeOffset GetUtcNow() => utcNow;
+
+        public override ITimer CreateTimer(
+            TimerCallback callback,
+            object? state,
+            TimeSpan dueTime,
+            TimeSpan period)
+        {
+            var timer = new ManualTimer(this, callback, state, dueTime, period);
+            _timers.Add(timer);
+            return timer;
+        }
+
+        public void Advance(TimeSpan amount)
+        {
+            utcNow += amount;
+            foreach (var timer in _timers.ToArray())
+                timer.FireIfDue();
+        }
+
+        private sealed class ManualTimer(
+            MutableTimeProvider owner,
+            TimerCallback callback,
+            object? state,
+            TimeSpan dueTime,
+            TimeSpan period) : ITimer
+        {
+            private DateTimeOffset? _dueAt = dueTime == Timeout.InfiniteTimeSpan ? null : owner.GetUtcNow() + dueTime;
+            private bool _disposed;
+
+            public bool Change(TimeSpan newDueTime, TimeSpan newPeriod)
+            {
+                if (_disposed)
+                    return false;
+                period = newPeriod;
+                _dueAt = newDueTime == Timeout.InfiniteTimeSpan ? null : owner.GetUtcNow() + newDueTime;
+                return true;
+            }
+
+            public void Dispose() => _disposed = true;
+
+            public ValueTask DisposeAsync()
+            {
+                Dispose();
+                return ValueTask.CompletedTask;
+            }
+
+            public void FireIfDue()
+            {
+                if (_disposed || _dueAt is null || owner.GetUtcNow() < _dueAt)
+                    return;
+                _dueAt = period == Timeout.InfiniteTimeSpan ? null : owner.GetUtcNow() + period;
+                callback(state);
+            }
+        }
+    }
+
+    private sealed class SequencedTimeProvider(params DateTimeOffset[] values) : TimeProvider
+    {
+        private int _index;
+
+        public override DateTimeOffset GetUtcNow()
+        {
+            var index = Math.Min(_index, values.Length - 1);
+            _index++;
+            return values[index];
+        }
+
+        public override ITimer CreateTimer(
+            TimerCallback callback,
+            object? state,
+            TimeSpan dueTime,
+            TimeSpan period) => new InertTimer();
+
+        private sealed class InertTimer : ITimer
+        {
+            public bool Change(TimeSpan dueTime, TimeSpan period) => true;
+            public void Dispose() { }
+            public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+        }
+    }
+}

--- a/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/StrictToolInputGuardTests.cs
+++ b/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/StrictToolInputGuardTests.cs
@@ -1,0 +1,61 @@
+using System.Text;
+using System.Text.Json.Nodes;
+using DotnetAgents.CalDav.Mcp.Hosting;
+using DotnetAgents.CalDav.Mcp.Tools;
+using Shouldly;
+using Xunit;
+
+namespace DotnetAgents.CalDav.Mcp.Tests.Unit;
+
+public sealed class StrictToolInputGuardTests
+{
+    [Theory]
+    [InlineData("[]", false)]
+    [InlineData("[1,{\"a\":true}]", false)]
+    [InlineData("{\"a\":1,\"A\":2}", false)]
+    [InlineData("{\"a\":1,\"a\":2}", true)]
+    [InlineData("{\"a\":{\"b\":1,\"b\":2}}", true)]
+    [InlineData("{\"a\":[{\"b\":1},{\"b\":2}]}", false)]
+    public void InspectArguments_DetectsOrdinalDuplicatesRecursively(string json, bool expectedDuplicate)
+    {
+        var arguments = JsonNode.Parse(json);
+
+        var evidence = StrictToolInputGuard.InspectArguments(arguments);
+
+        evidence.ArgumentBytes.ShouldBe(Encoding.UTF8.GetByteCount(json));
+        evidence.HasDuplicateProperty.ShouldBe(expectedDuplicate);
+    }
+
+    [Fact]
+    public void InspectArguments_NullHasNoEvidence()
+    {
+        StrictToolInputGuard.InspectArguments(null).ShouldBe(default);
+    }
+
+    [Theory]
+    [InlineData("other.tool", 300_000, true, null)]
+    [InlineData("calendar_entities.query", null, false, null)]
+    [InlineData("calendar_entities.query", 262_144, false, null)]
+    [InlineData("calendar_entities.query", 262_145, false, "payload_too_large")]
+    [InlineData("calendar_entities.query", 262_145, true, "payload_too_large")]
+    [InlineData("calendar_entities.query", 1, true, "invalid_input")]
+    public void Reject_AppliesQuerySpecificAdmissionBeforeDuplicateValidation(
+        string toolName,
+        int? argumentBytes,
+        bool duplicate,
+        string? expectedCode)
+    {
+        var result = StrictToolInputGuard.Reject(
+            toolName,
+            new StrictToolInputEvidence(argumentBytes, duplicate));
+
+        if (expectedCode is null)
+        {
+            result.ShouldBeNull();
+            return;
+        }
+        result.ShouldNotBeNull();
+        result.StructuredContent!.Value.GetProperty("code").GetString().ShouldBe(expectedCode);
+        result.StructuredContent.Value.TryGetProperty("items", out _).ShouldBeFalse();
+    }
+}


### PR DESCRIPTION
## Summary

- add `calendar_entities.query` across default, selected, and explicit-all Calendar Scope without broadening authorization
- return revision-coherent Event, Todo, or opaque snapshots through bounded CalDAV REPORT plus strong-ETag direct reads, with deterministic ordering and final local filtering
- add authenticated query-bound cursor pagination, strict raw MCP input validation, closed output shapes, and independent admission, execution, human-readable, and structured-result budgets
- update the transitional service/tool documentation for the unified Calendar surface

## Local verification

- Release build: 0 warnings and 0 errors
- Core unit tests: 394 passed
- MCP unit tests: 282 passed
- contract catalog, host, and metadata tests: 28 passed
- raw MCP stdio tests: 4 passed
- coverage: 94.8% line and 85.7% branch
- Slopwatch: 0 issues
- retry proof: GET, REPORT, and PROPFIND stop at 3 total attempts; mutation remains 1 attempt

## Docker limitation

The complete integration suite was attempted locally. The four no-Docker raw stdio tests passed, while 46 Docker-dependent tests could not initialize Testcontainers because the Resource Reaper was cancelled. Radicale runtime validation was therefore not reached locally. CI run 31929661381 subsequently passed all 50 integration tests and all three pinned Radicale conformance profiles.

Closes #39