### PR TITLE
feat: query bounded calendar occurrences

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ dotnet tool run slopwatch analyze --config .slopwatch/slopwatch.json --fail-on w
 
 - Runtime is transitional: unified Calendar tools use `ICalendarService`, while legacy task tools retain `ITaskService` until the 0.2 cleanup. Both services stay thin; WebDAV request/response logic belongs under `Core/Internal/Xml`, and iCalendar mapping belongs under `Core/Internal/Ical`.
 - `Program.cs` maps `CALDAV_*` environment variables, then delegates startup to `CalDavMcpRunner` and `CalDavHostBuilder`; keep startup testable through those types rather than adding logic to top-level statements.
-- The default host exposes `calendars.list`, `calendar_entities.query`, `calendar_resources.get`, and the staged legacy chat-safe tools. `CALDAV_EXPOSE_EXACT_TOOLS=true` enables exact Calendar resource access; the legacy `CALDAV_EXPOSE_ADVANCED_TOOLS=true` gate remains until its tools are removed.
+- The default host exposes `calendars.list`, `calendar_entities.query`, `calendar_occurrences.query`, `calendar_resources.get`, and the staged legacy chat-safe tools. `CALDAV_EXPOSE_EXACT_TOOLS=true` enables exact Calendar resource access; the legacy `CALDAV_EXPOSE_ADVANCED_TOOLS=true` gate remains until its tools are removed.
 - `.opencode/opencode.jsonc` launches the published NuGet tool through `dnx`; it does not run the current checkout. Do not treat that configuration as source-level end-to-end validation.
 
 ## Invariants

--- a/README.md
+++ b/README.md
@@ -58,9 +58,10 @@ Add this MCP server to VS Code, Claude Desktop, Cursor, or any MCP client:
 
 - `calendar_resources.get` — Read an authoritative semantic-or-opaque snapshot by confirmed absolute href.
 - `calendar_entities.query` — Query bounded persisted Event and To-do snapshots across default, selected, or explicit-all Calendar Scope.
+- `calendar_occurrences.query` — Expand Event and To-do occurrences locally within a required half-open UTC window, using an explicit IANA evaluation time zone only when floating or date-only values require it.
 - `calendar_resources.exact_get` — Opt-in exact read through a protected MCP resource link; enable with `CALDAV_EXPOSE_EXACT_TOOLS=true`.
 
-By default, the server exposes `calendars.list`, `calendar_resources.get`, and `calendar_entities.query` alongside the legacy chat-safe tools retained during the staged migration. Set `CALDAV_EXPOSE_ADVANCED_TOOLS=true` to also expose the legacy href-based advanced tools.
+By default, the server exposes `calendars.list`, `calendar_resources.get`, `calendar_entities.query`, and `calendar_occurrences.query` alongside the legacy chat-safe tools retained during the staged migration. Set `CALDAV_EXPOSE_ADVANCED_TOOLS=true` to also expose the legacy href-based advanced tools.
 
 ## Supported servers
 
@@ -70,7 +71,7 @@ Tested with Radicale (`tomsquest/docker-radicale`). It should work with any stan
 
 Layered design:
 
-`MCP tools` → `ITaskService` → `CalDavClient` → `HttpClient` + `Ical.Net`
+`MCP tools` → `ICalendarService`/`ITaskService` → thin service facade → `CalDavClient` → `HttpClient`; lossless iCalendar projection and bounded recurrence evaluation stay in Core's iCalendar modules.
 
 ## Development
 

--- a/contracts/0.2.0/compatibility-matrix.md
+++ b/contracts/0.2.0/compatibility-matrix.md
@@ -7,12 +7,12 @@ Every component cell uses exactly one closed class. `preserved but unevaluable` 
 | Event and To-do resource projection | supported | supported | pinned-profile-only | planned | `CAL-MODEL-001`, corpus plus live mixed-calendar cases |
 | Exact server-returned resource authority | supported | unsafe through Ical.Net | supported | planned | `CAL-RESOURCE-001`; only server GET bytes are authoritative |
 | Unknown registered and extension content on unrelated patch | supported | unsafe through Ical.Net | preserved but unevaluable | planned | `CAL-RESOURCE-002` corpus oracle; regenerated Ical.Net output is forbidden |
-| Resource-local VTIMEZONE evaluation | required typed rejection | preserved but unevaluable | pinned-profile-only | planned | `CAL-TIME-003`; no host-zone fallback |
-| Bounded RRULE evaluation | supported | supported | pinned-profile-only | planned | `CAL-RECUR-001`; client owns final evaluation |
-| Multiple RRULE resources | preserved but unevaluable | preserved but unevaluable | pinned-profile-only | planned | `CAL-MODEL-005`; return `recurrence_unevaluable` |
+| Resource-local VTIMEZONE evaluation | supported | preserved but unevaluable | pinned-profile-only | implemented for occurrence queries | `CAL-TIME-003`; one unambiguous resource-local definition wins, while unknown or conflicting definitions fail with a typed outcome and no host-zone fallback |
+| Bounded RRULE evaluation | supported | supported | pinned-profile-only | implemented for occurrence queries | `CAL-RECUR-001`; client owns final evaluation from authoritative GET bytes |
+| Multiple RRULE resources | preserved but unevaluable | preserved but unevaluable | pinned-profile-only | implemented for occurrence queries | `CAL-MODEL-005`; preserve the resource and return `recurrence_unevaluable` with no partial items |
 | RDATE PERIOD semantic write | required typed rejection | preserved but unevaluable | required typed rejection | planned | `CAL-RECUR-002`; reject before PUT |
 | THISANDFUTURE mutation | supported | unsafe through Ical.Net | pinned-profile-only | planned | `CAL-BASE-004`; service owns semantics |
-| Full-resource GET and REPORT candidate reduction | supported | required typed rejection | supported | planned | `CAL-DISC-006`, `CAL-DAV-001`; final filter is local |
+| Full-resource GET and REPORT candidate reduction | supported | required typed rejection | supported | implemented for entity and occurrence queries | `CAL-DISC-006`, `CAL-DAV-001`; REPORT is candidate reduction only and final filtering uses authoritative GET bytes locally |
 | Strong ETag conditional mutation | supported | required typed rejection | supported | planned | `CAL-RESOURCE-009`; no weak-tag bypass |
 | Strict preconditions mode | supported | required typed rejection | pinned-profile-only | implemented | `strict-preconditions` fixture variant |
 | Calendar alarms and URI values | supported | preserved but unevaluable | preserved but unevaluable | planned | `CAL-EVENT-006`; never execute or dereference |

--- a/contracts/0.2.0/requirement-evidence-catalog.md
+++ b/contracts/0.2.0/requirement-evidence-catalog.md
@@ -103,10 +103,10 @@ Every requirement row contains the normative statement, source, interoperability
 - Normative strength: MUST; this is a versioned 0.2.0 contract requirement.
 - Interoperability profile and compatibility class: standards baseline; Radicale 3.7.8 where applicable; see [compatibility matrix](compatibility-matrix.md).
 - Primary evidence layer: semantic corpus.
-- Named scenario or fixture: `0.2.0/model/cal-model-005`.
+- Named scenario or fixture: `0.2.0/model/cal-model-005`; committed issue #40 targets: `CalendarServiceTests.QueryOccurrencesAsync_MultipleRrulesAreTypedRecurrenceUnevaluableWithNoPartialItems` and `RadicaleConformanceHarnessTests.Pinned_profile_preserves_occurrence_boundary_dst_leap_range_and_typed_failures`.
 - Objective oracle: Given DTSTART, two RRULE lines, two RDATEs, one EXDATE, and two overrides, when read, then `rrules` has count 2, `evaluationState=unevaluable`, every RDATE/EXDATE/override remains ordered, and recurrence expansion returns `recurrence_unevaluable`.
-- Implementation status: planned.
-- Evidence status: planned until its named scenario is green in pull-request and release CI.
+- Implementation status: the occurrence-query slice is implemented: multiple RRULE resources remain projectable but recurrence evaluation fails closed with `recurrence_unevaluable` and zero partial items; semantic creation and mutation remain planned.
+- Evidence status: focused Core evidence passes locally; the digest-pinned Radicale target is committed and remains pending pull-request CI because this machine's Docker path could not complete fixture startup (Resource Reaper timeout, then fixture HTTP timeout when bypassed).
 
 ## CAL-MODEL-006
 
@@ -115,10 +115,10 @@ Every requirement row contains the normative statement, source, interoperability
 - Normative strength: MUST; this is a versioned 0.2.0 contract requirement.
 - Interoperability profile and compatibility class: standards baseline; Radicale 3.7.8 where applicable; see [compatibility matrix](compatibility-matrix.md).
 - Primary evidence layer: semantic corpus.
-- Named scenario or fixture: `0.2.0/model/cal-model-006`.
-- Objective oracle: Given a recurring event expanded into three occurrences, when occurrence query returns them, then every item has `timing` and recurrence identity, none has a resource href/ETag mutation target, and a direct write attempt is rejected as `invalid_input`.
-- Implementation status: planned.
-- Evidence status: planned until its named scenario is green in pull-request and release CI.
+- Named scenario or fixture: `0.2.0/model/cal-model-006`; committed issue #40 target: occurrence snapshot-shape assertions in `CalendarOccurrenceToolsTests.QueryAsync_EmitsExactOccurrenceShapeAndPaginatesByFrozenContinuationTuple`; direct Occurrence-object mutation rejection remains a planned mutation-tool target.
+- Objective oracle: Given a recurring event expanded into three occurrences, when occurrence query returns them, then every item has `timing`, original recurrence identity, and an `occurrenceSnapshot.calendarSnapshot` carrying the authoritative source href and ETag. The derived Occurrence object is not accepted directly as mutation input and is never serialized or written back. Any mutation uses its own input contract, an extracted or supplied Revision Reference, explicit original identity and intent, and an authoritative refetch; a direct Occurrence-object write is rejected as `invalid_input` once that mutation tool exists.
+- Implementation status: occurrence query returns the frozen derived shape with authoritative source revision; direct Occurrence-object mutation admission remains planned with the mutation tools.
+- Evidence status: focused occurrence snapshot-shape evidence passes locally; the direct-write rejection target remains planned and is not claimed as implemented evidence.
 
 ## CAL-MODEL-007
 
@@ -535,10 +535,10 @@ Every requirement row contains the normative statement, source, interoperability
 - Normative strength: MUST; this is a versioned 0.2.0 contract requirement.
 - Interoperability profile and compatibility class: standards baseline; Radicale 3.7.8 where applicable; see [compatibility matrix](compatibility-matrix.md).
 - Primary evidence layer: semantic corpus.
-- Named scenario or fixture: `0.2.0/time/cal-time-002`.
+- Named scenario or fixture: `0.2.0/time/cal-time-002`; committed issue #40 targets: `CalendarServiceTests.QueryOccurrencesAsync_FloatingComparisonRequiresExplicitEvaluationTimeZoneOnlyWhenEncountered`, `QueryOccurrencesAsync_ExplicitFloatingGapUsesPriorEvaluationZoneOffset`, `QueryOccurrencesAsync_FloatingRruleSkipsEvaluationZoneGapWithoutConsumingCount`, `QueryOccurrencesAsync_DateOnlyEventDefaultsToOneLocalDay`, and `QueryOccurrencesAsync_DateOnlyTodoStartAndDueAreLocalPoints`.
 - Objective oracle: Given date/floating values and explicit request IANA `America/Sao_Paulo`, when comparison/expansion runs, then that context is recorded and used; omitted context returns temporal_unresolved and never reads calendar/server/process/host timezone.
-- Implementation status: planned.
-- Evidence status: planned until its named scenario is green in pull-request and release CI.
+- Implementation status: implemented for occurrence comparison and expansion; the request IANA zone is required only when a floating or date-only value is actually evaluated, and no implicit host/server zone is used.
+- Evidence status: focused Core and MCP occurrence-query targets pass locally and are included in the CI test run.
 
 ## CAL-TIME-003
 
@@ -547,10 +547,10 @@ Every requirement row contains the normative statement, source, interoperability
 - Normative strength: MUST; this is a versioned 0.2.0 contract requirement.
 - Interoperability profile and compatibility class: standards baseline; Radicale 3.7.8 where applicable; see [compatibility matrix](compatibility-matrix.md).
 - Primary evidence layer: semantic corpus.
-- Named scenario or fixture: `0.2.0/time/cal-time-003`.
-- Objective oracle: Given unambiguous resource VTIMEZONE, recognized IANA, unknown `Mars/Base`, and conflicting VTIMEZONE, when evaluated, then unambiguous resource zone wins then IANA; unknown/conflicting values stay preserved with diagnostics, unrelated patch succeeds, and evaluation returns temporal_unresolved.
-- Implementation status: planned.
-- Evidence status: planned until its named scenario is green in pull-request and release CI.
+- Named scenario or fixture: `0.2.0/time/cal-time-003`; committed issue #40 targets: `CalendarServiceTests.QueryOccurrencesAsync_UnambiguousResourceLocalTimeZonePrecedesIanaDefinition`, `QueryOccurrencesAsync_ResourceLocalRecurringZoneIsEvaluatedWithoutIanaFallback`, `QueryOccurrencesAsync_ExplicitIanaGapUsesPriorOffsetAndOverlapUsesFirstOccurrence`, `QueryOccurrencesAsync_IanaRruleSkipsGapWithoutConsumingCount`, `QueryOccurrencesAsync_ExplicitResourceLocalGapAndOverlapFollowRfc5545`, `QueryOccurrencesAsync_ResourceLocalRruleSkipsGapWithoutConsumingCount`, `QueryOccurrencesAsync_RruleOverlapUsesFirstOccurrenceExactlyOnce`, `QueryOccurrencesAsync_ExdateSuppressedUnknownZoneOverrideDoesNotRequireResolution`, `QueryOccurrencesAsync_CancelledUnknownZoneOverrideDoesNotRequireResolution`, `QueryOccurrencesAsync_ActiveUnknownZoneOverrideRemainsTypedTemporalUnresolved`, `QueryOccurrencesAsync_UnknownNamedZoneIsTypedTemporalUnresolved`, and `QueryOccurrencesAsync_ConflictingResourceLocalZonesAreTypedTemporalUnresolved`.
+- Objective oracle: Given unambiguous resource VTIMEZONE, recognized IANA, explicit and RRULE-generated local values in gaps/overlaps, unknown `Mars/Base`, and conflicting VTIMEZONE, when evaluated, then the resource zone wins before IANA; explicit gap uses the pre-gap offset, overlap uses the first occurrence, generated gap instances are skipped without consuming COUNT, and unknown/conflicting values return temporal_unresolved.
+- Implementation status: the occurrence-query evaluation slice is implemented: one resource-local definition takes precedence, recognized IANA is the fallback, RFC gap/overlap semantics distinguish explicit from generated values, and unknown/conflicting definitions return `temporal_unresolved`; unrelated mutation behavior remains planned.
+- Evidence status: focused Core evidence passes locally; the typed unresolved path is also committed to the real-stdio and digest-pinned Radicale targets.
 
 ## CAL-TIME-004
 
@@ -559,10 +559,10 @@ Every requirement row contains the normative statement, source, interoperability
 - Normative strength: MUST; this is a versioned 0.2.0 contract requirement.
 - Interoperability profile and compatibility class: standards baseline; Radicale 3.7.8 where applicable; see [compatibility matrix](compatibility-matrix.md).
 - Primary evidence layer: semantic corpus.
-- Named scenario or fixture: `0.2.0/time/cal-time-004`.
+- Named scenario or fixture: `0.2.0/time/cal-time-004`; committed issue #40 targets: `CalendarServiceTests.QueryOccurrencesAsync_DateOnlyEventDefaultsToOneLocalDay`, `QueryOccurrencesAsync_DateEventIndividualOverrideDefaultsToOneDay`, `QueryOccurrencesAsync_DateEventRangeOverrideDefaultsEachOccurrenceToOneDay`, `QueryOccurrencesAsync_DateEventOverrideDefaultsToNextLocalDayAcrossDst`, `QueryOccurrencesAsync_IanaMasterDistinguishesNominalDayFromAccurateHours`, `QueryOccurrencesAsync_IanaOverrideDistinguishesNominalDayFromAccurateHours`, `QueryOccurrencesAsync_DetachedOverrideRetainsAccurateMasterSourceSpanAcrossDst`, `QueryOccurrencesAsync_ResourceLocalMasterUsesTheSameDurationArithmetic`, `QueryOccurrencesAsync_WeekDurationRemainsNominalAcrossDst`, `CalendarDurationParser_RejectsNonRfcGrammar`, `CalendarDurationParser_PreservesNominalAndAccurateComponents`, `QueryOccurrencesAsync_RangeDurationUsesPerInstanceNominalThenAccurateArithmetic`, `QueryOccurrencesAsync_RecurringExplicitEndPropagatesExactDurationAcrossDst`, `QueryOccurrencesAsync_RangeExplicitEndPropagatesExactDurationAfterAnchor`, `QueryOccurrencesAsync_RecurringTodoDuePropagatesExactDurationAcrossDst`, `QueryOccurrencesAsync_RecurringDateSearchIncludesTwentyFiveHourFallBackSpan`, `QueryOccurrencesAsync_DateOnlyTodoStartAndDueAreLocalPoints`, and `QueryOccurrencesAsync_SelectedScopeIncludesEventsAndEveryTimedTodoForm`.
 - Objective oracle: Given exclusive spans, default one-day event, zero-duration event, VTODO DUE/DURATION variants, missing DTSTART duration, and reschedule, when validated, then bounds/default/span/reschedule results match fixture; zero-duration has effective start=end and appears only when its start lies in range; invalid due/duration/start combinations reject before PUT.
-- Implementation status: planned.
-- Evidence status: planned until its named scenario is green in pull-request and release CI.
+- Implementation status: the occurrence-query effective-span slice is implemented, including exclusive bounds, one-day date Events, zero-duration date-time Events, and available To-do DTSTART/DUE/DURATION forms; reschedule mutation validation remains planned.
+- Evidence status: focused Core occurrence-query targets pass locally and are included in the CI test run.
 
 ## CAL-RECUR-001
 
@@ -571,10 +571,10 @@ Every requirement row contains the normative statement, source, interoperability
 - Normative strength: MUST; this is a versioned 0.2.0 contract requirement.
 - Interoperability profile and compatibility class: standards baseline; Radicale 3.7.8 where applicable; see [compatibility matrix](compatibility-matrix.md).
 - Primary evidence layer: semantic corpus.
-- Named scenario or fixture: `0.2.0/recur/cal-recur-001`.
+- Named scenario or fixture: `0.2.0/recur/cal-recur-001`; committed issue #40 targets: `CalendarServiceTests.QueryOccurrencesAsync_SelectedScopeIncludesEventsAndEveryTimedTodoForm`, `QueryOccurrencesAsync_ExdateAndCancellationSuppressWhileMovedTimingRetainsOriginalIdentity`, `CalendarMcpStdioIntegrationTests.CalendarOccurrenceQuery_ProvesBoundaryDstLeapRangeAndTypedFailuresOverRealStdioAndRadicale`, and `RadicaleConformanceHarnessTests.Pinned_profile_preserves_occurrence_boundary_dst_leap_range_and_typed_failures`.
 - Objective oracle: Given non-empty UTC `[from,to)` window, overlap event, zero-duration event, moved override, and nonrecurring VTODO fixtures with and without DTSTART/DUE/DURATION, when query runs, then overlap appears, zero-duration matches iff start is in range, moved effective span is returned, todo output follows timing presence, and invalid/empty window rejects.
-- Implementation status: planned.
-- Evidence status: planned until its named scenario is green in pull-request and release CI.
+- Implementation status: implemented for bounded Event and To-do occurrence queries, including half-open overlap/point matching, moved effective spans, every non-recurring To-do timing form, and no occurrence for a To-do without temporal data.
+- Evidence status: semantic-corpus targets pass locally; real-stdio and digest-pinned Radicale targets are committed, with live local execution pending because this machine's Docker path could not complete fixture startup.
 
 ## CAL-RECUR-002
 
@@ -583,10 +583,10 @@ Every requirement row contains the normative statement, source, interoperability
 - Normative strength: MUST; this is a versioned 0.2.0 contract requirement.
 - Interoperability profile and compatibility class: standards baseline; Radicale 3.7.8 where applicable; see [compatibility matrix](compatibility-matrix.md).
 - Primary evidence layer: semantic corpus.
-- Named scenario or fixture: `0.2.0/recur/cal-recur-002`.
-- Objective oracle: Given DTSTART, one RRULE, all RDATE/EXDATE/overrides including duplicate identities and RDATE PERIOD, when expansion/create run, then duplicates collapse, EXDATE wins, overrides remain, and PERIOD is preserved but rejected before Radicale PUT.
-- Implementation status: planned.
-- Evidence status: planned until its named scenario is green in pull-request and release CI.
+- Named scenario or fixture: `0.2.0/recur/cal-recur-002`; committed issue #40 targets: `CalendarServiceTests.QueryOccurrencesAsync_RdatePeriodSuppliesOccurrenceSpecificSpan`, `QueryOccurrencesAsync_RdatePeriodDeduplicatesAndOverrideUsesOccurrenceSpecificSourceSpan`, `QueryOccurrencesAsync_RdatePeriodUsesNominalThenAccurateDurationArithmetic`, `QueryOccurrencesAsync_ExdateSuppressesDuplicateRdatePeriodAndItsOverride`, `QueryOccurrencesAsync_DetachedEventOverridesAreEnumeratedWithCancellationAndExdatePrecedence`, `QueryOccurrencesAsync_DetachedTodoOverridesWithoutDtstartRemainObservable`, and `QueryOccurrencesAsync_DueOnlyRecurringTodoIsTypedRecurrenceUnevaluable`.
+- Objective oracle: Given DTSTART, one RRULE, all RDATE/EXDATE/overrides including duplicate and detached identities, VTODO overrides without DTSTART, and RDATE PERIOD, when expansion runs, then duplicates collapse, EXDATE wins even over preserved overrides, detached moved overrides remain observable, cancellations are omitted, PERIOD supplies its own span, and VTODO RRULE without DTSTART is recurrence_unevaluable.
+- Implementation status: the occurrence-query slice is implemented for RRULE/RDATE/EXDATE/override identity collapse, detached override enumeration, EXDATE precedence, VTODO recurrence validity, and occurrence-specific RDATE PERIOD spans; semantic create and Radicale write rejection remain planned.
+- Evidence status: focused Core occurrence-query targets pass locally and are included in the CI test run.
 
 ## CAL-RECUR-003
 
@@ -595,10 +595,10 @@ Every requirement row contains the normative statement, source, interoperability
 - Normative strength: MUST; this is a versioned 0.2.0 contract requirement.
 - Interoperability profile and compatibility class: standards baseline; Radicale 3.7.8 where applicable; see [compatibility matrix](compatibility-matrix.md).
 - Primary evidence layer: semantic corpus.
-- Named scenario or fixture: `0.2.0/recur/cal-recur-003`.
+- Named scenario or fixture: `0.2.0/recur/cal-recur-003`; committed issue #40 targets: `CalendarServiceTests.QueryOccurrencesAsync_NearestRangeReplacesEarlierAndIndividualOverrideWins`, `QueryOccurrencesAsync_MovedRangeMatchesEffectiveWindowAndRetainsOriginalIdentity`, `QueryOccurrencesAsync_CancelledRangeOmitsUntilLaterRangeWhileExactOverrideWins`, `QueryOccurrencesAsync_OldTodoRangeMovedByDueIsIncludedInBoundedSearch`, plus the real-stdio and pinned-Radicale advanced occurrence targets.
 - Objective oracle: Given master recurrence ID `2026-01-02T09:00:00`, moved override, and overlapping RANGE overrides, when expanded, then returned identity remains original master family/value and later applicable range override wins deterministically.
-- Implementation status: planned.
-- Evidence status: planned until its named scenario is green in pull-request and release CI.
+- Implementation status: implemented for occurrence queries: original Recurrence Identity is stable, the nearest applicable RANGE transformation is used without double stacking, a later range supersedes an earlier range, and an exact individual override wins.
+- Evidence status: focused Core targets pass locally; the moved-identity/range-precedence path is committed to real-stdio and digest-pinned Radicale CI targets.
 
 ## CAL-RECUR-004
 
@@ -667,10 +667,10 @@ Every requirement row contains the normative statement, source, interoperability
 - Normative strength: MUST; this is a versioned 0.2.0 contract requirement.
 - Interoperability profile and compatibility class: standards baseline; Radicale 3.7.8 where applicable; see [compatibility matrix](compatibility-matrix.md).
 - Primary evidence layer: real MCP client over stdio.
-- Named scenario or fixture: `0.2.0/mcp/cal-mcp-002`.
+- Named scenario or fixture: `0.2.0/mcp/cal-mcp-002`; committed issue #40 targets: `CalDavHostBuilderTests.CreateBuilder_DefaultMode_RegistersCalendarDiscoveryAlongsideChatSafeLegacyTools` and `BuildHost_DefaultMode_ListsToolsInCanonicalWireOrder`.
 - Objective oracle: Given tools/list, when catalog is emitted, then the 16 default names exactly equal the committed discovery order and no exact tool appears without opt-in.
-- Implementation status: planned.
-- Evidence status: planned until its named scenario is green in pull-request and release CI.
+- Implementation status: the `calendar_occurrences.query` catalog position and default exposure are implemented; later semantic tools in the frozen 16-tool catalog remain planned by their owning tickets.
+- Evidence status: focused host discovery/order targets pass locally and are included in the CI test run.
 
 ## CAL-MCP-003
 
@@ -691,10 +691,10 @@ Every requirement row contains the normative statement, source, interoperability
 - Normative strength: MUST; this is a versioned 0.2.0 contract requirement.
 - Interoperability profile and compatibility class: standards baseline; Radicale 3.7.8 where applicable; see [compatibility matrix](compatibility-matrix.md).
 - Primary evidence layer: real MCP client over stdio.
-- Named scenario or fixture: `0.2.0/mcp/cal-mcp-004`.
+- Named scenario or fixture: `0.2.0/mcp/cal-mcp-004`; committed issue #40 targets: `CalendarOccurrenceToolsTests.QueryRawAsync_AcceptsExactFrozenShapeWithoutEntityKindsAndDefaultsAbsentPageSize`, `QueryRawAsync_RejectsMissingNullAndUnknownFrozenShape`, `QueryAsync_EmitsExactOccurrenceShapeAndPaginatesByFrozenContinuationTuple`, and `CalendarMcpRawStdioTests.CalendarOccurrenceQuery_RootDuplicateArgumentsReturnTypedInvalidInputBeforeNetwork`.
 - Objective oracle: Given valid closed input, unknown sibling, duplicate JSON member, and typed failure, when tool validates, then valid authoritative structuredContent matches output schema with concise compatible text content, invalid values return schema-valid invalid_input, and parser rejects duplicate/unknown members.
-- Implementation status: planned.
-- Evidence status: planned until its named scenario is green in pull-request and release CI.
+- Implementation status: implemented for `calendar_occurrences.query`, including the frozen closed input without `entityKinds`, duplicate/unknown rejection, exact output union, authoritative structured content, and bounded compatible text; later tools remain planned.
+- Evidence status: focused MCP unit and raw-stdio targets pass locally and are included in the CI test run.
 
 ## CAL-MCP-005
 
@@ -703,10 +703,10 @@ Every requirement row contains the normative statement, source, interoperability
 - Normative strength: MUST; this is a versioned 0.2.0 contract requirement.
 - Interoperability profile and compatibility class: standards baseline; Radicale 3.7.8 where applicable; see [compatibility matrix](compatibility-matrix.md).
 - Primary evidence layer: real MCP client over stdio.
-- Named scenario or fixture: `0.2.0/mcp/cal-mcp-005`.
+- Named scenario or fixture: `0.2.0/mcp/cal-mcp-005`; committed issue #40 target: `CalendarOccurrenceToolsTests.QueryAsync_CursorIsNonceRandomTamperEvidentBoundToQueryCredentialsExpiryAndProcessKey` exercises default, selected, and all scope binding through the occurrence query cursor.
 - Objective oracle: Given by-name, by-href, default, selected, all scope, and a stale revision, when resolution/mutation runs, then exactly one selector branch is accepted, all is explicit, and mutation refetches expected href/UID/kind/ETag before write.
-- Implementation status: planned.
-- Evidence status: planned until its named scenario is green in pull-request and release CI.
+- Implementation status: the read-only Calendar Scope path is implemented for occurrence queries through the shared discovery/selection engine; mutation revision behavior remains planned.
+- Evidence status: focused occurrence-query scope and cursor-binding targets pass locally and are included in the CI test run.
 
 ## CAL-MCP-006
 
@@ -727,10 +727,10 @@ Every requirement row contains the normative statement, source, interoperability
 - Normative strength: MUST; this is a versioned 0.2.0 contract requirement.
 - Interoperability profile and compatibility class: standards baseline; Radicale 3.7.8 where applicable; see [compatibility matrix](compatibility-matrix.md).
 - Primary evidence layer: real MCP client over stdio.
-- Named scenario or fixture: `0.2.0/mcp/cal-mcp-007`.
+- Named scenario or fixture: `0.2.0/mcp/cal-mcp-007`; committed issue #40 targets: `CalendarServiceTests.QueryOccurrencesAsync_OrdersByEffectiveStartCalendarHrefUidThenRecurrenceIdentity` and `CalendarOccurrenceToolsTests.QueryAsync_EmitsExactOccurrenceShapeAndPaginatesByFrozenContinuationTuple`.
 - Objective oracle: Given paginated entity and occurrence results with equal timestamps, when query continues, then envelope has items/diagnostics/non_snapshot/nextCursor, entities sort calendar href/resource href and occurrences sort effective start/href/UID/identity.
-- Implementation status: planned.
-- Evidence status: planned until its named scenario is green in pull-request and release CI.
+- Implementation status: implemented for occurrence queries: exact effective-start/Calendar-href/UID/Recurrence-Identity ordering, non-snapshot envelope, and protected continuation tuple pagination; entity ordering was delivered by the preceding query slice.
+- Evidence status: focused Core and MCP targets pass locally and are included in the CI test run.
 
 ## CAL-MCP-008
 
@@ -739,10 +739,10 @@ Every requirement row contains the normative statement, source, interoperability
 - Normative strength: MUST; this is a versioned 0.2.0 contract requirement.
 - Interoperability profile and compatibility class: standards baseline; Radicale 3.7.8 where applicable; see [compatibility matrix](compatibility-matrix.md).
 - Primary evidence layer: real MCP client over stdio.
-- Named scenario or fixture: `0.2.0/mcp/cal-mcp-008`.
+- Named scenario or fixture: `0.2.0/mcp/cal-mcp-008`; committed issue #40 targets: `CalendarOccurrenceToolsTests.QueryAsync_MapsEveryDomainFailure`, `QueryAsync_PreservesDiscoveryPhaseForDiscovery404`, `QueryAsync_MalformedDiscoveryRetainsSelectionDiscoveryPhase`, and `CalendarMcpRawStdioTests.CalendarOccurrenceQuery_NormalRawCallReachesServiceAndReturnsTypedExecutionFailure`.
 - Objective oracle: Given invalid input, conflict, limit, upstream, unexpected exception, no_change, declined confirmation, invalid JSON, unknown method/tool, incompatible version and transport auth failure, when requests run, then tool failures use isError/schema-valid safe fields, protocol cases use their protocol/HTTP channel, and no_change/decline use isError false.
-- Implementation status: planned.
-- Evidence status: planned until its named scenario is green in pull-request and release CI.
+- Implementation status: implemented for expected occurrence-query failures, including schema-valid `isError`, sanitized unexpected failures, earliest discovery phase retention, execution-phase failures, and typed real-stdio results; non-query mutation outcomes remain planned.
+- Evidence status: focused MCP unit and raw-stdio targets pass locally and are included in the CI test run.
 
 ## CAL-MCP-009
 
@@ -787,10 +787,10 @@ Every requirement row contains the normative statement, source, interoperability
 - Normative strength: MUST; this is a versioned 0.2.0 contract requirement.
 - Interoperability profile and compatibility class: standards baseline; Radicale 3.7.8 where applicable; see [compatibility matrix](compatibility-matrix.md).
 - Primary evidence layer: real MCP client over stdio.
-- Named scenario or fixture: `0.2.0/mcp/cal-mcp-012`.
+- Named scenario or fixture: `0.2.0/mcp/cal-mcp-012`; committed issue #40 target: `CalDavHostBuilderTests.BuildHost_AdvertisesFrozenOccurrenceQuerySchemasAndPrivateCacheHint`.
 - Objective oracle: Given list/query/snapshot/mutation calls, when annotations/cache inspected, then ttlMs are 30000/5000/0, cacheScope private, no list-change notification is advertised, and all annotation booleans match external CalDAV behavior.
-- Implementation status: planned.
-- Evidence status: planned until its named scenario is green in pull-request and release CI.
+- Implementation status: the private five-second cache hint and frozen annotations are implemented for `calendar_occurrences.query`; later catalog entries remain planned by their owning tickets.
+- Evidence status: focused host metadata target passes locally and is included in the CI test run.
 
 ## CAL-MCP-013
 
@@ -811,10 +811,10 @@ Every requirement row contains the normative statement, source, interoperability
 - Normative strength: MUST; this is a versioned 0.2.0 contract requirement.
 - Interoperability profile and compatibility class: standards baseline; Radicale 3.7.8 where applicable; see [compatibility matrix](compatibility-matrix.md).
 - Primary evidence layer: deterministic WebDAV contract.
-- Named scenario or fixture: `0.2.0/bound/cal-bound-001`.
+- Named scenario or fixture: `0.2.0/bound/cal-bound-001`; committed issue #40 targets: `CalendarOccurrenceToolsTests.QueryRawAsync_EnforcesExactArgumentByteBoundary`, `QueryRawAsync_RejectsMissingNullAndUnknownFrozenShape`, `QueryAsync_PreservesDiscoveryPhaseForDiscovery404`, and `QueryAsync_MalformedDiscoveryRetainsSelectionDiscoveryPhase`.
 - Objective oracle: Given inputs failing authorization, payload, schema, origin, selection, revision, resource semantics, MRTR, execution and verification in combination, when validated, then only earliest phase is returned and at most 32 JSON-pointer-sorted safe violations appear.
-- Implementation status: planned.
-- Evidence status: planned until its named scenario is green in pull-request and release CI.
+- Implementation status: the occurrence-query validation path is implemented through execution, including payload-before-schema ordering and earliest `selectionDiscoveryCapability` versus `execution` phase mapping; mutation-only phases remain planned.
+- Evidence status: focused MCP targets pass locally and are included in the CI test run.
 
 ## CAL-BOUND-002
 
@@ -823,10 +823,10 @@ Every requirement row contains the normative statement, source, interoperability
 - Normative strength: MUST; this is a versioned 0.2.0 contract requirement.
 - Interoperability profile and compatibility class: standards baseline; Radicale 3.7.8 where applicable; see [compatibility matrix](compatibility-matrix.md).
 - Primary evidence layer: deterministic WebDAV contract.
-- Named scenario or fixture: `0.2.0/bound/cal-bound-002`.
+- Named scenario or fixture: `0.2.0/bound/cal-bound-002`; committed issue #40 targets: `CalendarOccurrenceToolsTests.QueryRawAsync_AcceptsExactFrozenShapeWithoutEntityKindsAndDefaultsAbsentPageSize` plus bounded-window and page-size cases in `CalendarServiceTests` and `CalendarOccurrenceToolsTests`.
 - Objective oracle: Given 0-day, 366-day, 367-day windows; page sizes 0,50,200,201; 256 calendars and 5001 resources, when queried, then valid bounds/default 50/cap 200 apply and excess returns limit_exhausted before partial results.
-- Implementation status: planned.
-- Evidence status: planned until its named scenario is green in pull-request and release CI.
+- Implementation status: implemented for occurrence queries through the shared bounded query engine: non-empty windows up to 366 days, nullable pageSize default 50/cap 200, and shared 5,000-resource/256-Calendar ceilings with zero partial results.
+- Evidence status: focused Core and MCP boundary targets pass locally and are included in the CI test run.
 
 ## CAL-BOUND-003
 
@@ -835,10 +835,10 @@ Every requirement row contains the normative statement, source, interoperability
 - Normative strength: MUST; this is a versioned 0.2.0 contract requirement.
 - Interoperability profile and compatibility class: standards baseline; Radicale 3.7.8 where applicable; see [compatibility matrix](compatibility-matrix.md).
 - Primary evidence layer: deterministic WebDAV contract.
-- Named scenario or fixture: `0.2.0/bound/cal-bound-003`.
-- Objective oracle: Given recurrence fixtures producing 2000,2001 entity occurrences; 5000,5001 query occurrences; and 10000,10001 unmatched increments, when expanded, then ceilings pass exactly and plus-one returns limit_exhausted with items count zero.
-- Implementation status: planned.
-- Evidence status: planned until its named scenario is green in pull-request and release CI.
+- Named scenario or fixture: `0.2.0/bound/cal-bound-003`; committed issue #40 targets: `CalendarServiceTests.QueryOccurrencesAsync_EnforcesExactPerEntityOccurrenceBoundaryWithZeroPartial`, `QueryOccurrencesAsync_PeriodBoundaryCountsUniqueDerivedWorkOutsideWindow`, `QueryOccurrencesAsync_DuplicatePeriodIdentityDoesNotInflateDerivedWork`, `QueryOccurrencesAsync_DetachedOverrideBoundaryCountsUniqueDerivedWorkOutsideWindow`, `QueryOccurrencesAsync_PerEntityBoundaryUnionsRrulePeriodAndDetachedIdentities`, `QueryOccurrencesAsync_EnforcesExactTotalOccurrenceBoundaryWithZeroPartial`, `QueryOccurrencesAsync_EnforcesExactUnmatchedIncrementBoundaryWithoutPartialOrInventedOccurrenceCount`, and `QueryOccurrencesAsync_OldResourceLocalSeriesStartsNearBoundedWindow`.
+- Objective oracle: Given recurrence fixtures deriving 2000/2001 unique entity identities in and outside the query window, including RDATE PERIOD and detached overrides; 5000/5001 query occurrences; and 10000/10001 unmatched increments, when expanded, then ceilings pass exactly, duplicate identities neither inflate nor bypass the work count, and plus-one returns limit_exhausted with items count zero.
+- Implementation status: implemented for recurrence expansion with exact 2,000/2,001 per-entity, 5,000/5,001 per-query, and 10,000/10,001 unmatched-increment behavior; every exhausted result contains zero partial items.
+- Evidence status: exact boundary targets pass locally and are included in the CI test run.
 
 ## CAL-BOUND-004
 
@@ -847,10 +847,10 @@ Every requirement row contains the normative statement, source, interoperability
 - Normative strength: MUST; this is a versioned 0.2.0 contract requirement.
 - Interoperability profile and compatibility class: standards baseline; Radicale 3.7.8 where applicable; see [compatibility matrix](compatibility-matrix.md).
 - Primary evidence layer: deterministic WebDAV contract.
-- Named scenario or fixture: `0.2.0/bound/cal-bound-004`.
+- Named scenario or fixture: `0.2.0/bound/cal-bound-004`; committed issue #40 targets: `CalendarOccurrenceToolsTests.QueryRawAsync_EnforcesExactArgumentByteBoundary`, `QueryAsync_RejectsSingleOccurrenceThatCannotFitStructuredBudget`, and `QueryAsync_RejectsHumanAndDiagnosticContentBeyondShared64KiBBudget`.
 - Objective oracle: Given UTF-8 JSON at 256KiB±1, resource/exact payload/page at 4MiB±1, text/diagnostics at 64KiB±1, and compressed body expanding over limit, when streamed, then limit-plus-one rejects with payload_too_large and no partial serialization.
-- Implementation status: planned.
-- Evidence status: planned until its named scenario is green in pull-request and release CI.
+- Implementation status: the occurrence-query slice is implemented for 256 KiB arguments, 4 MiB structured page/single-item handling, and 64 KiB text plus diagnostics with zero partial serialization; mutation payload paths remain planned.
+- Evidence status: focused MCP exact and plus-one boundary targets pass locally and are included in the CI test run.
 
 ## CAL-BOUND-005
 
@@ -859,10 +859,10 @@ Every requirement row contains the normative statement, source, interoperability
 - Normative strength: MUST; this is a versioned 0.2.0 contract requirement.
 - Interoperability profile and compatibility class: standards baseline; Radicale 3.7.8 where applicable; see [compatibility matrix](compatibility-matrix.md).
 - Primary evidence layer: deterministic WebDAV contract.
-- Named scenario or fixture: `0.2.0/bound/cal-bound-005`.
+- Named scenario or fixture: `0.2.0/bound/cal-bound-005`; committed issue #40 target: `CalendarOccurrenceToolsTests.QueryAsync_FinalDeadlineReturnsLimitErrorWithoutSuccessItems`.
 - Objective oracle: Given reads with transient failures, mutations before/after dispatch, and fake clock at 10/30/60 seconds, when retries execute, then reads make at most three attempts, mutations no blind retries, and timeout code/phase reflects attempt, operation, or reconciliation bound.
-- Implementation status: planned.
-- Evidence status: planned until its named scenario is green in pull-request and release CI.
+- Implementation status: the occurrence-query 30-second read deadline is implemented over the existing bounded HTTP read path; mutation, reconciliation, and generated-UID limits remain planned.
+- Evidence status: focused fake-time occurrence deadline target passes locally and is included in the CI test run.
 
 ## CAL-BOUND-006
 
@@ -883,10 +883,10 @@ Every requirement row contains the normative statement, source, interoperability
 - Normative strength: MUST; this is a versioned 0.2.0 contract requirement.
 - Interoperability profile and compatibility class: standards baseline; Radicale 3.7.8 where applicable; see [compatibility matrix](compatibility-matrix.md).
 - Primary evidence layer: deterministic WebDAV contract.
-- Named scenario or fixture: `0.2.0/bound/cal-bound-007`.
+- Named scenario or fixture: `0.2.0/bound/cal-bound-007`; committed issue #40 target: `CalendarOccurrenceToolsTests.QueryAsync_CallerCancellationPropagatesWithoutReturningAResult`.
 - Objective oracle: Given cancelled read, cancelled pre-dispatch mutation, and cancelled post-dispatch mutation, when tokens fire, then first two stop promptly with zero/one dispatch respectively and post-dispatch continues bounded reconciliation to truthful mutationState.
-- Implementation status: planned.
-- Evidence status: planned until its named scenario is green in pull-request and release CI.
+- Implementation status: prompt caller cancellation is implemented for occurrence reads; post-dispatch mutation reconciliation remains planned.
+- Evidence status: focused occurrence cancellation target passes locally and is included in the CI test run.
 
 ## CAL-BOUND-008
 
@@ -895,10 +895,10 @@ Every requirement row contains the normative statement, source, interoperability
 - Normative strength: MUST; this is a versioned 0.2.0 contract requirement.
 - Interoperability profile and compatibility class: standards baseline; Radicale 3.7.8 where applicable; see [compatibility matrix](compatibility-matrix.md).
 - Primary evidence layer: deterministic WebDAV contract.
-- Named scenario or fixture: `0.2.0/bound/cal-bound-008`.
+- Named scenario or fixture: `0.2.0/bound/cal-bound-008`; committed issue #40 targets: `CalendarOccurrenceToolsTests.QueryAsync_CursorIsNonceRandomTamperEvidentBoundToQueryCredentialsExpiryAndProcessKey` and `QueryAsync_CursorCredentialBindingRejectsSameKeyUnderDifferentCredentials`.
 - Objective oracle: Given cursor/requestState exceeding 2KiB, expired at ten minutes, rotated key, changed arguments/principal/ETag, one-bit tamper, and replay, when consumed, then each invalid handle fails closed; serialized bytes reveal none of normalized args/principal/identity/ETag and valid replay remains nonduplicating through conditional write.
-- Implementation status: planned.
-- Evidence status: planned until its named scenario is green in pull-request and release CI.
+- Implementation status: the occurrence cursor is implemented with authenticated encryption, random nonce, canonical base64url, ten-minute expiry, process-key rotation invalidation, credential and normalized-query binding, continuation tuple binding, and a 2 KiB cap; MRTR requestState and mutation replay remain planned.
+- Evidence status: focused tamper/expiry/restart/credential/query-binding targets pass locally and are included in the CI test run.
 
 ## CAL-ERROR-001
 
@@ -1051,10 +1051,10 @@ Every requirement row contains the normative statement, source, interoperability
 - Normative strength: MUST; this is a versioned 0.2.0 contract requirement.
 - Interoperability profile and compatibility class: standards baseline; Radicale 3.7.8 where applicable; see [compatibility matrix](compatibility-matrix.md).
 - Primary evidence layer: catalog verifier.
-- Named scenario or fixture: `0.2.0/evidence/cal-evidence-002`.
+- Named scenario or fixture: `0.2.0/evidence/cal-evidence-002`; committed issue #40 semantic targets are the `CalendarServiceTests.QueryOccurrencesAsync_*` corpus covering half-open boundaries, Event/To-do temporal partitions, DST/leap, RRULE/RDATE PERIOD/EXDATE, individual and RANGE overrides, moved identity, cancellation, unresolved zones, unevaluable recurrence, exact ordering, and limit partitions.
 - Objective oracle: Given semantic fixture inventory, when manifest is counted, then it contains named cases for discovery, snapshots, strict schemas, patch, temporal, recurrence, structured/inert/opaque content, concurrency, truth, limits, errors and MRTR plus listed pairwise cross-products.
-- Implementation status: planned.
-- Evidence status: planned until its named scenario is green in pull-request and release CI.
+- Implementation status: the occurrence-query equivalence partitions and recurrence-by-temporal, override-precedence, pagination-order, and limit cross-products are implemented; the remaining catalog-wide fixture inventory stays planned for downstream tickets.
+- Evidence status: the committed issue #40 semantic-corpus targets pass locally and are included in the CI test run; this partial slice does not claim completion of the broader inventory.
 
 ## CAL-EVIDENCE-003
 
@@ -1087,10 +1087,10 @@ Every requirement row contains the normative statement, source, interoperability
 - Normative strength: MUST; this is a versioned 0.2.0 contract requirement.
 - Interoperability profile and compatibility class: standards baseline; Radicale 3.7.8 where applicable; see [compatibility matrix](compatibility-matrix.md).
 - Primary evidence layer: catalog verifier.
-- Named scenario or fixture: `0.2.0/evidence/cal-evidence-005`.
-- Objective oracle: Given `RadicaleConformanceFixture` in baseline/strict/New_York variants, when `Pinned_profile_records_the_runtime_and_selected_variant` runs, then TRX records index/platform/runtime/TZ/strict facts and legacy task fixtures are never listed as evidence.
-- Implementation status: runtime-evidence slice implemented and passing; the broader behavioral cases remain planned for downstream tickets.
-- Evidence status: the runtime harness passes locally in all three variants and runs in the CI matrix; downstream behavioral cases are not represented by task fixtures.
+- Named scenario or fixture: `0.2.0/evidence/cal-evidence-005`; committed issue #40 target: `RadicaleConformanceHarnessTests.Pinned_profile_preserves_occurrence_boundary_dst_leap_range_and_typed_failures`, executed by the existing baseline/strict/New_York CI matrix after PUT followed by authoritative GET.
+- Objective oracle: Given `RadicaleConformanceFixture` in baseline/strict/New_York variants, when the runtime and occurrence targets run, then TRX records index/platform/runtime/TZ/strict facts and authoritative post-PUT GET bytes prove half-open boundary behavior, DST, leap recurrence, RANGE precedence with moved original identity, and typed unresolved/unevaluable failures.
+- Implementation status: runtime evidence plus the issue #40 recurrence/time-zone fidelity slice are implemented; the remaining live-server behaviors in this broad row stay planned for downstream tickets.
+- Evidence status: the runtime harness previously passes locally in all three variants and runs in the CI matrix; the new occurrence target is committed to that matrix and awaits CI because this machine's Docker path could not complete fixture startup (Resource Reaper timeout, then fixture HTTP timeout when bypassed).
 
 ## CAL-EVIDENCE-006
 
@@ -1123,10 +1123,10 @@ Every requirement row contains the normative statement, source, interoperability
 - Normative strength: MUST; this is a versioned 0.2.0 contract requirement.
 - Interoperability profile and compatibility class: standards baseline; Radicale 3.7.8 where applicable; see [compatibility matrix](compatibility-matrix.md).
 - Primary evidence layer: catalog verifier.
-- Named scenario or fixture: `0.2.0/evidence/cal-evidence-008`.
+- Named scenario or fixture: `0.2.0/evidence/cal-evidence-008`; committed issue #40 targets: the exact argument, page, text/diagnostics, 2,000/2,001, 5,000/5,001, and 10,000/10,001 boundary theories in `CalendarOccurrenceToolsTests` and `CalendarServiceTests`.
 - Objective oracle: Given each numeric boundary at minus-one/exact/plus-one and immutable expected fixture, when tests execute, then only within-bound cases pass, excess has no partial output, and fixture hash remains unchanged after run.
-- Implementation status: planned.
-- Evidence status: planned until its named scenario is green in pull-request and release CI.
+- Implementation status: the occurrence-query boundary inventory is implemented with immutable inline expectations and zero-partial plus-one outcomes; remaining non-occurrence boundaries stay planned.
+- Evidence status: focused issue #40 exact-boundary targets pass locally and are included in the CI test run; this partial slice does not claim completion of every catalog boundary.
 
 ## CAL-EVIDENCE-009
 

--- a/src/DotnetAgents.CalDav.Core/Abstractions/ICalendarService.cs
+++ b/src/DotnetAgents.CalDav.Core/Abstractions/ICalendarService.cs
@@ -18,6 +18,11 @@ public interface ICalendarService
         CalendarEntityQuery query,
         CancellationToken cancellationToken);
 
+    /// <summary>Queries bounded derived Event and To-do Occurrences.</summary>
+    Task<CalendarOccurrenceQueryResult> QueryOccurrencesAsync(
+        CalendarOccurrenceQuery query,
+        CancellationToken cancellationToken);
+
     /// <summary>Reads one authoritative Calendar Object Resource snapshot.</summary>
     Task<CalendarResourceRead> GetResourceAsync(string href, CancellationToken cancellationToken);
 }

--- a/src/DotnetAgents.CalDav.Core/DependencyInjection/CalDavServiceCollectionExtensions.cs
+++ b/src/DotnetAgents.CalDav.Core/DependencyInjection/CalDavServiceCollectionExtensions.cs
@@ -48,7 +48,8 @@ public static class CalDavServiceCollectionExtensions
         // SocketsHttpHandler is used instead of HttpClientHandler for:
         // - PooledConnectionLifetime: proactively recycle stale connections before the server
         //   can drop them (prevents "response ended prematurely" / ResponseEnded errors)
-        // - PooledConnectionIdleTimeout: close idle connections that Radicale may have already closed
+        // - PooledConnectionIdleTimeout: recycle idle connections before the pinned Radicale
+        //   profile's 30-second server timeout can close them
         //
         // Auto-redirect is disabled because CalDAV uses non-standard HTTP methods (PROPFIND, REPORT,
         // MKCOL) that must be preserved across redirects. Disable automatic redirects explicitly
@@ -74,7 +75,7 @@ public static class CalDavServiceCollectionExtensions
             AllowAutoRedirect = false,
             AutomaticDecompression = DecompressionMethods.All,
             PooledConnectionLifetime = TimeSpan.FromMinutes(2),
-            PooledConnectionIdleTimeout = TimeSpan.FromMinutes(1)
+            PooledConnectionIdleTimeout = TimeSpan.FromSeconds(20)
         })
         .AddStandardResilienceHandler(options =>
         {

--- a/src/DotnetAgents.CalDav.Core/Internal/Ical/CalendarContentDocument.cs
+++ b/src/DotnetAgents.CalDav.Core/Internal/Ical/CalendarContentDocument.cs
@@ -113,11 +113,24 @@ internal sealed partial class CalendarContentDocument
     [GeneratedRegex("^[+-](?:[01][0-9]|2[0-3])[0-5][0-9](?:[0-5][0-9]|60)?$", RegexOptions.CultureInvariant)]
     private static partial Regex UtcOffsetPattern();
 
-    public byte[] ReplayForTypedValidation()
+    public byte[] ReplayForTypedValidation() => ReplayForTypedValidation(static _ => false);
+
+    public byte[] ReplayForProjectionValidation() => ReplayForTypedValidation(IsEntityPeriodRecurrenceDate);
+
+    public byte[] ReplayForOccurrenceEvaluation() => ReplayForTypedValidation(IsEntityPeriodRecurrenceDate);
+
+    private static bool IsEntityPeriodRecurrenceDate(CalendarContentProperty property) =>
+        property.Name.Equals("RDATE", StringComparison.OrdinalIgnoreCase)
+        && property.ValueType == CalendarPropertyValueType.Period
+        && property.ComponentPath.Count == 2
+        && property.ComponentPath[1].Name is "VEVENT" or "VTODO";
+
+    private byte[] ReplayForTypedValidation(Func<CalendarContentProperty, bool> removeAdditionalProperty)
     {
         var componentRemovals = Components.Where(component => !IsTypedValidationComponent(component.Path[^1].Name))
             .Select(component => new ContentRange(component.Start, component.Length));
-        var propertyRemovals = Properties.Where(property => !IsTypedValidationProperty(property))
+        var propertyRemovals = Properties.Where(property => !IsTypedValidationProperty(property)
+                || removeAdditionalProperty(property))
             .Select(property => new ContentRange(property.Start, property.Length));
         var removals = componentRemovals.Concat(propertyRemovals)
             .OrderBy(range => range.Start)

--- a/src/DotnetAgents.CalDav.Core/Internal/Ical/CalendarDurationArithmetic.cs
+++ b/src/DotnetAgents.CalDav.Core/Internal/Ical/CalendarDurationArithmetic.cs
@@ -1,0 +1,274 @@
+using System.Globalization;
+using DotnetAgents.CalDav.Core.Models;
+using Ical.Net.DataTypes;
+
+namespace DotnetAgents.CalDav.Core.Internal.Ical;
+
+/// <summary>Applies RFC 5545 nominal day/week duration parts before accurate time parts.</summary>
+internal static class CalendarDurationArithmetic
+{
+    public static CalendarDurationResolution Resolve(
+        CalendarTemporalValue start,
+        DateTimeOffset resolvedStart,
+        string rawDuration,
+        CalendarTemporalResolver resolver)
+    {
+        try
+        {
+            return ResolveCore(start, resolvedStart, rawDuration, resolver);
+        }
+        catch (Exception exception) when (exception is ArgumentOutOfRangeException or OverflowException)
+        {
+            return CalendarDurationResolution.Invalid;
+        }
+    }
+
+    private static CalendarDurationResolution ResolveCore(
+        CalendarTemporalValue start,
+        DateTimeOffset resolvedStart,
+        string rawDuration,
+        CalendarTemporalResolver resolver)
+    {
+        if (!TryParse(rawDuration, out var duration) || !duration.IsStrictlyPositive)
+            return CalendarDurationResolution.Invalid;
+        var nominalEnd = AddLocalDays(start, duration.NominalDays);
+        var resolvedNominalEnd = duration.NominalDays == 0
+            ? new ResolvedCalendarInstant(resolvedStart, false)
+            : resolver.Resolve(ToCalDateTime(nominalEnd));
+        if (resolvedNominalEnd.Value is null)
+            return new(null, resolvedNominalEnd);
+        if (duration.Accurate == TimeSpan.Zero)
+            return new(nominalEnd, resolvedNominalEnd);
+
+        var instant = resolvedNominalEnd.Value.Value + duration.Accurate;
+        var projected = resolver.Project(instant, nominalEnd);
+        return projected is null
+            ? new(null, new ResolvedCalendarInstant(null, true))
+            : new(projected, new ResolvedCalendarInstant(instant, false));
+    }
+
+    public static CalendarDurationResolution ResolveAccurate(
+        CalendarTemporalValue start,
+        DateTimeOffset resolvedStart,
+        TimeSpan duration,
+        CalendarTemporalResolver resolver)
+    {
+        try
+        {
+            return ResolveAccurateCore(start, resolvedStart, duration, resolver);
+        }
+        catch (Exception exception) when (exception is ArgumentOutOfRangeException or OverflowException)
+        {
+            return CalendarDurationResolution.Invalid;
+        }
+    }
+
+    private static CalendarDurationResolution ResolveAccurateCore(
+        CalendarTemporalValue start,
+        DateTimeOffset resolvedStart,
+        TimeSpan duration,
+        CalendarTemporalResolver resolver)
+    {
+        if (duration <= TimeSpan.Zero)
+            return CalendarDurationResolution.Invalid;
+        var instant = resolvedStart + duration;
+        var projected = resolver.Project(instant, start);
+        return projected is null
+            ? new(null, new ResolvedCalendarInstant(null, true))
+            : new(projected, new ResolvedCalendarInstant(instant, false));
+    }
+
+    internal static bool TryParse(string raw, out CalendarDurationParts duration)
+    {
+        duration = default;
+        try
+        {
+            var index = 0;
+            var sign = ReadSign(raw, ref index);
+            if (index >= raw.Length || raw[index++] != 'P' || index >= raw.Length)
+                return false;
+            var parsed = raw[index] == 'T'
+                ? TryParseTime(raw, index + 1, sign, 0, out duration)
+                : TryParseDate(raw, index, sign, out duration);
+            if (parsed)
+                _ = duration.LocalClockDuration;
+            return parsed;
+        }
+        catch (Exception exception) when (exception is FormatException
+            or ArgumentOutOfRangeException
+            or OverflowException)
+        {
+            return false;
+        }
+    }
+
+    internal static bool LooksLikeDuration(string raw) => raw.StartsWith('P')
+        || raw.StartsWith("+P", StringComparison.Ordinal)
+        || raw.StartsWith("-P", StringComparison.Ordinal);
+
+    private static bool TryParseDate(
+        string raw,
+        int index,
+        int sign,
+        out CalendarDurationParts duration)
+    {
+        duration = default;
+        if (!TryReadNumber(raw, ref index, out var amount) || index >= raw.Length)
+            return false;
+        if (raw[index] == 'W')
+            return index + 1 == raw.Length
+                && TryCreate(sign, amount, 7, TimeSpan.Zero, out duration);
+        if (raw[index++] != 'D' || !TryCreate(sign, amount, 1, TimeSpan.Zero, out duration))
+            return false;
+        return index == raw.Length
+            || raw[index] == 'T' && TryParseTime(raw, index + 1, sign, duration.NominalDays, out duration);
+    }
+
+    private static int ReadSign(string raw, ref int index)
+    {
+        if (raw.Length == 0 || raw[0] is not ('+' or '-'))
+            return 1;
+        index = 1;
+        return raw[0] == '-' ? -1 : 1;
+    }
+
+    private static bool TryParseTime(
+        string raw,
+        int index,
+        int sign,
+        int nominalDays,
+        out CalendarDurationParts duration)
+    {
+        duration = default;
+        if (!TryReadNumber(raw, ref index, out var first) || index >= raw.Length)
+            return false;
+        var designator = raw[index++];
+        return designator switch
+        {
+            'H' => TryParseAfterHours(raw, index, sign, nominalDays, first, out duration),
+            'M' => TryParseAfterMinutes(raw, index, sign, nominalDays, first, out duration),
+            'S' => index == raw.Length
+                && TryCreateAccurate(sign, nominalDays, 0, 0, first, out duration),
+            _ => false
+        };
+    }
+
+    private static bool TryParseAfterHours(
+        string raw,
+        int index,
+        int sign,
+        int nominalDays,
+        long hours,
+        out CalendarDurationParts duration)
+    {
+        duration = default;
+        long minutes = 0;
+        long seconds = 0;
+        return (index == raw.Length || TryReadComponent(raw, ref index, 'M', out minutes))
+            && (index == raw.Length || TryReadComponent(raw, ref index, 'S', out seconds))
+            && index == raw.Length
+            && TryCreateAccurate(sign, nominalDays, hours, minutes, seconds, out duration);
+    }
+
+    private static bool TryParseAfterMinutes(
+        string raw,
+        int index,
+        int sign,
+        int nominalDays,
+        long minutes,
+        out CalendarDurationParts duration)
+    {
+        duration = default;
+        long seconds = 0;
+        return (index == raw.Length || TryReadComponent(raw, ref index, 'S', out seconds))
+            && index == raw.Length
+            && TryCreateAccurate(sign, nominalDays, 0, minutes, seconds, out duration);
+    }
+
+    private static bool TryReadComponent(string raw, ref int index, char designator, out long value)
+    {
+        value = 0;
+        return TryReadNumber(raw, ref index, out value)
+            && index < raw.Length
+            && raw[index++] == designator;
+    }
+
+    private static bool TryReadNumber(string raw, ref int index, out long value)
+    {
+        value = 0;
+        var start = index;
+        while (index < raw.Length && raw[index] is >= '0' and <= '9')
+            index++;
+        return index > start
+            && long.TryParse(raw.AsSpan(start, index - start), NumberStyles.None, CultureInfo.InvariantCulture, out value);
+    }
+
+    private static bool TryCreate(
+        int sign,
+        long amount,
+        int multiplier,
+        TimeSpan accurate,
+        out CalendarDurationParts duration)
+    {
+        var nominalDays = checked((int)checked(sign * amount * multiplier));
+        duration = new CalendarDurationParts(nominalDays, accurate);
+        return true;
+    }
+
+    private static bool TryCreateAccurate(
+        int sign,
+        int nominalDays,
+        long hours,
+        long minutes,
+        long seconds,
+        out CalendarDurationParts duration)
+    {
+        var ticks = checked(hours * TimeSpan.TicksPerHour
+            + minutes * TimeSpan.TicksPerMinute
+            + seconds * TimeSpan.TicksPerSecond);
+        duration = new CalendarDurationParts(nominalDays, TimeSpan.FromTicks(checked(sign * ticks)));
+        return true;
+    }
+
+    private static CalendarTemporalValue AddLocalDays(CalendarTemporalValue value, int days)
+    {
+        var format = value.Kind == CalendarTemporalKind.Date ? "yyyy-MM-dd" : "yyyy-MM-dd'T'HH:mm:ss";
+        var parsed = DateTime.ParseExact(value.Value.TrimEnd('Z'), format, CultureInfo.InvariantCulture).AddDays(days);
+        var suffix = value.Kind == CalendarTemporalKind.UtcDateTime ? "Z" : string.Empty;
+        return value with { Value = parsed.ToString(format, CultureInfo.InvariantCulture) + suffix };
+    }
+
+    private static CalDateTime ToCalDateTime(CalendarTemporalValue value)
+    {
+        if (value.Kind == CalendarTemporalKind.Date)
+        {
+            var date = DateTime.ParseExact(value.Value, "yyyy-MM-dd", CultureInfo.InvariantCulture);
+            return new CalDateTime(date.Year, date.Month, date.Day);
+        }
+        var local = DateTime.ParseExact(
+            value.Value.TrimEnd('Z'),
+            "yyyy-MM-dd'T'HH:mm:ss",
+            CultureInfo.InvariantCulture);
+        return value.Kind switch
+        {
+            CalendarTemporalKind.UtcDateTime => new CalDateTime(DateTime.SpecifyKind(local, DateTimeKind.Utc)),
+            CalendarTemporalKind.ZonedDateTime => new CalDateTime(local, value.TimeZoneId),
+            _ => new CalDateTime(local)
+        };
+    }
+
+}
+
+internal readonly record struct CalendarDurationParts(int NominalDays, TimeSpan Accurate)
+{
+    public TimeSpan LocalClockDuration => TimeSpan.FromDays(NominalDays) + Accurate;
+
+    public bool IsStrictlyPositive => NominalDays > 0 || NominalDays == 0 && Accurate > TimeSpan.Zero;
+}
+
+internal readonly record struct CalendarDurationResolution(
+    CalendarTemporalValue? Value,
+    ResolvedCalendarInstant Instant)
+{
+    public static CalendarDurationResolution Invalid { get; } = new(null, new ResolvedCalendarInstant(null, false));
+}

--- a/src/DotnetAgents.CalDav.Core/Internal/Ical/CalendarOccurrenceEvaluator.cs
+++ b/src/DotnetAgents.CalDav.Core/Internal/Ical/CalendarOccurrenceEvaluator.cs
@@ -1,0 +1,1355 @@
+using System.Globalization;
+using System.Text;
+using DotnetAgents.CalDav.Core.Models;
+using Ical.Net;
+using Ical.Net.CalendarComponents;
+using Ical.Net.DataTypes;
+using Ical.Net.Evaluation;
+using CalendarProperty = DotnetAgents.CalDav.Core.Models.CalendarProperty;
+using IcalCalendar = Ical.Net.Calendar;
+
+namespace DotnetAgents.CalDav.Core.Internal.Ical;
+
+internal sealed record CalendarOccurrenceEvaluation(
+    CalendarOccurrenceQueryCode Code,
+    IReadOnlyList<CalendarOccurrenceSnapshot> Items,
+    int ObservedOccurrenceCount,
+    IReadOnlySet<string>? ObservedIdentities = null);
+
+/// <summary>Expands one authoritative resource without using a server-expanded representation.</summary>
+internal static class CalendarOccurrenceEvaluator
+{
+    private const int MaximumEntityOccurrences = 2000;
+    private const int MaximumUnmatchedIncrements = 10_000;
+
+    public static CalendarOccurrenceEvaluation Evaluate(
+        CalendarResourceSnapshot snapshot,
+        CalendarOccurrenceQuery query,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var properties = GetEntityProperties(snapshot);
+            var masterProperties = properties.Where(property => property.ComponentPath[1].Occurrence == 0).ToArray();
+            if (HasUnevaluableRecurrenceShape(snapshot, properties, masterProperties))
+                return Failure(CalendarOccurrenceQueryCode.RecurrenceUnevaluable);
+
+            var resolver = new CalendarTemporalResolver(
+                snapshot.CalendarProperties,
+                snapshot.AuthoritativeUtf8.Span,
+                cancellationToken,
+                query.EvaluationTimeZone);
+            var periodValidation = ValidatePeriodStructure(properties, resolver);
+            if (periodValidation is not null)
+                return Failure(periodValidation.Value);
+            if (masterProperties.Where(RequiresEagerResolution).Any(property => !resolver.CanResolve(property)))
+                return Failure(CalendarOccurrenceQueryCode.TemporalUnresolved);
+            var overrides = CreateOverrides(properties, snapshot.Projection.Kind);
+
+            var replay = CalendarContentDocument.Parse(snapshot.AuthoritativeUtf8.Span).ReplayForOccurrenceEvaluation();
+            var calendar = IcalCalendar.Load(Encoding.UTF8.GetString(replay));
+            if (calendar is null)
+                return Failure(CalendarOccurrenceQueryCode.RecurrenceUnevaluable);
+            var evaluated = snapshot.Projection.Kind == CalendarResourceProjectionKind.Event
+                ? EvaluateEvent(
+                    snapshot,
+                    query,
+                    resolver,
+                    calendar.Events.Single(item => item.RecurrenceIdentifier is null),
+                    properties,
+                    overrides,
+                    cancellationToken)
+                : EvaluateTodo(
+                    snapshot,
+                    query,
+                    resolver,
+                    calendar.Todos.Single(item => item.RecurrenceIdentifier is null),
+                    properties,
+                    overrides,
+                    cancellationToken);
+            if (evaluated.Code != CalendarOccurrenceQueryCode.Success)
+                return evaluated;
+            var periodDates = EvaluatePeriodDates(snapshot, query, resolver, properties, overrides, cancellationToken);
+            if (periodDates.Code != CalendarOccurrenceQueryCode.Success)
+                return periodDates;
+            var detached = EvaluateDetachedOverrides(
+                snapshot, query, resolver, properties, overrides, cancellationToken);
+            if (detached.Code != CalendarOccurrenceQueryCode.Success)
+                return detached;
+            var merged = MergeOccurrences(evaluated, periodDates);
+            return merged.Code == CalendarOccurrenceQueryCode.Success
+                ? MergeOccurrences(merged, detached, replaceExisting: false)
+                : merged;
+        }
+        catch (EvaluationLimitExceededException)
+        {
+            return Failure(CalendarOccurrenceQueryCode.LimitExhausted);
+        }
+        catch (Exception exception) when (exception is EvaluationOutOfRangeException
+            or FormatException
+            or ArgumentException
+            or OverflowException
+            or InvalidOperationException)
+        {
+            return Failure(CalendarOccurrenceQueryCode.RecurrenceUnevaluable);
+        }
+    }
+
+    public static string GetIdentitySortKey(CalendarTemporalValue value) =>
+        value.GetCanonicalSortKey();
+
+    public static bool HasInvalidComponentStructure(CalendarResourceSnapshot snapshot) =>
+        snapshot.CalendarProperties.Any(IsInvalidObservanceRecurrenceDate)
+        || snapshot.CalendarProperties
+            .Where(property => property.ComponentPath.Count == 2
+                && property.ComponentPath[1].Name is "VEVENT" or "VTODO")
+            .GroupBy(property => (
+                property.ComponentPath[1].Name,
+                property.ComponentPath[1].Occurrence))
+            .Any(HasInvalidComponentDuration);
+
+    private static bool IsInvalidObservanceRecurrenceDate(CalendarProperty property) =>
+        property.Name.Equals("RDATE", StringComparison.OrdinalIgnoreCase)
+        && property.ValueType == CalendarPropertyValueType.Period
+        && property.ComponentPath.Count == 3
+        && property.ComponentPath[2].Name is "STANDARD" or "DAYLIGHT";
+
+    private static bool HasInvalidComponentDuration(IEnumerable<CalendarProperty> component)
+    {
+        var properties = component.ToArray();
+        var durationProperty = GetProperty(properties, "DURATION");
+        if (durationProperty is null)
+            return false;
+        var startProperty = GetProperty(properties, "DTSTART");
+        var endPropertyName = properties[0].ComponentPath[1].Name == "VEVENT" ? "DTEND" : "DUE";
+        return startProperty is null
+            || GetProperty(properties, endPropertyName) is not null
+            || !CalendarDurationArithmetic.TryParse(durationProperty.RawEncodedValue, out var duration)
+            || !duration.IsStrictlyPositive
+            || startProperty.ValueType == CalendarPropertyValueType.Date
+                && durationProperty.RawEncodedValue.Contains('T', StringComparison.Ordinal);
+    }
+
+    private static bool HasUnevaluableRecurrenceShape(
+        CalendarResourceSnapshot snapshot,
+        IReadOnlyList<CalendarProperty> properties,
+        IReadOnlyList<CalendarProperty> masterProperties) =>
+        HasInvalidComponentStructure(snapshot)
+        || properties.Count(property => property.Name.Equals("RRULE", StringComparison.OrdinalIgnoreCase)) > 1
+        || properties.Any(HasUnsupportedRange)
+        || snapshot.Projection.Kind == CalendarResourceProjectionKind.Todo
+            && GetProperty(masterProperties, "RRULE") is not null
+            && GetProperty(masterProperties, "DTSTART") is null;
+
+    private static CalendarOccurrenceQueryCode? ValidatePeriodStructure(
+        IEnumerable<CalendarProperty> properties,
+        CalendarTemporalResolver resolver)
+    {
+        foreach (var property in properties.Where(property =>
+                     property.Name.Equals("RDATE", StringComparison.OrdinalIgnoreCase)
+                     && property.ValueType == CalendarPropertyValueType.Period))
+        {
+            foreach (var period in property.RawEncodedValue.Split(',', StringSplitOptions.None))
+            {
+                var code = ValidatePeriod(property, period, resolver);
+                if (code is not null)
+                    return code;
+            }
+        }
+        return null;
+    }
+
+    private static CalendarOccurrenceQueryCode? ValidatePeriod(
+        CalendarProperty property,
+        string period,
+        CalendarTemporalResolver resolver)
+    {
+        var parts = period.Split('/', StringSplitOptions.None);
+        if (parts.Length != 2 || !IsPeriodDateTime(parts[0]))
+            return CalendarOccurrenceQueryCode.RecurrenceUnevaluable;
+        return CalendarDurationArithmetic.LooksLikeDuration(parts[1])
+            ? ValidatePeriodDuration(property, parts, resolver)
+            : ValidateExplicitPeriod(property, parts, resolver);
+    }
+
+    private static CalendarOccurrenceQueryCode? ValidatePeriodDuration(
+        CalendarProperty property,
+        IReadOnlyList<string> parts,
+        CalendarTemporalResolver resolver)
+    {
+        if (!CalendarDurationArithmetic.TryParse(parts[1], out var duration) || !duration.IsStrictlyPositive)
+            return CalendarOccurrenceQueryCode.RecurrenceUnevaluable;
+        var start = resolver.ResolveToken(property, parts[0]);
+        if (start.Value is null)
+            return ToFailure(start);
+        return null;
+    }
+
+    private static CalendarOccurrenceQueryCode? ValidateExplicitPeriod(
+        CalendarProperty property,
+        IReadOnlyList<string> parts,
+        CalendarTemporalResolver resolver)
+    {
+        if (!IsPeriodDateTime(parts[1]))
+            return CalendarOccurrenceQueryCode.RecurrenceUnevaluable;
+        var start = resolver.ResolveToken(property, parts[0]);
+        if (start.Value is null)
+            return ToFailure(start);
+        var end = resolver.ResolveToken(property, parts[1]);
+        if (end.Value is null)
+            return ToFailure(end);
+        return end.Value <= start.Value ? CalendarOccurrenceQueryCode.RecurrenceUnevaluable : null;
+    }
+
+    private static bool IsPeriodDateTime(string raw) => raw.EndsWith('Z')
+        ? DateTimeOffset.TryParseExact(
+            raw,
+            "yyyyMMdd'T'HHmmss'Z'",
+            CultureInfo.InvariantCulture,
+            DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
+            out _)
+        : DateTime.TryParseExact(
+            raw,
+            "yyyyMMdd'T'HHmmss",
+            CultureInfo.InvariantCulture,
+            DateTimeStyles.None,
+            out _);
+
+    private static CalendarOccurrenceEvaluation MergeOccurrences(
+        CalendarOccurrenceEvaluation generated,
+        CalendarOccurrenceEvaluation periodDates,
+        bool replaceExisting = true)
+    {
+        var identities = generated.ObservedIdentities is null
+            ? new HashSet<string>(StringComparer.Ordinal)
+            : new HashSet<string>(generated.ObservedIdentities, StringComparer.Ordinal);
+        if (periodDates.ObservedIdentities is not null)
+            identities.UnionWith(periodDates.ObservedIdentities);
+        if (identities.Count > MaximumEntityOccurrences)
+            return Failure(CalendarOccurrenceQueryCode.LimitExhausted, identities.Count);
+        var items = generated.Items.ToDictionary(
+            item => GetIdentitySortKey(item.RecurrenceIdentity),
+            StringComparer.Ordinal);
+        foreach (var item in periodDates.Items)
+        {
+            var key = GetIdentitySortKey(item.RecurrenceIdentity);
+            if (replaceExisting || !items.ContainsKey(key))
+                items[key] = item;
+        }
+        return new CalendarOccurrenceEvaluation(
+            CalendarOccurrenceQueryCode.Success,
+            items.Values.ToArray(),
+            identities.Count,
+            identities);
+    }
+
+    private static CalendarOccurrenceEvaluation EvaluatePeriodDates(
+        CalendarResourceSnapshot snapshot,
+        CalendarOccurrenceQuery query,
+        CalendarTemporalResolver resolver,
+        IReadOnlyList<CalendarProperty> properties,
+        OverridePlan overrides,
+        CancellationToken cancellationToken)
+    {
+        var items = new Dictionary<string, CalendarOccurrenceSnapshot>(StringComparer.Ordinal);
+        var identities = new HashSet<string>(StringComparer.Ordinal);
+        var excluded = GetExcludedIdentities(properties);
+        foreach (var property in properties.Where(property => property.ComponentPath[1].Occurrence == 0
+                     && property.Name.Equals("RDATE", StringComparison.OrdinalIgnoreCase)
+                     && property.ValueType == CalendarPropertyValueType.Period))
+        {
+            foreach (var period in property.RawEncodedValue.Split(',', StringSplitOptions.None))
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var identity = GetPeriodIdentity(property, period);
+                if (identity is not null && identities.Add(identity) && identities.Count > MaximumEntityOccurrences)
+                    return Failure(CalendarOccurrenceQueryCode.LimitExhausted, identities.Count);
+                var evaluated = EvaluatePeriodDate(snapshot, query, resolver, property, period, excluded, overrides);
+                if (evaluated.Code is { } code)
+                    return Failure(code, identities.Count);
+                if (evaluated.Item is not null)
+                    items[GetIdentitySortKey(evaluated.Item.RecurrenceIdentity)] = evaluated.Item;
+            }
+        }
+        return new CalendarOccurrenceEvaluation(
+            CalendarOccurrenceQueryCode.Success, items.Values.ToArray(), identities.Count, identities);
+    }
+
+    private static string? GetPeriodIdentity(CalendarProperty property, string period)
+    {
+        var separator = period.IndexOf('/');
+        return separator < 0
+            ? null
+            : GetIdentitySortKey(ToTemporalValue(property, period[..separator]));
+    }
+
+    private static CalendarOccurrenceEvaluation EvaluateDetachedOverrides(
+        CalendarResourceSnapshot snapshot,
+        CalendarOccurrenceQuery query,
+        CalendarTemporalResolver resolver,
+        IReadOnlyList<CalendarProperty> properties,
+        OverridePlan overrides,
+        CancellationToken cancellationToken)
+    {
+        if (overrides.All.Count == 0)
+            return new CalendarOccurrenceEvaluation(CalendarOccurrenceQueryCode.Success, [], 0, new HashSet<string>());
+        var items = new Dictionary<string, CalendarOccurrenceSnapshot>(StringComparer.Ordinal);
+        var identities = new HashSet<string>(StringComparer.Ordinal);
+        var excluded = GetExcludedIdentities(properties);
+        var master = properties.Where(property => property.ComponentPath[1].Occurrence == 0).ToArray();
+        var sourceDuration = GetMasterDurationValue(properties);
+        var sourceExactDuration = GetMasterExactDuration(master, resolver);
+        var nominalDuration = GetNominalMasterDuration(master);
+        foreach (var definition in overrides.All)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var sourceStart = ToTemporalValue(definition.Identity);
+            var identityKey = GetIdentitySortKey(sourceStart);
+            if (ExceedsEntityLimit(identities, identityKey))
+                return Failure(CalendarOccurrenceQueryCode.LimitExhausted, identities.Count);
+            if (excluded.Contains(identityKey) || definition.Cancelled)
+                continue;
+            var sourceEnd = ResolveDetachedSourceEnd(
+                sourceStart, sourceDuration, sourceExactDuration, nominalDuration, resolver);
+            if (CannotUseDetachedSourceEnd(sourceEnd, sourceDuration, sourceExactDuration))
+                return Failure(ToFailure(sourceEnd.Instant), identities.Count);
+            var evaluated = definition.IsRange
+                ? EvaluateRangeOverride(
+                    snapshot, query, resolver, definition, sourceStart, sourceEnd.Value, sourceDuration)
+                : EvaluateOverride(
+                    snapshot, query, resolver, definition, sourceStart, sourceEnd.Value, sourceDuration);
+            if (evaluated.Code is { } code)
+                return Failure(code, identities.Count);
+            if (evaluated.Item is not null)
+                items[identityKey] = evaluated.Item;
+        }
+        return new CalendarOccurrenceEvaluation(
+            CalendarOccurrenceQueryCode.Success, items.Values.ToArray(), identities.Count, identities);
+    }
+
+    private static CalendarDurationResolution ResolveDetachedSourceEnd(
+        CalendarTemporalValue sourceStart,
+        string? sourceDuration,
+        TimeSpan? sourceExactDuration,
+        TimeSpan nominalDuration,
+        CalendarTemporalResolver resolver)
+    {
+        if (sourceExactDuration is not null)
+        {
+            if (sourceStart.Kind == CalendarTemporalKind.Date)
+            {
+                var value = AddTemporalOffset(sourceStart, nominalDuration);
+                return new(value, resolver.Resolve(ToCalDateTime(value)));
+            }
+            return ResolveAccurateDuration(sourceStart, sourceExactDuration.Value, resolver);
+        }
+        if (sourceDuration is null)
+        {
+            var value = nominalDuration == TimeSpan.Zero
+                ? null
+                : AddTemporalOffset(sourceStart, nominalDuration);
+            return new(value, new ResolvedCalendarInstant(null, false));
+        }
+        var start = resolver.Resolve(ToCalDateTime(sourceStart));
+        return start.Value is null
+            ? new CalendarDurationResolution(null, start)
+            : CalendarDurationArithmetic.Resolve(sourceStart, start.Value.Value, sourceDuration, resolver);
+    }
+
+    private static CalendarDurationResolution ResolveAccurateDuration(
+        CalendarTemporalValue start,
+        TimeSpan duration,
+        CalendarTemporalResolver resolver)
+    {
+        var resolvedStart = resolver.Resolve(ToCalDateTime(start));
+        return resolvedStart.Value is null
+            ? new CalendarDurationResolution(null, resolvedStart)
+            : CalendarDurationArithmetic.ResolveAccurate(start, resolvedStart.Value.Value, duration, resolver);
+    }
+
+    private static bool CannotUseDetachedSourceEnd(
+        CalendarDurationResolution sourceEnd,
+        string? sourceDuration,
+        TimeSpan? sourceExactDuration) => sourceEnd.Instant.Unresolved
+        || sourceEnd.Instant.Value is null && (sourceDuration is not null || sourceExactDuration is not null);
+
+    private static bool ExceedsEntityLimit(ISet<string> identities, string identity)
+    {
+        identities.Add(identity);
+        return identities.Count > MaximumEntityOccurrences;
+    }
+
+    private static PeriodEvaluation EvaluatePeriodDate(
+        CalendarResourceSnapshot snapshot,
+        CalendarOccurrenceQuery query,
+        CalendarTemporalResolver resolver,
+        CalendarProperty property,
+        string period,
+        IReadOnlySet<string> excluded,
+        OverridePlan overrides)
+    {
+        var parts = period.Split('/', StringSplitOptions.None);
+        if (parts.Length != 2)
+            return PeriodEvaluation.Failure(CalendarOccurrenceQueryCode.RecurrenceUnevaluable);
+        var start = resolver.ResolveToken(property, parts[0]);
+        if (start.Value is null)
+            return PeriodEvaluation.Failure(ToFailure(start));
+        var sourceStart = ToTemporalValue(property, parts[0]);
+        var resolvedEnd = ResolvePeriodEnd(property, parts[1], sourceStart, start.Value.Value, resolver);
+        if (resolvedEnd.Instant.Value is null)
+            return PeriodEvaluation.Failure(ToFailure(resolvedEnd.Instant));
+        if (excluded.Contains(GetIdentitySortKey(sourceStart)))
+            return PeriodEvaluation.NoMatch;
+        var sourceDuration = CalendarDurationArithmetic.LooksLikeDuration(parts[1]) ? parts[1] : null;
+        var identityKey = GetIdentitySortKey(sourceStart);
+        var overridden = EvaluateAppliedOverride(
+            snapshot, query, resolver, overrides, identityKey, sourceStart, resolvedEnd.Value, sourceDuration);
+        if (overridden is not null)
+            return overridden;
+        if (!Overlaps(start.Value.Value, resolvedEnd.Instant.Value.Value, query.From, query.To))
+            return PeriodEvaluation.NoMatch;
+        return PeriodEvaluation.Match(new CalendarOccurrenceSnapshot(
+            snapshot,
+            sourceStart,
+            new CalendarOccurrenceTiming(
+                sourceStart,
+                sourceStart,
+                resolvedEnd.Value,
+                resolvedEnd.Value,
+                SourceDuration: sourceDuration,
+                EffectiveDuration: sourceDuration,
+                EvaluatedStartUtc: ToUtcValue(start.Value.Value),
+                EvaluatedEndUtc: ToUtcValue(resolvedEnd.Instant.Value.Value),
+                EvaluationTimeZone: query.EvaluationTimeZone)));
+    }
+
+    private static CalendarDurationResolution ResolvePeriodEnd(
+        CalendarProperty property,
+        string rawEnd,
+        CalendarTemporalValue sourceStart,
+        DateTimeOffset start,
+        CalendarTemporalResolver resolver)
+    {
+        if (CalendarDurationArithmetic.LooksLikeDuration(rawEnd))
+            return CalendarDurationArithmetic.Resolve(sourceStart, start, rawEnd, resolver);
+        return new(ToTemporalValue(property, rawEnd), resolver.ResolveToken(property, rawEnd));
+    }
+
+    private static IReadOnlySet<string> GetExcludedIdentities(IReadOnlyList<CalendarProperty> properties) => properties
+        .Where(property => property.ComponentPath[1].Occurrence == 0
+            && property.Name.Equals("EXDATE", StringComparison.OrdinalIgnoreCase))
+        .SelectMany(property => property.RawEncodedValue.Split(',', StringSplitOptions.None)
+            .Select(value => GetIdentitySortKey(ToTemporalValue(property, value))))
+        .ToHashSet(StringComparer.Ordinal);
+
+    private static CalendarOccurrenceEvaluation EvaluateEvent(
+        CalendarResourceSnapshot snapshot,
+        CalendarOccurrenceQuery query,
+        CalendarTemporalResolver resolver,
+        CalendarEvent master,
+        IReadOnlyList<CalendarProperty> properties,
+        OverridePlan overrides,
+        CancellationToken cancellationToken) => IsRecurring(properties)
+            ? EvaluatePeriods(
+                snapshot,
+                query,
+                resolver,
+                GetRecurringOccurrences(master, properties, resolver, query),
+                overrides,
+                GetEvaluationBounds(properties, resolver, query).StopAt,
+                false,
+                GetMasterDurationValue(properties),
+                GetMasterExactDuration(properties, resolver),
+                cancellationToken)
+            : EvaluateNonRecurringEvent(snapshot, query, resolver, properties);
+
+    private static CalendarOccurrenceEvaluation EvaluateNonRecurringEvent(
+        CalendarResourceSnapshot snapshot,
+        CalendarOccurrenceQuery query,
+        CalendarTemporalResolver resolver,
+        IReadOnlyList<CalendarProperty> properties)
+    {
+        var master = properties.Where(property => property.ComponentPath[1].Occurrence == 0).ToArray();
+        var startProperty = GetProperty(master, "DTSTART")!;
+        var start = resolver.Resolve(startProperty);
+        if (start.Value is null)
+            return Failure(ToFailure(start));
+        var sourceStart = ToTemporalValue(startProperty);
+        var endProperty = GetProperty(master, "DTEND");
+        var durationProperty = GetProperty(master, "DURATION");
+        var sourceEnd = ResolveNonRecurringEventEnd(
+            startProperty, endProperty, durationProperty, resolver, start.Value.Value);
+        if (sourceEnd.Instant is null)
+            return Failure(sourceEnd.Code);
+        if (!Overlaps(start.Value.Value, sourceEnd.Instant.Value, query.From, query.To))
+            return new CalendarOccurrenceEvaluation(
+                CalendarOccurrenceQueryCode.Success, [], 1, new HashSet<string> { GetIdentitySortKey(sourceStart) });
+        var endValue = sourceEnd.Value;
+        return new CalendarOccurrenceEvaluation(
+            CalendarOccurrenceQueryCode.Success,
+            [new CalendarOccurrenceSnapshot(
+                snapshot,
+                sourceStart,
+                new CalendarOccurrenceTiming(
+                    sourceStart,
+                    sourceStart,
+                    endValue,
+                    endValue,
+                    SourceDuration: durationProperty?.RawEncodedValue,
+                    EffectiveDuration: durationProperty?.RawEncodedValue,
+                    EvaluatedStartUtc: ToUtcValue(start.Value.Value),
+                    EvaluatedEndUtc: ToUtcValue(sourceEnd.Instant.Value),
+                    EvaluationTimeZone: query.EvaluationTimeZone))],
+            1,
+            new HashSet<string> { GetIdentitySortKey(sourceStart) });
+    }
+
+    private static OverrideEndResolution ResolveNonRecurringEventEnd(
+        CalendarProperty startProperty,
+        CalendarProperty? endProperty,
+        CalendarProperty? durationProperty,
+        CalendarTemporalResolver resolver,
+        DateTimeOffset start)
+    {
+        if (endProperty is not null)
+        {
+            var end = resolver.Resolve(endProperty);
+            return end.Value is null
+                ? new OverrideEndResolution(null, null, ToFailure(end))
+                : new OverrideEndResolution(ToTemporalValue(endProperty), end.Value, CalendarOccurrenceQueryCode.Success);
+        }
+        if (durationProperty is not null)
+            return FromDuration(CalendarDurationArithmetic.Resolve(
+                ToTemporalValue(startProperty), start, durationProperty.RawEncodedValue, resolver));
+        if (startProperty.ValueType != CalendarPropertyValueType.Date)
+            return new OverrideEndResolution(null, start, CalendarOccurrenceQueryCode.Success);
+        return FromDuration(CalendarDurationArithmetic.Resolve(
+            ToTemporalValue(startProperty), start, "P1D", resolver));
+    }
+
+    private static CalendarOccurrenceEvaluation EvaluateTodo(
+        CalendarResourceSnapshot snapshot,
+        CalendarOccurrenceQuery query,
+        CalendarTemporalResolver resolver,
+        Todo master,
+        IReadOnlyList<CalendarProperty> properties,
+        OverridePlan overrides,
+        CancellationToken cancellationToken) => EvaluatePeriods(
+            snapshot,
+            query,
+            resolver,
+            IsRecurring(properties)
+                ? GetRecurringOccurrences(master, properties, resolver, query)
+                : CreateNonRecurringTodoOccurrence(properties),
+            overrides,
+            GetEvaluationBounds(properties, resolver, query).StopAt,
+            !IsRecurring(properties) && IsPointTodo(properties),
+            GetMasterDurationValue(properties),
+            GetMasterExactDuration(properties, resolver),
+            cancellationToken);
+
+    private static string? GetMasterDurationValue(IReadOnlyList<CalendarProperty> properties) =>
+        GetProperty(properties.Where(property => property.ComponentPath[1].Occurrence == 0), "DURATION")?.RawEncodedValue;
+
+    private static TimeSpan? GetMasterExactDuration(
+        IReadOnlyList<CalendarProperty> properties,
+        CalendarTemporalResolver resolver)
+    {
+        var master = properties.Where(property => property.ComponentPath[1].Occurrence == 0).ToArray();
+        if (GetProperty(master, "DURATION") is not null)
+            return null;
+        var start = resolver.Resolve(GetProperty(master, "DTSTART")).Value;
+        var end = resolver.Resolve(GetProperty(master, "DTEND") ?? GetProperty(master, "DUE")).Value;
+        return start is not null && end > start ? end.Value - start.Value : null;
+    }
+
+    private static bool IsPointTodo(IReadOnlyList<CalendarProperty> properties)
+    {
+        var master = properties.Where(property => property.ComponentPath[1].Occurrence == 0).ToArray();
+        return GetProperty(master, "DURATION") is null
+            && (GetProperty(master, "DTSTART") is null || GetProperty(master, "DUE") is null);
+    }
+
+    private static IEnumerable<Occurrence> CreateNonRecurringTodoOccurrence(
+        IReadOnlyList<CalendarProperty> properties)
+    {
+        var master = properties.Where(property => property.ComponentPath[1].Occurrence == 0).ToArray();
+        var start = GetProperty(master, "DTSTART");
+        var due = GetProperty(master, "DUE");
+        var identity = start ?? due;
+        if (identity is null)
+            return [];
+
+        var typedStart = ToCalDateTime(identity);
+        var end = due is not null && start is not null
+            ? ToCalDateTime(due)
+            : AddDuration(typedStart, GetProperty(master, "DURATION"));
+        return [new Occurrence(null!, new Period(typedStart, end))];
+    }
+
+    private static bool IsRecurring(IReadOnlyList<CalendarProperty> properties) => properties.Any(property =>
+        property.Name is "RRULE" or "RDATE" or "EXDATE" or "RECURRENCE-ID");
+
+    private static IEnumerable<Occurrence> GetRecurringOccurrences(
+        RecurringComponent master,
+        IReadOnlyList<CalendarProperty> properties,
+        CalendarTemporalResolver resolver,
+        CalendarOccurrenceQuery query)
+    {
+        var searchStart = GetSearchStart(properties, resolver, query);
+        var masterProperties = properties.Where(property => property.ComponentPath[1].Occurrence == 0).ToArray();
+        var identity = GetProperty(masterProperties, "DTSTART") ?? GetProperty(masterProperties, "DUE");
+        var timeZoneId = identity?.Parameters
+            .Where(parameter => parameter.Name.Equals("TZID", StringComparison.OrdinalIgnoreCase))
+            .SelectMany(parameter => parameter.Values)
+            .SingleOrDefault();
+        var usesEvaluationZone = timeZoneId is null
+            && identity is not null
+            && (identity.ValueType == CalendarPropertyValueType.Date
+                || !identity.RawEncodedValue.EndsWith('Z'))
+            && query.EvaluationTimeZone is not null;
+        return timeZoneId is not null || usesEvaluationZone
+            ? CreateLocalOccurrences(properties, resolver, query, timeZoneId)
+            : master.GetOccurrences(
+                searchStart,
+                new EvaluationOptions { MaxUnmatchedIncrementsLimit = MaximumUnmatchedIncrements });
+    }
+
+    private static IEnumerable<Occurrence> CreateLocalOccurrences(
+        IReadOnlyList<CalendarProperty> properties,
+        CalendarTemporalResolver resolver,
+        CalendarOccurrenceQuery query,
+        string? timeZoneId)
+    {
+        var master = properties.Where(property => property.ComponentPath[1].Occurrence == 0).ToArray();
+        var identity = GetProperty(master, "DTSTART") ?? GetProperty(master, "DUE")
+            ?? throw new InvalidOperationException("A recurring component has no temporal identity.");
+        var start = ToCalDateTime(identity);
+        var nominalStart = new CalDateTime(start.Value);
+        var ruleProperty = GetProperty(master, "RRULE");
+        var ruleStarts = ruleProperty is null
+            ? [nominalStart]
+            : CreateLocalRuleStarts(
+                ruleProperty.RawEncodedValue,
+                nominalStart,
+                timeZoneId,
+                resolver,
+                GetEvaluationBounds(properties, resolver, query).SearchFrom);
+        var recurrenceDates = master.Where(property => property.Name.Equals("RDATE", StringComparison.OrdinalIgnoreCase)
+                && property.ValueType != CalendarPropertyValueType.Period)
+            .SelectMany(property => property.RawEncodedValue.Split(',', StringSplitOptions.None)
+                .Select(value => new CalDateTime(ToCalDateTime(property, value).Value)))
+            .OrderBy(value => value.Value)
+            .ToArray();
+        var excluded = GetExcludedIdentities(properties);
+        var duration = GetNominalMasterDuration(master);
+        return MergeNominalStarts(ruleStarts, recurrenceDates)
+            .Select(value => CreateOccurrenceStart(value.Value, identity, timeZoneId))
+            .Where(value => !excluded.Contains(GetIdentitySortKey(ToTemporalValue(value))))
+            .Select(value => new Occurrence(null!, new Period(
+                value,
+                CreateOccurrenceStart(value.Value.Add(duration), identity, timeZoneId))));
+    }
+
+    private static CalDateTime CreateOccurrenceStart(
+        DateTime value,
+        CalendarProperty identity,
+        string? timeZoneId) => identity.ValueType == CalendarPropertyValueType.Date
+            ? new CalDateTime(value.Year, value.Month, value.Day)
+            : CreateLocalDateTime(value, timeZoneId);
+
+    private static IEnumerable<CalDateTime> CreateLocalRuleStarts(
+        string rawRule,
+        CalDateTime nominalStart,
+        string? timeZoneId,
+        CalendarTemporalResolver resolver,
+        DateTimeOffset searchFrom)
+    {
+        var pattern = new RecurrenceRule(rawRule);
+        var count = pattern.Count;
+        var evaluationPattern = count is null
+            ? pattern
+            : new RecurrenceRule(string.Join(
+                ';',
+                rawRule.Split(';', StringSplitOptions.RemoveEmptyEntries)
+                    .Where(part => !part.StartsWith("COUNT=", StringComparison.OrdinalIgnoreCase))));
+        var periodStart = count is null
+            ? new CalDateTime(Max(nominalStart.Value, SubtractSafely(searchFrom, TimeSpan.FromDays(2)).UtcDateTime))
+            : nominalStart;
+        var starts = new RecurrencePatternEvaluator(evaluationPattern)
+                .Evaluate(
+                    nominalStart,
+                    periodStart,
+                    new EvaluationOptions { MaxUnmatchedIncrementsLimit = MaximumUnmatchedIncrements })
+                .Select(period => period.StartTime);
+        return TakeValidLocalStarts(starts, nominalStart, timeZoneId, resolver, count);
+    }
+
+    private static IEnumerable<CalDateTime> TakeValidLocalStarts(
+        IEnumerable<CalDateTime> starts,
+        CalDateTime nominalStart,
+        string? timeZoneId,
+        CalendarTemporalResolver resolver,
+        int? count)
+    {
+        var accepted = 0;
+        foreach (var start in starts)
+        {
+            var local = CreateLocalDateTime(start.Value, timeZoneId);
+            var generated = start.Value != nominalStart.Value;
+            if (resolver.Resolve(local, generated).Skipped)
+                continue;
+            yield return start;
+            accepted++;
+            if (count is not null && accepted >= count)
+                yield break;
+        }
+    }
+
+    private static CalDateTime CreateLocalDateTime(DateTime value, string? timeZoneId) =>
+        timeZoneId is null ? new CalDateTime(value) : new CalDateTime(value, timeZoneId);
+
+    private static IEnumerable<CalDateTime> MergeNominalStarts(
+        IEnumerable<CalDateTime> ruleStarts,
+        IReadOnlyList<CalDateTime> recurrenceDates)
+    {
+        using var rules = ruleStarts.GetEnumerator();
+        var hasRule = rules.MoveNext();
+        var dateIndex = 0;
+        CalDateTime? previous = null;
+        while (hasRule || dateIndex < recurrenceDates.Count)
+        {
+            var next = !hasRule || dateIndex < recurrenceDates.Count
+                    && recurrenceDates[dateIndex].Value < rules.Current.Value
+                ? recurrenceDates[dateIndex++]
+                : rules.Current;
+            if (hasRule && next == rules.Current)
+                hasRule = rules.MoveNext();
+            if (previous is null || next.Value != previous.Value)
+                yield return next;
+            previous = next;
+        }
+    }
+
+    private static TimeSpan GetNominalMasterDuration(IReadOnlyList<CalendarProperty> properties)
+    {
+        var duration = GetProperty(properties, "DURATION");
+        if (duration is not null)
+            return CalendarDurationArithmetic.TryParse(duration.RawEncodedValue, out var parsed)
+                && parsed.IsStrictlyPositive
+                ? parsed.LocalClockDuration
+                : throw new FormatException("The DURATION value is invalid.");
+        var start = GetProperty(properties, "DTSTART") ?? GetProperty(properties, "DUE")!;
+        var end = GetProperty(properties, "DTEND") ?? GetProperty(properties, "DUE");
+        if (end is not null && end != start)
+            return GetNominalDifference(ToTemporalValue(start), ToTemporalValue(end));
+        return start.ValueType == CalendarPropertyValueType.Date ? TimeSpan.FromDays(1) : TimeSpan.Zero;
+    }
+
+    private static CalDateTime GetSearchStart(
+        IReadOnlyList<CalendarProperty> properties,
+        CalendarTemporalResolver resolver,
+        CalendarOccurrenceQuery query)
+    {
+        var master = properties.Where(property => property.ComponentPath[1].Occurrence == 0).ToArray();
+        var identity = GetProperty(master, "DTSTART") ?? GetProperty(master, "DUE")
+            ?? throw new InvalidOperationException("A recurring component has no temporal identity.");
+        var masterStart = ToCalDateTime(identity);
+        return masterStart.TzId is { Length: > 0 } timeZoneId && resolver.HasResourceLocalDefinition(timeZoneId)
+            ? masterStart
+            : new CalDateTime(GetEvaluationBounds(properties, resolver, query).SearchFrom.UtcDateTime);
+    }
+
+    private static CalDateTime AddDuration(CalDateTime start, CalendarProperty? property)
+    {
+        if (property is null)
+            return start;
+        if (!CalendarDurationArithmetic.TryParse(property.RawEncodedValue, out var duration)
+            || !duration.IsStrictlyPositive)
+        {
+            throw new FormatException("The DURATION value is invalid.");
+        }
+        if (start.HasTime || duration.Accurate != TimeSpan.Zero)
+            return start.Add(Duration.FromTimeSpanExact(duration.LocalClockDuration));
+        var end = start.Value.AddDays(duration.NominalDays);
+        return new CalDateTime(end.Year, end.Month, end.Day);
+    }
+
+    private static CalDateTime ToCalDateTime(CalendarProperty property)
+        => ToCalDateTime(property, property.RawEncodedValue);
+
+    private static CalDateTime ToCalDateTime(CalendarProperty property, string rawValue)
+    {
+        var timeZoneId = property.Parameters
+            .Where(parameter => parameter.Name.Equals("TZID", StringComparison.OrdinalIgnoreCase))
+            .SelectMany(parameter => parameter.Values)
+            .SingleOrDefault();
+        if (property.ValueType == CalendarPropertyValueType.Date)
+        {
+            var date = DateTime.ParseExact(rawValue, "yyyyMMdd", CultureInfo.InvariantCulture);
+            return new CalDateTime(date.Year, date.Month, date.Day);
+        }
+        if (rawValue.EndsWith('Z'))
+        {
+            var utc = DateTime.ParseExact(
+                rawValue,
+                "yyyyMMdd'T'HHmmss'Z'",
+                CultureInfo.InvariantCulture,
+                DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal);
+            return new CalDateTime(utc);
+        }
+        var local = DateTime.ParseExact(rawValue, "yyyyMMdd'T'HHmmss", CultureInfo.InvariantCulture);
+        return timeZoneId is null ? new CalDateTime(local) : new CalDateTime(local, timeZoneId);
+    }
+
+    private static CalDateTime ToCalDateTime(CalendarTemporalValue value)
+    {
+        if (value.Kind == CalendarTemporalKind.Date)
+        {
+            var date = DateTime.ParseExact(value.Value, "yyyy-MM-dd", CultureInfo.InvariantCulture);
+            return new CalDateTime(date.Year, date.Month, date.Day);
+        }
+        var local = DateTime.ParseExact(
+            value.Value.TrimEnd('Z'),
+            "yyyy-MM-dd'T'HH:mm:ss",
+            CultureInfo.InvariantCulture);
+        return value.Kind switch
+        {
+            CalendarTemporalKind.UtcDateTime => new CalDateTime(DateTime.SpecifyKind(local, DateTimeKind.Utc)),
+            CalendarTemporalKind.ZonedDateTime => new CalDateTime(local, value.TimeZoneId),
+            _ => new CalDateTime(local)
+        };
+    }
+
+    private static CalendarOccurrenceEvaluation EvaluatePeriods(
+        CalendarResourceSnapshot snapshot,
+        CalendarOccurrenceQuery query,
+        CalendarTemporalResolver resolver,
+        IEnumerable<Occurrence> periods,
+        OverridePlan overrides,
+        DateTimeOffset stopAt,
+        bool pointEndIsImplicit,
+        string? sourceDuration,
+        TimeSpan? sourceExactDuration,
+        CancellationToken cancellationToken)
+    {
+        var items = new List<CalendarOccurrenceSnapshot>();
+        var identities = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var occurrence in periods)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var start = resolver.Resolve(occurrence.Period.StartTime);
+            if (start.Value is null)
+                return Failure(ToFailure(start), identities.Count);
+            if (start.Value >= stopAt)
+                break;
+            identities.Add(GetIdentitySortKey(ToTemporalValue(occurrence.Period.StartTime)));
+            if (identities.Count > MaximumEntityOccurrences)
+                return Failure(CalendarOccurrenceQueryCode.LimitExhausted, identities.Count);
+            var evaluated = EvaluatePeriod(
+                snapshot,
+                query,
+                resolver,
+                occurrence,
+                overrides,
+                start.Value.Value,
+                pointEndIsImplicit,
+                sourceDuration,
+                sourceExactDuration);
+            if (evaluated.Code is { } code)
+                return Failure(code, identities.Count);
+            if (evaluated.Item is not null)
+                items.Add(evaluated.Item);
+        }
+        return new CalendarOccurrenceEvaluation(
+            CalendarOccurrenceQueryCode.Success, items, identities.Count, identities);
+    }
+
+    private static PeriodEvaluation EvaluatePeriod(
+        CalendarResourceSnapshot snapshot,
+        CalendarOccurrenceQuery query,
+        CalendarTemporalResolver resolver,
+        Occurrence occurrence,
+        OverridePlan overrides,
+        DateTimeOffset resolvedStart,
+        bool pointEndIsImplicit,
+        string? sourceDuration,
+        TimeSpan? sourceExactDuration)
+    {
+        var sourceStart = ToTemporalValue(occurrence.Period.StartTime);
+        var end = ResolveOccurrenceEnd(
+            occurrence,
+            pointEndIsImplicit,
+            sourceDuration,
+            sourceExactDuration,
+            sourceStart,
+            resolvedStart,
+            resolver);
+        if (end.Instant.Value is null)
+            return PeriodEvaluation.Failure(ToFailure(end.Instant));
+        var sourceEnd = sourceExactDuration is not null
+            && sourceStart.Kind == CalendarTemporalKind.Date
+            && occurrence.Period.EffectiveEndTime is not null
+                ? ToTemporalValue(occurrence.Period.EffectiveEndTime)
+                : end.Value;
+        var identityKey = GetIdentitySortKey(sourceStart);
+        var overridden = EvaluateAppliedOverride(
+            snapshot, query, resolver, overrides, identityKey, sourceStart, sourceEnd, sourceDuration);
+        if (overridden is not null)
+            return overridden;
+        if (!Overlaps(resolvedStart, end.Instant.Value.Value, query.From, query.To))
+            return PeriodEvaluation.NoMatch;
+
+        var evaluatedStart = ToUtcValue(resolvedStart);
+        var evaluatedEnd = end.Value is null ? null : ToUtcValue(end.Instant.Value.Value);
+        return PeriodEvaluation.Match(new CalendarOccurrenceSnapshot(
+            snapshot,
+            sourceStart,
+            new CalendarOccurrenceTiming(
+                sourceStart,
+                sourceStart,
+                sourceEnd,
+                end.Value,
+                SourceDuration: sourceDuration,
+                EffectiveDuration: sourceDuration,
+                EvaluatedStartUtc: evaluatedStart,
+                EvaluatedEndUtc: evaluatedEnd,
+                EvaluationTimeZone: query.EvaluationTimeZone)));
+    }
+
+    private static CalendarDurationResolution ResolveOccurrenceEnd(
+        Occurrence occurrence,
+        bool pointEndIsImplicit,
+        string? sourceDuration,
+        TimeSpan? sourceExactDuration,
+        CalendarTemporalValue sourceStart,
+        DateTimeOffset start,
+        CalendarTemporalResolver resolver)
+    {
+        if (sourceDuration is not null)
+            return CalendarDurationArithmetic.Resolve(sourceStart, start, sourceDuration, resolver);
+        if (sourceExactDuration is not null)
+            return CalendarDurationArithmetic.ResolveAccurate(
+                sourceStart, start, sourceExactDuration.Value, resolver);
+        var endTime = pointEndIsImplicit ? null : occurrence.Period.EffectiveEndTime;
+        return endTime is null
+            ? new CalendarDurationResolution(null, new ResolvedCalendarInstant(start, false))
+            : new CalendarDurationResolution(ToTemporalValue(endTime), resolver.Resolve(endTime));
+    }
+
+    private static PeriodEvaluation? EvaluateAppliedOverride(
+        CalendarResourceSnapshot snapshot,
+        CalendarOccurrenceQuery query,
+        CalendarTemporalResolver resolver,
+        OverridePlan overrides,
+        string identityKey,
+        CalendarTemporalValue sourceStart,
+        CalendarTemporalValue? sourceEnd,
+        string? sourceDuration = null)
+    {
+        if (overrides.Individuals.TryGetValue(identityKey, out var definition))
+            return EvaluateOverride(snapshot, query, resolver, definition, sourceStart, sourceEnd, sourceDuration);
+        var range = FindRange(overrides, identityKey);
+        return range is null
+            ? null
+            : EvaluateRangeOverride(snapshot, query, resolver, range, sourceStart, sourceEnd, sourceDuration);
+    }
+
+    private static PeriodEvaluation EvaluateOverride(
+        CalendarResourceSnapshot snapshot,
+        CalendarOccurrenceQuery query,
+        CalendarTemporalResolver resolver,
+        OverrideDefinition definition,
+        CalendarTemporalValue sourceStart,
+        CalendarTemporalValue? sourceEnd,
+        string? sourceDuration = null)
+    {
+        if (definition.Cancelled)
+            return PeriodEvaluation.NoMatch;
+        if (!resolver.CanResolve(definition.Identity))
+            return PeriodEvaluation.Failure(CalendarOccurrenceQueryCode.TemporalUnresolved);
+        if (definition.Start is null)
+            return PeriodEvaluation.Failure(CalendarOccurrenceQueryCode.RecurrenceUnevaluable);
+        var resolvedStart = resolver.Resolve(definition.Start);
+        if (resolvedStart.Value is null)
+            return PeriodEvaluation.Failure(ToFailure(resolvedStart));
+        var effectiveStart = ToTemporalValue(definition.Start);
+        var resolvedEnd = ResolveOverrideEnd(definition, effectiveStart, resolver, resolvedStart.Value.Value);
+        if (resolvedEnd.Instant is null)
+            return PeriodEvaluation.Failure(resolvedEnd.Code);
+        if (!Overlaps(resolvedStart.Value.Value, resolvedEnd.Instant.Value, query.From, query.To))
+            return PeriodEvaluation.NoMatch;
+
+        var effectiveEnd = resolvedEnd.Value;
+        return PeriodEvaluation.Match(new CalendarOccurrenceSnapshot(
+            snapshot,
+            sourceStart,
+            new CalendarOccurrenceTiming(
+                sourceStart,
+                effectiveStart,
+                sourceEnd,
+                effectiveEnd,
+                SourceDuration: sourceDuration,
+                EffectiveDuration: definition.Duration?.RawEncodedValue,
+                EvaluatedStartUtc: ToUtcValue(resolvedStart.Value.Value),
+                EvaluatedEndUtc: effectiveEnd is null ? null : ToUtcValue(resolvedEnd.Instant.Value),
+                EvaluationTimeZone: query.EvaluationTimeZone)));
+    }
+
+    private static PeriodEvaluation EvaluateRangeOverride(
+        CalendarResourceSnapshot snapshot,
+        CalendarOccurrenceQuery query,
+        CalendarTemporalResolver resolver,
+        OverrideDefinition definition,
+        CalendarTemporalValue sourceStart,
+        CalendarTemporalValue? sourceEnd,
+        string? sourceDuration = null)
+    {
+        if (definition.Cancelled)
+            return PeriodEvaluation.NoMatch;
+        if (!resolver.CanResolve(definition.Identity))
+            return PeriodEvaluation.Failure(CalendarOccurrenceQueryCode.TemporalUnresolved);
+        if (definition.Start is null)
+            return PeriodEvaluation.Failure(CalendarOccurrenceQueryCode.RecurrenceUnevaluable);
+        var anchorIdentity = ToTemporalValue(definition.Identity);
+        var anchorStart = ToTemporalValue(definition.Start);
+        var effectiveStart = AddTemporalOffset(sourceStart, GetNominalDifference(anchorIdentity, anchorStart));
+        var resolvedStart = resolver.Resolve(ToCalDateTime(effectiveStart));
+        if (resolvedStart.Value is null)
+            return PeriodEvaluation.Failure(ToFailure(resolvedStart));
+        var resolvedEnd = ResolveRangeEnd(definition, effectiveStart, resolvedStart.Value.Value, resolver);
+        if (resolvedEnd.Instant.Value is null)
+            return PeriodEvaluation.Failure(ToFailure(resolvedEnd.Instant));
+        if (!Overlaps(resolvedStart.Value.Value, resolvedEnd.Instant.Value.Value, query.From, query.To))
+            return PeriodEvaluation.NoMatch;
+        return PeriodEvaluation.Match(new CalendarOccurrenceSnapshot(
+            snapshot,
+            sourceStart,
+            new CalendarOccurrenceTiming(
+                sourceStart,
+                effectiveStart,
+                sourceEnd,
+                resolvedEnd.Value,
+                SourceDuration: sourceDuration,
+                EffectiveDuration: definition.Duration?.RawEncodedValue,
+                EvaluatedStartUtc: ToUtcValue(resolvedStart.Value.Value),
+                EvaluatedEndUtc: resolvedEnd.Value is null ? null : ToUtcValue(resolvedEnd.Instant.Value.Value),
+                EvaluationTimeZone: query.EvaluationTimeZone)));
+    }
+
+    private static OverrideDefinition? FindRange(OverridePlan overrides, string identityKey) =>
+        overrides.Ranges.LastOrDefault(candidate =>
+            string.CompareOrdinal(GetIdentitySortKey(ToTemporalValue(candidate.Identity)), identityKey) <= 0);
+
+    private static CalendarDurationResolution ResolveRangeEnd(
+        OverrideDefinition definition,
+        CalendarTemporalValue effectiveStart,
+        DateTimeOffset resolvedStart,
+        CalendarTemporalResolver resolver)
+    {
+        if (definition.Duration is not null)
+            return CalendarDurationArithmetic.Resolve(
+                effectiveStart, resolvedStart, definition.Duration.RawEncodedValue, resolver);
+        if (definition.End is not null)
+        {
+            var anchorStart = resolver.Resolve(definition.Start);
+            var anchorEnd = resolver.Resolve(definition.End);
+            if (anchorStart.Value is null || anchorEnd.Value is null)
+                return new(null, anchorStart.Value is null ? anchorStart : anchorEnd);
+            return CalendarDurationArithmetic.ResolveAccurate(
+                effectiveStart,
+                resolvedStart,
+                anchorEnd.Value.Value - anchorStart.Value.Value,
+                resolver);
+        }
+        return definition.DateEventDefaultsToOneDay
+            ? CalendarDurationArithmetic.Resolve(effectiveStart, resolvedStart, "P1D", resolver)
+            : new CalendarDurationResolution(null, new ResolvedCalendarInstant(resolvedStart, false));
+    }
+
+    private static OverrideEndResolution ResolveOverrideEnd(
+        OverrideDefinition definition,
+        CalendarTemporalValue effectiveStart,
+        CalendarTemporalResolver resolver,
+        DateTimeOffset start)
+    {
+        if (definition.End is not null)
+        {
+            var end = resolver.Resolve(definition.End);
+            return end.Value is null
+                ? new OverrideEndResolution(null, null, ToFailure(end))
+                : new OverrideEndResolution(ToTemporalValue(definition.End), end.Value, CalendarOccurrenceQueryCode.Success);
+        }
+        if (definition.Duration is null)
+            return definition.DateEventDefaultsToOneDay
+                ? FromDuration(CalendarDurationArithmetic.Resolve(effectiveStart, start, "P1D", resolver))
+                : new OverrideEndResolution(null, start, CalendarOccurrenceQueryCode.Success);
+        return FromDuration(CalendarDurationArithmetic.Resolve(
+            effectiveStart, start, definition.Duration.RawEncodedValue, resolver));
+    }
+
+    private static OverrideEndResolution FromDuration(CalendarDurationResolution duration) =>
+        duration.Instant.Value is null
+            ? new OverrideEndResolution(null, null, ToFailure(duration.Instant))
+            : new OverrideEndResolution(
+                duration.Value, duration.Instant.Value, CalendarOccurrenceQueryCode.Success);
+
+    private static CalendarTemporalValue AddTemporalOffset(CalendarTemporalValue value, TimeSpan offset)
+    {
+        var format = value.Kind == CalendarTemporalKind.Date ? "yyyy-MM-dd" : "yyyy-MM-dd'T'HH:mm:ss";
+        var parsed = DateTime.ParseExact(value.Value.TrimEnd('Z'), format, CultureInfo.InvariantCulture).Add(offset);
+        var suffix = value.Kind == CalendarTemporalKind.UtcDateTime ? "Z" : string.Empty;
+        return value with { Value = parsed.ToString(format, CultureInfo.InvariantCulture) + suffix };
+    }
+
+    private static TimeSpan GetNominalDifference(CalendarTemporalValue identity, CalendarTemporalValue movedStart)
+    {
+        var format = identity.Kind == CalendarTemporalKind.Date ? "yyyy-MM-dd" : "yyyy-MM-dd'T'HH:mm:ss";
+        var original = DateTime.ParseExact(identity.Value.TrimEnd('Z'), format, CultureInfo.InvariantCulture);
+        var moved = DateTime.ParseExact(movedStart.Value.TrimEnd('Z'), format, CultureInfo.InvariantCulture);
+        return moved - original;
+    }
+
+    private static OverridePlan CreateOverrides(
+        IReadOnlyList<CalendarProperty> properties,
+        CalendarResourceProjectionKind kind)
+    {
+        var definitions = properties.Where(property => property.ComponentPath[1].Occurrence > 0)
+            .GroupBy(property => property.ComponentPath[1].Occurrence)
+            .Select(group => CreateOverride(group.ToArray(), kind))
+            .Where(definition => definition is not null)
+            .Cast<OverrideDefinition>()
+            .ToArray();
+        var individuals = definitions.Where(definition => !definition.IsRange).ToDictionary(
+            definition => GetIdentitySortKey(ToTemporalValue(definition.Identity)),
+            StringComparer.Ordinal);
+        var ranges = definitions.Where(definition => definition.IsRange)
+            .OrderBy(definition => GetIdentitySortKey(ToTemporalValue(definition.Identity)), StringComparer.Ordinal)
+            .ToArray();
+        return new OverridePlan(individuals, ranges, definitions);
+    }
+
+    private static OverrideDefinition? CreateOverride(
+        IReadOnlyList<CalendarProperty> properties,
+        CalendarResourceProjectionKind kind)
+    {
+        var identity = GetProperty(properties, "RECURRENCE-ID");
+        var explicitStart = GetProperty(properties, "DTSTART");
+        var due = GetProperty(properties, "DUE");
+        var start = GetOverrideStart(kind, explicitStart, due);
+        var cancelled = IsCancelled(properties);
+        if (identity is null || start is null && !cancelled)
+            return null;
+        var range = identity.Parameters
+            .Where(parameter => parameter.Name.Equals("RANGE", StringComparison.OrdinalIgnoreCase))
+            .SelectMany(parameter => parameter.Values)
+            .SingleOrDefault();
+        return new OverrideDefinition(
+            identity,
+            start,
+            GetProperty(properties, "DTEND") ?? (explicitStart is null ? null : due),
+            GetProperty(properties, "DURATION"),
+            cancelled,
+            range is not null,
+            IsDefaultDateEvent(kind, start));
+    }
+
+    private static CalendarProperty? GetOverrideStart(
+        CalendarResourceProjectionKind kind,
+        CalendarProperty? explicitStart,
+        CalendarProperty? due) => explicitStart
+            ?? (kind == CalendarResourceProjectionKind.Todo ? due : null);
+
+    private static bool IsCancelled(IEnumerable<CalendarProperty> properties) =>
+        GetProperty(properties, "STATUS")?.RawEncodedValue.Equals(
+            "CANCELLED", StringComparison.OrdinalIgnoreCase) == true;
+
+    private static bool IsDefaultDateEvent(
+        CalendarResourceProjectionKind kind,
+        CalendarProperty? start) => kind == CalendarResourceProjectionKind.Event
+            && start?.ValueType == CalendarPropertyValueType.Date;
+
+    private static EvaluationBounds GetEvaluationBounds(
+        IReadOnlyList<CalendarProperty> properties,
+        CalendarTemporalResolver resolver,
+        CalendarOccurrenceQuery query)
+    {
+        var maximumShift = properties.Where(property => property.ComponentPath[1].Occurrence > 0)
+            .GroupBy(property => property.ComponentPath[1].Occurrence)
+            .Select(group => GetOverrideShift(group.ToArray(), resolver))
+            .DefaultIfEmpty(TimeSpan.Zero)
+            .Max();
+        var maximumDuration = properties.GroupBy(property => property.ComponentPath[1].Occurrence)
+            .Select(group => GetDuration(group.ToArray(), resolver))
+            .DefaultIfEmpty(TimeSpan.Zero)
+            .Max();
+        maximumDuration = Max(maximumDuration, GetMaximumPeriodDuration(properties, resolver));
+        return new EvaluationBounds(
+            SubtractSafely(query.From, maximumShift + maximumDuration),
+            AddSafely(query.To, maximumShift));
+    }
+
+    private static TimeSpan GetOverrideShift(
+        IReadOnlyList<CalendarProperty> properties,
+        CalendarTemporalResolver resolver)
+    {
+        var identity = resolver.Resolve(GetProperty(properties, "RECURRENCE-ID")).Value;
+        var start = resolver.Resolve(
+            GetProperty(properties, "DTSTART") ?? GetProperty(properties, "DUE")).Value;
+        return identity is null || start is null ? TimeSpan.Zero : (start.Value - identity.Value).Duration();
+    }
+
+    private static TimeSpan GetDuration(
+        IReadOnlyList<CalendarProperty> properties,
+        CalendarTemporalResolver resolver)
+    {
+        var startProperty = GetProperty(properties, "DTSTART");
+        var start = resolver.Resolve(startProperty).Value;
+        var end = resolver.Resolve(GetProperty(properties, "DTEND") ?? GetProperty(properties, "DUE")).Value;
+        if (start is not null && end > start)
+            return end.Value - start.Value;
+        var duration = GetProperty(properties, "DURATION");
+        var rawDuration = duration?.RawEncodedValue ?? GetDefaultEventDuration(properties, startProperty);
+        if (start is null || startProperty is null || rawDuration is null)
+            return TimeSpan.Zero;
+        var resolved = CalendarDurationArithmetic.Resolve(
+            ToTemporalValue(startProperty), start.Value, rawDuration, resolver).Instant.Value;
+        return resolved is null ? TimeSpan.Zero : (resolved.Value - start.Value).Duration();
+    }
+
+    private static string? GetDefaultEventDuration(
+        IReadOnlyList<CalendarProperty> properties,
+        CalendarProperty? start) => start?.ValueType == CalendarPropertyValueType.Date
+        && properties.Any(property => property.ComponentPath[1].Name.Equals("VEVENT", StringComparison.OrdinalIgnoreCase))
+            ? "P1D"
+            : null;
+
+    private static TimeSpan GetMaximumPeriodDuration(
+        IEnumerable<CalendarProperty> properties,
+        CalendarTemporalResolver resolver) => properties
+        .Where(property => property.Name.Equals("RDATE", StringComparison.OrdinalIgnoreCase)
+            && property.ValueType == CalendarPropertyValueType.Period)
+        .SelectMany(property => property.RawEncodedValue.Split(',', StringSplitOptions.None)
+            .Select(period => GetPeriodDuration(property, period, resolver)))
+        .DefaultIfEmpty(TimeSpan.Zero)
+        .Max();
+
+    private static TimeSpan GetPeriodDuration(
+        CalendarProperty property,
+        string period,
+        CalendarTemporalResolver resolver)
+    {
+        var parts = period.Split('/', StringSplitOptions.None);
+        if (parts.Length != 2)
+            return TimeSpan.Zero;
+        if (CalendarDurationArithmetic.LooksLikeDuration(parts[1]))
+        {
+            var startValue = resolver.ResolveToken(property, parts[0]).Value;
+            if (startValue is null)
+                return TimeSpan.Zero;
+            var resolved = CalendarDurationArithmetic.Resolve(
+                ToTemporalValue(property, parts[0]), startValue.Value, parts[1], resolver).Instant.Value;
+            return resolved is null ? TimeSpan.Zero : (resolved.Value - startValue.Value).Duration();
+        }
+        var start = resolver.ResolveToken(property, parts[0]).Value;
+        var end = resolver.ResolveToken(property, parts[1]).Value;
+        return start is not null && end > start ? end.Value - start.Value : TimeSpan.Zero;
+    }
+
+    private static TimeSpan Max(TimeSpan left, TimeSpan right) => left >= right ? left : right;
+
+    private static DateTime Max(DateTime left, DateTime right) => left >= right ? left : right;
+
+    private static DateTimeOffset SubtractSafely(DateTimeOffset value, TimeSpan offset) =>
+        value - DateTimeOffset.MinValue < offset ? DateTimeOffset.MinValue : value - offset;
+
+    private static DateTimeOffset AddSafely(DateTimeOffset value, TimeSpan offset) =>
+        DateTimeOffset.MaxValue - value < offset ? DateTimeOffset.MaxValue : value + offset;
+
+    private static CalendarOccurrenceQueryCode ToFailure(ResolvedCalendarInstant instant) => instant.Unresolved
+        ? CalendarOccurrenceQueryCode.TemporalUnresolved
+        : CalendarOccurrenceQueryCode.RecurrenceUnevaluable;
+
+    private static bool Overlaps(DateTimeOffset start, DateTimeOffset end, DateTimeOffset from, DateTimeOffset to) =>
+        end > start ? start < to && end > from : start >= from && start < to;
+
+    private static CalendarTemporalValue ToTemporalValue(CalDateTime value)
+    {
+        if (!value.HasTime)
+            return new(CalendarTemporalKind.Date, value.Value.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture));
+        var localValue = value.Value.ToString("yyyy-MM-dd'T'HH:mm:ss", CultureInfo.InvariantCulture);
+        if (value.IsUtc)
+            return new(CalendarTemporalKind.UtcDateTime, localValue + "Z");
+        return value.TzId is { Length: > 0 } timeZoneId
+            ? new CalendarTemporalValue(CalendarTemporalKind.ZonedDateTime, localValue, timeZoneId)
+            : new CalendarTemporalValue(CalendarTemporalKind.FloatingDateTime, localValue);
+    }
+
+    private static CalendarTemporalValue ToTemporalValue(CalendarProperty property) =>
+        ToTemporalValue(ToCalDateTime(property));
+
+    private static CalendarTemporalValue ToTemporalValue(CalendarProperty property, string rawValue) =>
+        ToTemporalValue(ToCalDateTime(property, rawValue));
+
+    private static CalendarTemporalValue ToUtcValue(DateTimeOffset value) => new(
+        CalendarTemporalKind.UtcDateTime,
+        value.UtcDateTime.ToString("yyyy-MM-dd'T'HH:mm:ss'Z'", CultureInfo.InvariantCulture));
+
+    private static CalendarProperty[] GetEntityProperties(CalendarResourceSnapshot snapshot)
+    {
+        var componentName = snapshot.Projection.Kind == CalendarResourceProjectionKind.Event ? "VEVENT" : "VTODO";
+        return snapshot.CalendarProperties.Where(property => property.ComponentPath.Count == 2
+            && property.ComponentPath[1].Name.Equals(componentName, StringComparison.OrdinalIgnoreCase)).ToArray();
+    }
+
+    private static bool IsTemporalProperty(CalendarProperty property) => property.Name is
+        "DTSTART" or "DTEND" or "DUE" or "RDATE" or "EXDATE" or "RECURRENCE-ID";
+
+    private static bool RequiresEagerResolution(CalendarProperty property) =>
+        IsTemporalProperty(property)
+        && !property.Name.Equals("EXDATE", StringComparison.OrdinalIgnoreCase)
+        && property.ValueType != CalendarPropertyValueType.Period;
+
+    private static bool HasUnsupportedRange(CalendarProperty property) =>
+        property.Name.Equals("RECURRENCE-ID", StringComparison.OrdinalIgnoreCase)
+        && property.Parameters.Where(parameter => parameter.Name.Equals("RANGE", StringComparison.OrdinalIgnoreCase))
+            .SelectMany(parameter => parameter.Values)
+            .Any(value => !value.Equals("THISANDFUTURE", StringComparison.OrdinalIgnoreCase));
+
+    private static CalendarProperty? GetProperty(IEnumerable<CalendarProperty> properties, string name) =>
+        properties.FirstOrDefault(property => property.Name.Equals(name, StringComparison.OrdinalIgnoreCase));
+
+    private static CalendarOccurrenceEvaluation Failure(
+        CalendarOccurrenceQueryCode code,
+        int observed = 0) => new(code, [], observed);
+
+    private sealed record PeriodEvaluation(
+        CalendarOccurrenceQueryCode? Code,
+        CalendarOccurrenceSnapshot? Item)
+    {
+        public static PeriodEvaluation NoMatch { get; } = new(null, null);
+        public static PeriodEvaluation Failure(CalendarOccurrenceQueryCode code) => new(code, null);
+        public static PeriodEvaluation Match(CalendarOccurrenceSnapshot item) => new(null, item);
+    }
+
+    private sealed record OverrideDefinition(
+        CalendarProperty Identity,
+        CalendarProperty? Start,
+        CalendarProperty? End,
+        CalendarProperty? Duration,
+        bool Cancelled,
+        bool IsRange,
+        bool DateEventDefaultsToOneDay);
+
+    private sealed record OverridePlan(
+        IReadOnlyDictionary<string, OverrideDefinition> Individuals,
+        IReadOnlyList<OverrideDefinition> Ranges,
+        IReadOnlyList<OverrideDefinition> All);
+
+    private readonly record struct OverrideEndResolution(
+        CalendarTemporalValue? Value,
+        DateTimeOffset? Instant,
+        CalendarOccurrenceQueryCode Code);
+
+    private readonly record struct EvaluationBounds(DateTimeOffset SearchFrom, DateTimeOffset StopAt);
+}

--- a/src/DotnetAgents.CalDav.Core/Internal/Ical/CalendarResourceProjector.cs
+++ b/src/DotnetAgents.CalDav.Core/Internal/Ical/CalendarResourceProjector.cs
@@ -64,7 +64,7 @@ internal static class CalendarResourceProjector
             if (diagnostic is not null)
                 return Opaque(properties, diagnostic);
 
-            if (!IcalNetCorroborates(document.ReplayForTypedValidation(), entities[0].Kind, entities.Count))
+            if (!IcalNetCorroborates(document.ReplayForProjectionValidation(), entities[0].Kind, entities.Count))
                 return Opaque(properties, "typed_projection_invalid");
 
             var master = entities.Single(entity => entity.RecurrenceIdentity is null);

--- a/src/DotnetAgents.CalDav.Core/Internal/Ical/CalendarTemporalResolver.cs
+++ b/src/DotnetAgents.CalDav.Core/Internal/Ical/CalendarTemporalResolver.cs
@@ -18,14 +18,17 @@ internal sealed class CalendarTemporalResolver
     private readonly IReadOnlyList<CalendarProperty> _properties;
     private readonly IcalCalendar? _typedCalendar;
     private readonly CancellationToken _cancellationToken;
+    private readonly string? _evaluationTimeZone;
 
     public CalendarTemporalResolver(
         IReadOnlyList<CalendarProperty> properties,
         ReadOnlySpan<byte> authoritativeUtf8,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default,
+        string? evaluationTimeZone = null)
     {
         _properties = properties;
         _cancellationToken = cancellationToken;
+        _evaluationTimeZone = evaluationTimeZone;
         _typedCalendar = LoadTypedCalendar(authoritativeUtf8);
     }
 
@@ -35,7 +38,7 @@ internal sealed class CalendarTemporalResolver
         if (property is null)
             return new(null, false);
         if (property.ValueType == CalendarPropertyValueType.Date)
-            return new(null, true);
+            return ResolveDate(property.RawEncodedValue);
         return ResolveToken(property.RawEncodedValue, GetTimeZoneId(property));
     }
 
@@ -44,7 +47,9 @@ internal sealed class CalendarTemporalResolver
         _cancellationToken.ThrowIfCancellationRequested();
         return property.ValueType switch
         {
-            CalendarPropertyValueType.Date => false,
+            CalendarPropertyValueType.Date => property.RawEncodedValue
+                .Split(',', StringSplitOptions.None)
+                .All(token => ResolveDate(token).Value is not null),
             CalendarPropertyValueType.DateTime => property.RawEncodedValue
                 .Split(',', StringSplitOptions.None)
                 .All(token => ResolveToken(token, GetTimeZoneId(property)).Value is not null),
@@ -58,23 +63,53 @@ internal sealed class CalendarTemporalResolver
     public ResolvedCalendarInstant ResolveToken(CalendarProperty property, string raw) =>
         ResolveToken(raw, GetTimeZoneId(property));
 
-    public ResolvedCalendarInstant Resolve(CalDateTime value)
+    public ResolvedCalendarInstant Resolve(CalDateTime value, bool generated = false)
     {
         _cancellationToken.ThrowIfCancellationRequested();
         if (!value.HasTime)
-            return new(null, true);
+            return ResolveInEvaluationZone(value.Value.Date);
         if (value.IsUtc)
             return new(new DateTimeOffset(DateTime.SpecifyKind(value.Value, DateTimeKind.Utc)), false);
         return value.TzId is { Length: > 0 } timeZoneId
-            ? ResolveLocal(DateTime.SpecifyKind(value.Value, DateTimeKind.Unspecified), timeZoneId)
-            : new(null, true);
+            ? ResolveLocal(DateTime.SpecifyKind(value.Value, DateTimeKind.Unspecified), timeZoneId, generated)
+            : ResolveInEvaluationZone(DateTime.SpecifyKind(value.Value, DateTimeKind.Unspecified), generated);
+    }
+
+    public bool HasResourceLocalDefinition(string timeZoneId) => CountRawLocalDefinitions(timeZoneId) > 0;
+
+    public CalendarTemporalValue? Project(DateTimeOffset instant, CalendarTemporalValue template)
+    {
+        _cancellationToken.ThrowIfCancellationRequested();
+        if (template.Kind == CalendarTemporalKind.UtcDateTime)
+            return template with { Value = FormatUtc(instant) };
+        var timeZoneId = template.Kind == CalendarTemporalKind.ZonedDateTime
+            ? template.TimeZoneId
+            : _evaluationTimeZone;
+        if (timeZoneId is null)
+            return null;
+        var local = ProjectLocal(instant, timeZoneId);
+        if (local is null)
+            return null;
+        if (template.Kind != CalendarTemporalKind.Date)
+        {
+            return template with
+            {
+                Value = local.Value.ToString("yyyy-MM-dd'T'HH:mm:ss", CultureInfo.InvariantCulture)
+            };
+        }
+        return local.Value.TimeOfDay == TimeSpan.Zero
+            ? template with { Value = local.Value.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture) }
+            : new CalendarTemporalValue(
+                CalendarTemporalKind.ZonedDateTime,
+                local.Value.ToString("yyyy-MM-dd'T'HH:mm:ss", CultureInfo.InvariantCulture),
+                timeZoneId);
     }
 
     private static IcalCalendar? LoadTypedCalendar(ReadOnlySpan<byte> authoritativeUtf8)
     {
         try
         {
-            var replay = CalendarContentDocument.Parse(authoritativeUtf8).ReplayForTypedValidation();
+            var replay = CalendarContentDocument.Parse(authoritativeUtf8).ReplayForOccurrenceEvaluation();
             return IcalCalendar.Load(Encoding.UTF8.GetString(replay));
         }
         catch (Exception exception) when (exception is FormatException or ArgumentException or InvalidOperationException)
@@ -88,8 +123,7 @@ internal sealed class CalendarTemporalResolver
         var parts = period.Split('/', StringSplitOptions.None);
         return parts.Length == 2
             && ResolveToken(parts[0], timeZoneId).Value is not null
-            && (parts[1].StartsWith('P')
-                || parts[1].StartsWith("-P", StringComparison.Ordinal)
+            && (CalendarDurationArithmetic.LooksLikeDuration(parts[1])
                 || ResolveToken(parts[1], timeZoneId).Value is not null);
     }
 
@@ -106,25 +140,41 @@ internal sealed class CalendarTemporalResolver
                 out var instant);
             return new(parsed ? instant : null, false);
         }
-        if (timeZoneId is null
-            || !DateTime.TryParseExact(raw, "yyyyMMdd'T'HHmmss", CultureInfo.InvariantCulture,
+        if (!DateTime.TryParseExact(raw, "yyyyMMdd'T'HHmmss", CultureInfo.InvariantCulture,
                 DateTimeStyles.None, out var local))
             return new(null, true);
 
-        return ResolveLocal(local, timeZoneId);
+        return timeZoneId is null ? ResolveInEvaluationZone(local) : ResolveLocal(local, timeZoneId);
     }
 
-    private ResolvedCalendarInstant ResolveLocal(DateTime local, string timeZoneId)
+    private ResolvedCalendarInstant ResolveDate(string raw)
+    {
+        var parsed = DateTime.TryParseExact(
+            raw,
+            "yyyyMMdd",
+            CultureInfo.InvariantCulture,
+            DateTimeStyles.None,
+            out var date);
+        return parsed ? ResolveInEvaluationZone(date) : new(null, true);
+    }
+
+    private ResolvedCalendarInstant ResolveInEvaluationZone(DateTime local, bool generated = false) =>
+        _evaluationTimeZone is null
+            ? new(null, true)
+            : ResolveFromIana(
+                DateTime.SpecifyKind(local, DateTimeKind.Unspecified), _evaluationTimeZone, generated);
+
+    private ResolvedCalendarInstant ResolveLocal(DateTime local, string timeZoneId, bool generated = false)
     {
         _cancellationToken.ThrowIfCancellationRequested();
         var rawDefinitionCount = CountRawLocalDefinitions(timeZoneId);
         if (rawDefinitionCount > 1)
             return new(null, true);
         if (rawDefinitionCount == 0)
-            return ResolveFromIana(local, timeZoneId);
+            return ResolveFromIana(local, timeZoneId, generated);
         var typedDefinitions = FindTypedLocalDefinitions(timeZoneId);
         return typedDefinitions.Count == 1
-            ? ResolveFromLocalDefinition(local, typedDefinitions[0], _cancellationToken)
+            ? ResolveFromLocalDefinition(local, typedDefinitions[0], generated, _cancellationToken)
             : new(null, true);
     }
 
@@ -138,7 +188,67 @@ internal sealed class CalendarTemporalResolver
         .Where(zone => string.Equals(zone.TzId, timeZoneId, StringComparison.Ordinal))
         .ToArray() ?? [];
 
-    private static ResolvedCalendarInstant ResolveFromIana(DateTime local, string timeZoneId)
+    private DateTime? ProjectLocal(DateTimeOffset instant, string timeZoneId)
+    {
+        var rawDefinitionCount = CountRawLocalDefinitions(timeZoneId);
+        if (rawDefinitionCount > 1)
+            return null;
+        if (rawDefinitionCount == 0)
+            return ProjectFromIana(instant, timeZoneId);
+        var definitions = FindTypedLocalDefinitions(timeZoneId);
+        return definitions.Count == 1
+            ? ProjectFromLocalDefinition(instant, definitions[0], _cancellationToken)
+            : null;
+    }
+
+    private static DateTime? ProjectFromIana(DateTimeOffset instant, string timeZoneId)
+    {
+        var zone = DateTimeZoneProviders.Tzdb.GetZoneOrNull(timeZoneId);
+        return zone is null
+            ? null
+            : Instant.FromDateTimeOffset(instant).InZone(zone).LocalDateTime.ToDateTimeUnspecified();
+    }
+
+    private static DateTime? ProjectFromLocalDefinition(
+        DateTimeOffset instant,
+        VTimeZone zone,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            if (!TryGetConsistentTransitions(zone, instant.UtcDateTime, cancellationToken, out var transitions)
+                || transitions.Length == 0)
+                return null;
+            var previous = transitions.LastOrDefault(transition =>
+                GetTransitionInstant(transition) <= instant);
+            var offset = previous?.OffsetTo ?? transitions[0].OffsetFrom;
+            return DateTime.SpecifyKind(instant.UtcDateTime + offset, DateTimeKind.Unspecified);
+        }
+        catch (Exception exception) when (exception is EvaluationLimitExceededException
+            or EvaluationOutOfRangeException
+            or ZoneTransitionLimitException
+            or FormatException
+            or ArgumentException
+            or OverflowException
+            or InvalidOperationException)
+        {
+            return null;
+        }
+    }
+
+    private static DateTimeOffset GetTransitionInstant(ZoneTransition transition)
+    {
+        var utcTicks = checked(transition.LocalStart.Ticks - transition.OffsetFrom.Ticks);
+        return new DateTimeOffset(new DateTime(utcTicks, DateTimeKind.Utc));
+    }
+
+    private static string FormatUtc(DateTimeOffset instant) =>
+        instant.UtcDateTime.ToString("yyyy-MM-dd'T'HH:mm:ss'Z'", CultureInfo.InvariantCulture);
+
+    private static ResolvedCalendarInstant ResolveFromIana(
+        DateTime local,
+        string timeZoneId,
+        bool generated = false)
     {
         try
         {
@@ -146,9 +256,14 @@ internal sealed class CalendarTemporalResolver
             if (zone is null)
                 return new(null, true);
             var mapping = zone.MapLocal(LocalDateTime.FromDateTime(local));
-            return mapping.Count == 1
-                ? new(mapping.Single().ToDateTimeOffset().ToUniversalTime(), false)
-                : new(null, true);
+            return mapping.Count switch
+            {
+                0 when generated => new(null, false, true),
+                0 => new(new DateTimeOffset(local, mapping.EarlyInterval.WallOffset.ToTimeSpan())
+                    .ToUniversalTime(), false),
+                1 => new(mapping.Single().ToDateTimeOffset().ToUniversalTime(), false),
+                _ => new(mapping.First().ToDateTimeOffset().ToUniversalTime(), false)
+            };
         }
         catch (ArgumentException)
         {
@@ -159,17 +274,18 @@ internal sealed class CalendarTemporalResolver
     private static ResolvedCalendarInstant ResolveFromLocalDefinition(
         DateTime local,
         VTimeZone zone,
+        bool generated,
         CancellationToken cancellationToken)
     {
         try
         {
             cancellationToken.ThrowIfCancellationRequested();
             if (!TryGetConsistentTransitions(zone, local, cancellationToken, out var transitions)
-                || transitions.Length == 0
-                || IsAmbiguousOrInvalid(local, transitions))
+                || transitions.Length == 0)
                 return new(null, true);
-            var previous = transitions.LastOrDefault(item => item.LocalStart <= local);
-            var offset = previous?.OffsetTo ?? transitions[0].OffsetFrom;
+            var offset = ResolveLocalOffset(local, transitions, generated, out var skipped);
+            if (skipped)
+                return new(null, false, true);
             var utcTicks = checked(local.Ticks - offset.Ticks);
             return new(new DateTimeOffset(new DateTime(utcTicks, DateTimeKind.Utc)), false);
         }
@@ -236,21 +352,30 @@ internal sealed class CalendarTemporalResolver
         return true;
     }
 
-    private static bool IsAmbiguousOrInvalid(DateTime local, IEnumerable<ZoneTransition> transitions)
+    private static TimeSpan ResolveLocalOffset(
+        DateTime local,
+        IReadOnlyList<ZoneTransition> transitions,
+        bool generated,
+        out bool skipped)
     {
+        skipped = false;
         foreach (var transition in transitions)
         {
             var change = transition.OffsetTo - transition.OffsetFrom;
             if (change > TimeSpan.Zero
                 && local >= transition.LocalStart
                 && local < transition.LocalStart + change)
-                return true;
+            {
+                skipped = generated;
+                return transition.OffsetFrom;
+            }
             if (change < TimeSpan.Zero
                 && local >= transition.LocalStart + change
                 && local < transition.LocalStart)
-                return true;
+                return transition.OffsetFrom;
         }
-        return false;
+        var previous = transitions.LastOrDefault(item => item.LocalStart <= local);
+        return previous?.OffsetTo ?? transitions[0].OffsetFrom;
     }
 
     private static string? GetTimeZoneId(CalendarProperty property) => property.Parameters
@@ -265,4 +390,7 @@ internal sealed class CalendarTemporalResolver
     }
 }
 
-internal readonly record struct ResolvedCalendarInstant(DateTimeOffset? Value, bool Unresolved);
+internal readonly record struct ResolvedCalendarInstant(
+    DateTimeOffset? Value,
+    bool Unresolved,
+    bool Skipped = false);

--- a/src/DotnetAgents.CalDav.Core/Models/CalendarOccurrenceQuery.cs
+++ b/src/DotnetAgents.CalDav.Core/Models/CalendarOccurrenceQuery.cs
@@ -1,0 +1,89 @@
+namespace DotnetAgents.CalDav.Core.Models;
+
+/// <summary>A bounded query for derived Event and To-do Occurrences.</summary>
+public sealed record CalendarOccurrenceQuery(
+    CalendarEntityScope Scope,
+    DateTimeOffset From,
+    DateTimeOffset To,
+    string? EvaluationTimeZone = null);
+
+/// <summary>Preserved temporal family of a Calendar value.</summary>
+public enum CalendarTemporalKind
+{
+    Date,
+    FloatingDateTime,
+    UtcDateTime,
+    ZonedDateTime
+}
+
+/// <summary>A date or date-time that retains its original temporal family.</summary>
+public sealed record CalendarTemporalValue(
+    CalendarTemporalKind Kind,
+    string Value,
+    string? TimeZoneId = null)
+{
+    /// <summary>Returns the canonical ordinal key used for recurrence identity ordering and continuation.</summary>
+    public string GetCanonicalSortKey() => $"{Kind:D}|{TimeZoneId}|{Value}";
+}
+
+/// <summary>Original and effective timing for one derived Occurrence.</summary>
+public sealed record CalendarOccurrenceTiming(
+    CalendarTemporalValue SourceStart,
+    CalendarTemporalValue EffectiveStart,
+    CalendarTemporalValue? SourceEnd = null,
+    CalendarTemporalValue? EffectiveEnd = null,
+    string? SourceDuration = null,
+    string? EffectiveDuration = null,
+    CalendarTemporalValue? EvaluatedStartUtc = null,
+    CalendarTemporalValue? EvaluatedEndUtc = null,
+    string? EvaluationTimeZone = null);
+
+/// <summary>One immutable derived Occurrence over an authoritative resource snapshot.</summary>
+public sealed record CalendarOccurrenceSnapshot(
+    CalendarResourceSnapshot Snapshot,
+    CalendarTemporalValue RecurrenceIdentity,
+    CalendarOccurrenceTiming Timing);
+
+/// <summary>Truthful numeric observation when Occurrence evaluation exhausts a frozen budget.</summary>
+public sealed record CalendarOccurrenceQueryExecutionLimits(
+    int? ResourcesInspected = null,
+    int? OccurrenceCount = null,
+    int? ByteCount = null);
+
+/// <summary>Closed service outcomes for bounded Occurrence queries.</summary>
+public enum CalendarOccurrenceQueryCode
+{
+    Success,
+    InvalidInput,
+    UnsafeScope,
+    NotFound,
+    Ambiguous,
+    OutsideScope,
+    UnsupportedCapability,
+    ConcurrencyUnavailable,
+    LimitExhausted,
+    PayloadTooLarge,
+    UpstreamProtocolError,
+    TemporalUnresolved,
+    RecurrenceUnevaluable
+}
+
+/// <summary>Typed bounded Occurrence query outcome.</summary>
+public sealed record CalendarOccurrenceQueryResult(
+    CalendarOccurrenceQueryCode Code,
+    IReadOnlyList<CalendarOccurrenceSnapshot> Items,
+    IReadOnlyList<CalendarResourceDiagnostic> Diagnostics,
+    IReadOnlyList<CalendarDescriptor> AuthorizedCandidates,
+    CalendarOccurrenceQueryExecutionLimits? Limits = null)
+{
+    public static CalendarOccurrenceQueryResult Success(
+        IReadOnlyList<CalendarOccurrenceSnapshot> items,
+        IReadOnlyList<CalendarResourceDiagnostic>? diagnostics = null) =>
+        new(CalendarOccurrenceQueryCode.Success, items, diagnostics ?? [], []);
+
+    public static CalendarOccurrenceQueryResult Failure(
+        CalendarOccurrenceQueryCode code,
+        IReadOnlyList<CalendarDescriptor>? authorizedCandidates = null,
+        CalendarOccurrenceQueryExecutionLimits? limits = null) =>
+        new(code, [], [], authorizedCandidates ?? [], limits);
+}

--- a/src/DotnetAgents.CalDav.Core/Services/CalendarEntityQueryEngine.cs
+++ b/src/DotnetAgents.CalDav.Core/Services/CalendarEntityQueryEngine.cs
@@ -1,3 +1,4 @@
+using System.Xml;
 using DotnetAgents.CalDav.Core.Abstractions;
 using DotnetAgents.CalDav.Core.Configuration;
 using DotnetAgents.CalDav.Core.Internal.Ical;
@@ -110,7 +111,15 @@ internal sealed class CalendarEntityQueryEngine
         foreach (var candidate in candidates)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            var read = await ReadSnapshotAsync(candidate.Value, candidate.Key, cancellationToken);
+            CalendarResourceRead read;
+            try
+            {
+                read = await ReadSnapshotAsync(candidate.Value, candidate.Key, cancellationToken);
+            }
+            catch (Exception exception) when (exception is CalendarDiscoveryProtocolException or XmlException)
+            {
+                return CandidateFetchResult.Failure(CalendarEntityQueryCode.UpstreamProtocolError);
+            }
             if (read.Code == CalendarResourceReadCode.NotFound)
             {
                 AddDiagnostic(diagnostics, "resource_disappeared_during_query",

--- a/src/DotnetAgents.CalDav.Core/Services/CalendarOccurrenceQueryEngine.cs
+++ b/src/DotnetAgents.CalDav.Core/Services/CalendarOccurrenceQueryEngine.cs
@@ -1,0 +1,110 @@
+using DotnetAgents.CalDav.Core.Abstractions;
+using DotnetAgents.CalDav.Core.Configuration;
+using DotnetAgents.CalDav.Core.Internal.Ical;
+using DotnetAgents.CalDav.Core.Models;
+using NodaTime;
+
+namespace DotnetAgents.CalDav.Core.Services;
+
+/// <summary>Owns bounded Occurrence evaluation over authoritative local resource snapshots.</summary>
+internal sealed class CalendarOccurrenceQueryEngine
+{
+    private const int MaximumQueryOccurrences = 5000;
+    private readonly CalendarEntityQueryEngine _entityQueryEngine;
+
+    public CalendarOccurrenceQueryEngine(
+        ICalendarClient calendarClient,
+        CalDavOptions options,
+        Func<IReadOnlyList<CalendarDescriptor>, CalendarDiscoveryResult> applyScope,
+        Func<CalendarEntityKind, IReadOnlyList<CalendarDescriptor>, IReadOnlyList<CalendarDescriptor>, CalendarSelectionResult>
+            resolveDefault)
+    {
+        _entityQueryEngine = new CalendarEntityQueryEngine(calendarClient, options, applyScope, resolveDefault);
+    }
+
+    public async Task<CalendarOccurrenceQueryResult> QueryAsync(
+        CalendarOccurrenceQuery query,
+        CancellationToken cancellationToken)
+    {
+        if (!IsValid(query))
+            return CalendarOccurrenceQueryResult.Failure(CalendarOccurrenceQueryCode.InvalidInput);
+
+        var resources = await _entityQueryEngine.QueryAsync(
+            new CalendarEntityQuery(query.Scope, [CalendarEntityKind.Event, CalendarEntityKind.Todo]),
+            cancellationToken);
+        if (resources.Code != CalendarEntityQueryCode.Success)
+            return MapResourceFailure(resources);
+
+        var items = new List<CalendarOccurrenceSnapshot>();
+        var observedCount = 0;
+        foreach (var snapshot in resources.Items)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (CalendarOccurrenceEvaluator.HasInvalidComponentStructure(snapshot))
+            {
+                return CalendarOccurrenceQueryResult.Failure(
+                    CalendarOccurrenceQueryCode.RecurrenceUnevaluable);
+            }
+            if (snapshot.Projection.Kind == CalendarResourceProjectionKind.Opaque)
+                continue;
+            var evaluated = CalendarOccurrenceEvaluator.Evaluate(snapshot, query, cancellationToken);
+            observedCount += evaluated.ObservedOccurrenceCount;
+            if (evaluated.Code != CalendarOccurrenceQueryCode.Success)
+            {
+                return CalendarOccurrenceQueryResult.Failure(
+                    evaluated.Code,
+                    limits: evaluated.Code == CalendarOccurrenceQueryCode.LimitExhausted && observedCount > 0
+                        ? new CalendarOccurrenceQueryExecutionLimits(OccurrenceCount: observedCount)
+                        : null);
+            }
+            if (observedCount > MaximumQueryOccurrences)
+            {
+                return CalendarOccurrenceQueryResult.Failure(
+                    CalendarOccurrenceQueryCode.LimitExhausted,
+                    limits: new CalendarOccurrenceQueryExecutionLimits(OccurrenceCount: observedCount));
+            }
+            items.AddRange(evaluated.Items);
+        }
+
+        return CalendarOccurrenceQueryResult.Success(
+            items.OrderBy(item => item.Timing.EvaluatedStartUtc!.Value, StringComparer.Ordinal)
+                .ThenBy(item => item.Snapshot.CalendarHref, StringComparer.Ordinal)
+                .ThenBy(item => item.Snapshot.Projection.EntityUid, StringComparer.Ordinal)
+                .ThenBy(item => CalendarOccurrenceEvaluator.GetIdentitySortKey(item.RecurrenceIdentity), StringComparer.Ordinal)
+                .ToArray(),
+            resources.Diagnostics);
+    }
+
+    private static bool IsValid(CalendarOccurrenceQuery query) =>
+        query.From.Offset == TimeSpan.Zero
+        && query.To.Offset == TimeSpan.Zero
+        && query.To > query.From
+        && query.To - query.From <= TimeSpan.FromDays(366)
+        && (query.EvaluationTimeZone is null
+            || DateTimeZoneProviders.Tzdb.GetZoneOrNull(query.EvaluationTimeZone) is not null);
+
+    private static CalendarOccurrenceQueryResult MapResourceFailure(CalendarEntityQueryResult result) =>
+        CalendarOccurrenceQueryResult.Failure(
+            result.Code switch
+            {
+                CalendarEntityQueryCode.InvalidInput => CalendarOccurrenceQueryCode.InvalidInput,
+                CalendarEntityQueryCode.UnsafeScope => CalendarOccurrenceQueryCode.UnsafeScope,
+                CalendarEntityQueryCode.NotFound => CalendarOccurrenceQueryCode.NotFound,
+                CalendarEntityQueryCode.Ambiguous => CalendarOccurrenceQueryCode.Ambiguous,
+                CalendarEntityQueryCode.OutsideScope => CalendarOccurrenceQueryCode.OutsideScope,
+                CalendarEntityQueryCode.UnsupportedCapability => CalendarOccurrenceQueryCode.UnsupportedCapability,
+                CalendarEntityQueryCode.ConcurrencyUnavailable => CalendarOccurrenceQueryCode.ConcurrencyUnavailable,
+                CalendarEntityQueryCode.LimitExhausted => CalendarOccurrenceQueryCode.LimitExhausted,
+                CalendarEntityQueryCode.PayloadTooLarge => CalendarOccurrenceQueryCode.PayloadTooLarge,
+                CalendarEntityQueryCode.TemporalUnresolved => CalendarOccurrenceQueryCode.TemporalUnresolved,
+                CalendarEntityQueryCode.RecurrenceUnevaluable => CalendarOccurrenceQueryCode.RecurrenceUnevaluable,
+                _ => CalendarOccurrenceQueryCode.UpstreamProtocolError
+            },
+            result.AuthorizedCandidates,
+            result.Limits is null
+                ? null
+                : new CalendarOccurrenceQueryExecutionLimits(
+                    result.Limits.ResourcesInspected,
+                    result.Limits.OccurrenceCount,
+                    result.Limits.ByteCount));
+}

--- a/src/DotnetAgents.CalDav.Core/Services/CalendarService.cs
+++ b/src/DotnetAgents.CalDav.Core/Services/CalendarService.cs
@@ -81,6 +81,15 @@ internal sealed class CalendarService : ICalendarService
             ResolveDefaultCalendar).QueryAsync(query, cancellationToken);
 
     /// <inheritdoc />
+    public async Task<CalendarOccurrenceQueryResult> QueryOccurrencesAsync(
+        CalendarOccurrenceQuery query,
+        CancellationToken cancellationToken) => await new CalendarOccurrenceQueryEngine(
+            _calendarClient,
+            _options.Value,
+            ApplyScope,
+            ResolveDefaultCalendar).QueryAsync(query, cancellationToken);
+
+    /// <inheritdoc />
     public async Task<CalendarResourceRead> GetResourceAsync(string href, CancellationToken cancellationToken)
     {
         if (!TryGetCanonicalResourceUri(href, out var resourceUri))

--- a/src/DotnetAgents.CalDav.Mcp/Hosting/CalDavHostBuilder.cs
+++ b/src/DotnetAgents.CalDav.Mcp/Hosting/CalDavHostBuilder.cs
@@ -34,6 +34,7 @@ public sealed class CalDavHostBuilder
             .WithRequestFilters(filters => filters.AddCallToolFilter(StrictToolInputGuard.CallTool))
             .WithTools<CalendarTools>()
             .WithTools<CalendarEntityTools>()
+            .WithTools<CalendarOccurrenceTools>()
             .WithTools<CalendarResourceTools>()
             .WithTools<TaskListTools>()
             .WithTools<ChatTaskTools>();
@@ -68,6 +69,10 @@ public sealed class CalDavHostBuilder
             serviceProvider.GetRequiredService<DotnetAgents.CalDav.Core.Abstractions.ICalendarService>(),
             serviceProvider.GetRequiredService<CalendarEntityCursorProtector>(),
             serviceProvider.GetRequiredService<TimeProvider>()));
+        builder.Services.AddTransient(serviceProvider => new CalendarOccurrenceTools(
+            serviceProvider.GetRequiredService<DotnetAgents.CalDav.Core.Abstractions.ICalendarService>(),
+            serviceProvider.GetRequiredService<CalendarEntityCursorProtector>(),
+            serviceProvider.GetRequiredService<TimeProvider>()));
         builder.Services.AddTransient<TaskCompletion>();
 
         return builder;
@@ -81,6 +86,7 @@ public sealed class CalDavHostBuilder
         options.ToolCollection = new OrderedToolCollection(options.ToolCollection.ToArray());
         ConfigureTool(options.ToolCollection, "calendars.list");
         ConfigureTool(options.ToolCollection, "calendar_entities.query");
+        ConfigureTool(options.ToolCollection, "calendar_occurrences.query");
         ConfigureTool(options.ToolCollection, "calendar_resources.get");
         ConfigureTool(options.ToolCollection, "calendar_resources.exact_get");
     }

--- a/src/DotnetAgents.CalDav.Mcp/Hosting/OrderedToolCollection.cs
+++ b/src/DotnetAgents.CalDav.Mcp/Hosting/OrderedToolCollection.cs
@@ -9,14 +9,15 @@ internal sealed class OrderedToolCollection : McpServerPrimitiveCollection<McpSe
     {
         ["calendars.list"] = 0,
         ["calendar_entities.query"] = 1,
-        ["calendar_resources.get"] = 2,
-        ["calendar_resources.exact_get"] = 3,
-        ["list_task_lists"] = 4,
-        ["show_tasks"] = 5,
-        ["add_task"] = 6,
-        ["find_tasks"] = 7,
-        ["complete_task_by_summary"] = 8,
-        ["delete_task_by_summary"] = 9
+        ["calendar_occurrences.query"] = 2,
+        ["calendar_resources.get"] = 3,
+        ["calendar_resources.exact_get"] = 4,
+        ["list_task_lists"] = 5,
+        ["show_tasks"] = 6,
+        ["add_task"] = 7,
+        ["find_tasks"] = 8,
+        ["complete_task_by_summary"] = 9,
+        ["delete_task_by_summary"] = 10
     };
 
     public OrderedToolCollection(IEnumerable<McpServerTool> tools)

--- a/src/DotnetAgents.CalDav.Mcp/Hosting/StrictToolInputGuard.cs
+++ b/src/DotnetAgents.CalDav.Mcp/Hosting/StrictToolInputGuard.cs
@@ -35,13 +35,28 @@ internal static class StrictToolInputGuard
 
     internal static CallToolResult? Reject(string? toolName, StrictToolInputEvidence evidence)
     {
-        if (toolName != "calendar_entities.query")
-            return null;
-        if (evidence.ArgumentBytes > CalendarEntityTools.MaximumArgumentBytes)
-            return CalendarEntityTools.CreateInputGuardError(payloadTooLarge: true);
-        return evidence.HasDuplicateProperty
-            ? CalendarEntityTools.CreateInputGuardError(payloadTooLarge: false)
-            : null;
+        return toolName switch
+        {
+            "calendar_entities.query" => RejectEntity(evidence),
+            "calendar_occurrences.query" => RejectOccurrence(evidence),
+            _ => null
+        };
+    }
+
+    private static CallToolResult? RejectEntity(StrictToolInputEvidence evidence) =>
+        Reject(evidence, CalendarQueryToolSupport.MaximumArgumentBytes, CalendarEntityTools.CreateInputGuardError);
+
+    private static CallToolResult? RejectOccurrence(StrictToolInputEvidence evidence) =>
+        Reject(evidence, CalendarQueryToolSupport.MaximumArgumentBytes, CalendarOccurrenceTools.CreateInputGuardError);
+
+    private static CallToolResult? Reject(
+        StrictToolInputEvidence evidence,
+        int maximumArgumentBytes,
+        Func<bool, CallToolResult> createError)
+    {
+        if (evidence.ArgumentBytes > maximumArgumentBytes)
+            return createError(true);
+        return evidence.HasDuplicateProperty ? createError(false) : null;
     }
 
     internal static StrictToolInputEvidence InspectArguments(JsonNode? arguments)

--- a/src/DotnetAgents.CalDav.Mcp/Tools/CalendarEntityTools.cs
+++ b/src/DotnetAgents.CalDav.Mcp/Tools/CalendarEntityTools.cs
@@ -18,9 +18,9 @@ public sealed class CalendarEntityTools
 {
     private const int DefaultPageSize = 50;
     private const int MaximumPageSize = 200;
-    internal const int MaximumArgumentBytes = 256 * 1024;
-    internal const int MaximumHumanReadableBytes = 64 * 1024;
-    internal const int MaximumStructuredResultBytes = 4 * 1024 * 1024;
+    internal const int MaximumArgumentBytes = CalendarQueryToolSupport.MaximumArgumentBytes;
+    internal const int MaximumHumanReadableBytes = CalendarQueryToolSupport.MaximumHumanReadableBytes;
+    internal const int MaximumStructuredResultBytes = CalendarQueryToolSupport.MaximumStructuredResultBytes;
     private readonly ICalendarService _calendarService;
     private readonly CalendarEntityCursorProtector _cursorProtector;
     private readonly TimeProvider _timeProvider;
@@ -386,56 +386,11 @@ public sealed class CalendarEntityTools
         out CalendarEntityQuery query)
     {
         query = null!;
-        if (!TryCreateScope(scope, out var domainScope)
+        if (!CalendarQueryToolSupport.TryCreateScope(scope, out var domainScope)
             || !TryCreateKinds(entityKinds, out var domainKinds)
             || !TryCreateWindow(from, to, out var domainFrom, out var domainTo))
             return false;
         query = new CalendarEntityQuery(domainScope, domainKinds, domainFrom, domainTo);
-        return true;
-    }
-
-    private static bool TryCreateScope(CalendarEntityScopeArgument scope, out CalendarEntityScope domainScope)
-    {
-        domainScope = null!;
-        if (scope.Mode == "default" && scope.Calendar is null)
-        {
-            domainScope = CalendarEntityScope.Default;
-            return true;
-        }
-        if (scope.Mode == "all" && scope.Calendar is null)
-        {
-            domainScope = CalendarEntityScope.All;
-            return true;
-        }
-        if (scope.Mode != "selected" || scope.Calendar is null)
-            return false;
-        return scope.Calendar.By switch
-        {
-            "name" => TryCreateNameScope(scope.Calendar, out domainScope),
-            "href" => TryCreateHrefScope(scope.Calendar, out domainScope),
-            _ => false
-        };
-    }
-
-    private static bool TryCreateNameScope(
-        CalendarEntityReferenceArgument reference,
-        out CalendarEntityScope domainScope)
-    {
-        domainScope = null!;
-        if (reference.Name is not { Length: > 0 } name || name != name.Trim() || reference.Href is not null)
-            return false;
-        domainScope = CalendarEntityScope.Selected(new CalendarReference(Name: name));
-        return true;
-    }
-
-    private static bool TryCreateHrefScope(
-        CalendarEntityReferenceArgument reference,
-        out CalendarEntityScope domainScope)
-    {
-        domainScope = null!;
-        if (reference.Href is not { Length: > 0 } href || reference.Name is not null)
-            return false;
-        domainScope = CalendarEntityScope.Selected(new CalendarReference(Href: href));
         return true;
     }
 
@@ -468,55 +423,8 @@ public sealed class CalendarEntityTools
         domainTo = null;
         if (from is null || to is null)
             return from is null && to is null;
-        return TryParseUtc(from, out domainFrom) && TryParseUtc(to, out domainTo);
-    }
-
-    private static bool TryParseUtc(CalendarEntityUtcArgument argument, out DateTimeOffset? value)
-    {
-        value = null;
-        if (argument.Kind != "utcDateTime")
-            return false;
-        var lexical = argument.Value;
-        var hasFraction = lexical.Length > 20 && lexical.Length >= 22 && lexical[19] == '.';
-        var secondLexical = hasFraction ? lexical[..19] + "Z" : lexical;
-        if (!DateTimeOffset.TryParseExact(
-                secondLexical,
-                "yyyy-MM-dd'T'HH:mm:ss'Z'",
-                CultureInfo.InvariantCulture,
-                DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
-                out var parsed))
-            return false;
-        if (!hasFraction)
-        {
-            value = parsed;
-            return true;
-        }
-        var fraction = lexical.AsSpan(20, lexical.Length - 21);
-        if (lexical[^1] != 'Z' || fraction.IsEmpty || !fraction.ToString().All(char.IsAsciiDigit))
-            return false;
-        return TryApplyFraction(parsed, fraction, out value);
-    }
-
-    private static bool TryApplyFraction(
-        DateTimeOffset parsed,
-        ReadOnlySpan<char> fraction,
-        out DateTimeOffset? value)
-    {
-        value = null;
-        var representedDigits = Math.Min(7, fraction.Length);
-        var ticksText = fraction[..representedDigits].ToString().PadRight(7, '0');
-        var ticks = int.Parse(ticksText, CultureInfo.InvariantCulture);
-        if (fraction[representedDigits..].ContainsAnyExcept('0'))
-            ticks++;
-        if (ticks == TimeSpan.TicksPerSecond)
-        {
-            if (parsed.Ticks > DateTimeOffset.MaxValue.Ticks - TimeSpan.TicksPerSecond)
-                return false;
-            parsed = parsed.AddSeconds(1);
-            ticks = 0;
-        }
-        value = parsed.AddTicks(ticks);
-        return true;
+        return CalendarQueryToolSupport.TryParseUtc(from, out domainFrom)
+            && CalendarQueryToolSupport.TryParseUtc(to, out domainTo);
     }
 
     private static int MeasureArguments(
@@ -526,17 +434,9 @@ public sealed class CalendarEntityTools
         CalendarEntityUtcArgument? to,
         int? pageSize,
         string? cursor,
-        IDictionary<string, JsonElement>? rawArguments) => rawArguments is { } raw
-            ? JsonSerializer.SerializeToUtf8Bytes(raw).Length
-            : JsonSerializer.SerializeToUtf8Bytes(new
-            {
-                scope,
-                entityKinds,
-                from,
-                to,
-                pageSize,
-                cursor
-            }).Length;
+        IDictionary<string, JsonElement>? rawArguments) => CalendarQueryToolSupport.MeasureArguments(
+            rawArguments,
+            new { scope, entityKinds, from, to, pageSize, cursor });
 
     private static bool TryDeserializeRawArguments(
         IDictionary<string, JsonElement>? arguments,
@@ -589,96 +489,28 @@ public sealed class CalendarEntityTools
         var allowed = new[] { "scope", "entityKinds", "from", "to", "pageSize", "cursor" };
         if (arguments.Keys.Any(key => !allowed.Contains(key, StringComparer.Ordinal)))
             return false;
-        return (!arguments.TryGetValue("scope", out var scope) || HasScopeShape(scope))
-            && (!arguments.TryGetValue("from", out var from) || HasTemporalShape(from))
-            && (!arguments.TryGetValue("to", out var to) || HasTemporalShape(to));
+        return (!arguments.TryGetValue("scope", out var scope) || CalendarQueryToolSupport.HasScopeShape(scope))
+            && (!arguments.TryGetValue("from", out var from) || CalendarQueryToolSupport.HasTemporalShape(from))
+            && (!arguments.TryGetValue("to", out var to) || CalendarQueryToolSupport.HasTemporalShape(to));
     }
 
-    private static bool HasScopeShape(JsonElement scope)
-    {
-        if (!TryGetUniqueProperties(scope, out var properties)
-            || !properties.TryGetValue("mode", out var modeElement)
-            || modeElement.ValueKind != JsonValueKind.String)
-            return false;
-        var mode = modeElement.GetString();
-        if (mode is "default" or "all")
-            return properties.Count == 1;
-        return mode == "selected"
-            && properties.Count == 2
-            && properties.TryGetValue("calendar", out var calendar)
-            && HasCalendarReferenceShape(calendar);
-    }
+    internal static int MeasureResult(CallToolResult result) => CalendarQueryToolSupport.MeasureResult(result);
 
-    private static bool HasCalendarReferenceShape(JsonElement calendar)
-    {
-        if (!TryGetUniqueProperties(calendar, out var properties)
-            || !properties.TryGetValue("by", out var byElement)
-            || byElement.ValueKind != JsonValueKind.String
-            || properties.Count != 2)
-            return false;
-        var by = byElement.GetString();
-        return by == "name" && properties.ContainsKey("name")
-            || by == "href" && properties.ContainsKey("href");
-    }
+    internal static int MeasureHumanReadableResult(CallToolResult result) =>
+        CalendarQueryToolSupport.MeasureHumanReadableResult(result);
 
-    private static bool HasTemporalShape(JsonElement temporal) =>
-        TryGetUniqueProperties(temporal, out var properties)
-        && properties.Count == 2
-        && properties.ContainsKey("kind")
-        && properties.ContainsKey("value");
+    internal static CallToolResult EnsureBoundedResult(CallToolResult result) =>
+        CalendarQueryToolSupport.EnsureBoundedResult(result, CreatePayloadLimitError);
 
-    private static bool TryGetUniqueProperties(
-        JsonElement element,
-        out Dictionary<string, JsonElement> properties)
-    {
-        properties = new Dictionary<string, JsonElement>(StringComparer.Ordinal);
-        if (element.ValueKind != JsonValueKind.Object)
-            return false;
-        foreach (var property in element.EnumerateObject())
-        {
-            if (!properties.TryAdd(property.Name, property.Value))
-                return false;
-        }
-        return true;
-    }
-
-    internal static int MeasureResult(CallToolResult result) => JsonSerializer.SerializeToUtf8Bytes(result).Length;
-
-    internal static int MeasureHumanReadableResult(CallToolResult result)
-    {
-        var diagnostics = result.StructuredContent is { ValueKind: JsonValueKind.Object } structured
-            && structured.TryGetProperty("diagnostics", out var value)
-            ? value
-            : JsonSerializer.SerializeToElement(Array.Empty<object>());
-        return JsonSerializer.SerializeToUtf8Bytes(new CalendarHumanReadableBudget(
-            result.Content.OfType<TextContentBlock>().Select(block => block.Text).ToArray(),
-            diagnostics)).Length;
-    }
-
-    internal static CallToolResult EnsureBoundedResult(CallToolResult result)
-    {
-        var humanReadableBytes = MeasureHumanReadableResult(result);
-        if (humanReadableBytes > MaximumHumanReadableBytes)
-        {
-            return Error(
-                "payload_too_large",
-                "limitsAndAdmission",
-                "The Calendar Entity query human-readable result exceeds the safe payload limit.",
-                false,
-                "admissionAndPayload",
-                new CalendarEntityExecutionLimits(ByteCount: humanReadableBytes));
-        }
-        var observedBytes = MeasureResult(result);
-        return observedBytes <= MaximumStructuredResultBytes
-            ? result
-            : Error(
-                "payload_too_large",
-                "limitsAndAdmission",
-                "The Calendar Entity query result exceeds the safe payload limit.",
-                false,
-                "admissionAndPayload",
-                new CalendarEntityExecutionLimits(ByteCount: observedBytes));
-    }
+    private static CallToolResult CreatePayloadLimitError(int byteCount, bool humanReadable) => Error(
+        "payload_too_large",
+        "limitsAndAdmission",
+        humanReadable
+            ? "The Calendar Entity query human-readable result exceeds the safe payload limit."
+            : "The Calendar Entity query result exceeds the safe payload limit.",
+        false,
+        "admissionAndPayload",
+        new CalendarEntityExecutionLimits(ByteCount: byteCount));
 
     private static string CreateQueryContext(CalendarEntityQuery query, int pageSize)
     {
@@ -712,10 +544,6 @@ public sealed class CalendarEntityTools
         CalendarEntityUtcArgument? To,
         int? PageSize,
         string? Cursor);
-
-    private sealed record CalendarHumanReadableBudget(
-        IReadOnlyList<string> Text,
-        JsonElement Diagnostics);
 
     private sealed class CalendarEntityDeadlineException : Exception
     {

--- a/src/DotnetAgents.CalDav.Mcp/Tools/CalendarOccurrenceTools.cs
+++ b/src/DotnetAgents.CalDav.Mcp/Tools/CalendarOccurrenceTools.cs
@@ -1,0 +1,611 @@
+using System.ComponentModel;
+using System.Globalization;
+using System.Net;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Xml;
+using DotnetAgents.CalDav.Core.Abstractions;
+using DotnetAgents.CalDav.Core.Internal;
+using DotnetAgents.CalDav.Core.Models;
+using Microsoft.Extensions.DependencyInjection;
+using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
+
+namespace DotnetAgents.CalDav.Mcp.Tools;
+
+/// <summary>Bounded derived Calendar Occurrence queries.</summary>
+[McpServerToolType]
+public sealed class CalendarOccurrenceTools
+{
+    private const int DefaultPageSize = 50;
+    private const int MaximumPageSize = 200;
+    internal const int MaximumArgumentBytes = CalendarQueryToolSupport.MaximumArgumentBytes;
+    private readonly ICalendarService _calendarService;
+    private readonly CalendarEntityCursorProtector _cursorProtector;
+    private readonly TimeProvider _timeProvider;
+
+    public CalendarOccurrenceTools(IServiceProvider services)
+        : this(
+            services.GetRequiredService<ICalendarService>(),
+            services.GetRequiredService<CalendarEntityCursorProtector>(),
+            services.GetRequiredService<TimeProvider>())
+    {
+    }
+
+    internal CalendarOccurrenceTools(
+        ICalendarService calendarService,
+        CalendarEntityCursorProtector cursorProtector,
+        TimeProvider timeProvider)
+    {
+        _calendarService = calendarService;
+        _cursorProtector = cursorProtector;
+        _timeProvider = timeProvider;
+    }
+
+    /// <summary>Queries derived Event and To-do Occurrences.</summary>
+    [McpServerTool(
+        Name = "calendar_occurrences.query",
+        ReadOnly = true,
+        Destructive = false,
+        Idempotent = true,
+        OpenWorld = true,
+        UseStructuredContent = true,
+        OutputSchemaType = typeof(CalendarOccurrenceQuerySuccessResult)),
+     Description("Query bounded derived occurrences over a half-open UTC range.")]
+    public Task<CallToolResult> QueryAsync(
+        RequestContext<CallToolRequestParams> requestContext,
+        CancellationToken cancellationToken) =>
+        QueryRawAsync(requestContext.Params?.Arguments, cancellationToken);
+
+    internal async Task<CallToolResult> QueryRawAsync(
+        IDictionary<string, JsonElement>? arguments,
+        CancellationToken cancellationToken)
+    {
+        if (arguments is not null && JsonSerializer.SerializeToUtf8Bytes(arguments).Length > MaximumArgumentBytes)
+            return EnsureBoundedResult(CreateInputGuardError(payloadTooLarge: true));
+        if (!TryDeserializeRawArguments(arguments, out var parsed))
+            return EnsureBoundedResult(CreateInputGuardError(payloadTooLarge: false));
+        return await QueryCoreAsync(
+            parsed.Scope,
+            parsed.From,
+            parsed.To,
+            cancellationToken,
+            parsed.EvaluationTimeZone,
+            parsed.PageSize,
+            parsed.Cursor,
+            arguments);
+    }
+
+    internal static CallToolResult CreateInputGuardError(bool payloadTooLarge) => payloadTooLarge
+        ? Error("payload_too_large", "limitsAndAdmission", "The Occurrence query arguments exceed the safe payload limit.", false, "admissionAndPayload")
+        : Error("invalid_input", "input", "The Occurrence query input is invalid.", false, "schemaLexicalDiscriminator");
+
+    internal async Task<CallToolResult> QueryCoreAsync(
+        CalendarEntityScopeArgument scope,
+        CalendarEntityUtcArgument from,
+        CalendarEntityUtcArgument to,
+        CancellationToken cancellationToken,
+        string? evaluationTimeZone = null,
+        int? pageSize = null,
+        string? cursor = null,
+        IDictionary<string, JsonElement>? rawArguments = null)
+    {
+        if (MeasureArguments(scope, from, to, evaluationTimeZone, pageSize, cursor, rawArguments) > MaximumArgumentBytes)
+            return EnsureBoundedResult(CreateInputGuardError(payloadTooLarge: true));
+        if (!TryPrepareQuery(
+                scope, from, to, evaluationTimeZone, pageSize, cursor, rawArguments, out var query, out var effectivePageSize))
+            return EnsureBoundedResult(CreateInputGuardError(payloadTooLarge: false));
+
+        var queryContext = CreateQueryContext(query, effectivePageSize);
+        CalendarOccurrenceContinuation? continuation = null;
+        if (cursor is not null && !TryDecodeCursor(cursor, queryContext, out continuation))
+            return EnsureBoundedResult(Error("invalid_input", "input", "The continuation cursor is invalid or expired.", false, "schemaLexicalDiscriminator"));
+
+        return EnsureBoundedResult(await ExecuteQuerySafelyAsync(
+            query, continuation, queryContext, effectivePageSize, cancellationToken));
+    }
+
+    private async Task<CallToolResult> ExecuteQuerySafelyAsync(
+        CalendarOccurrenceQuery query,
+        CalendarOccurrenceContinuation? continuation,
+        string queryContext,
+        int pageSize,
+        CancellationToken cancellationToken)
+    {
+        var deadlineAt = _timeProvider.GetUtcNow().AddSeconds(30);
+        using var deadline = new CancellationTokenSource(TimeSpan.FromSeconds(30), _timeProvider);
+        using var linked = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, deadline.Token);
+        try
+        {
+            var result = await _calendarService.QueryOccurrencesAsync(query, linked.Token);
+            ThrowIfDeadlineExpired(deadlineAt, linked.Token);
+            return result.Code == CalendarOccurrenceQueryCode.Success
+                ? CreatePage(result, continuation, queryContext, pageSize, deadlineAt, linked.Token)
+                : MapQueryFailure(result);
+        }
+        catch (CalendarDiscoveryLimitException exception)
+        {
+            return Error("limit_exhausted", "limitsAndAdmission", "The Occurrence query exceeded the Calendar limit.", false,
+                "admissionAndPayload", new CalendarEntityExecutionLimits(CalendarCount: exception.CalendarCount));
+        }
+        catch (HttpRequestException exception)
+        {
+            return MapHttpFailure(exception.StatusCode);
+        }
+        catch (OperationCanceledException) when (deadline.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+        {
+            return DeadlineError();
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            return Error("upstream_unavailable", "upstream", "The Occurrence query is temporarily unavailable.", true, "execution");
+        }
+        catch (TimeoutException)
+        {
+            return Error("upstream_unavailable", "upstream", "The Occurrence query is temporarily unavailable.", true, "execution");
+        }
+        catch (XmlException)
+        {
+            return SelectionProtocolError();
+        }
+        catch (CalendarDiscoveryProtocolException)
+        {
+            return SelectionProtocolError();
+        }
+        catch (CalendarDiscoveryUnsupportedCapabilityException)
+        {
+            return Error("unsupported_capability", "capabilityAndProjection",
+                "The server does not support the required Calendar query capability.", false,
+                "selectionDiscoveryCapability");
+        }
+        catch (CalendarOccurrenceDeadlineException)
+        {
+            return DeadlineError();
+        }
+    }
+
+    private CallToolResult CreatePage(
+        CalendarOccurrenceQueryResult result,
+        CalendarOccurrenceContinuation? continuation,
+        string queryContext,
+        int pageSize,
+        DateTimeOffset deadlineAt,
+        CancellationToken cancellationToken)
+    {
+        var eligible = result.Items.Where(item => continuation is null || IsAfter(item, continuation.Value)).ToArray();
+        var page = new List<CalendarOccurrenceSnapshotResult>(Math.Min(pageSize, eligible.Length));
+        for (var index = 0; index < eligible.Length && page.Count < pageSize; index++)
+        {
+            ThrowIfDeadlineExpired(deadlineAt, cancellationToken);
+            page.Add(CalendarOccurrenceSnapshotResult.FromSnapshot(eligible[index]));
+            var hasMore = index + 1 < eligible.Length;
+            if (!TryCreateCursor(hasMore, queryContext, eligible[index], out var candidateCursor))
+                return CursorPayloadError();
+            var candidate = CreateSuccess(page, result.Diagnostics, hasMore ? candidateCursor : null);
+            if (CalendarQueryToolSupport.MeasureResult(candidate)
+                <= CalendarQueryToolSupport.MaximumStructuredResultBytes)
+                continue;
+
+            page.RemoveAt(page.Count - 1);
+            if (page.Count == 0)
+                return Error("payload_too_large", "limitsAndAdmission", "One Occurrence cannot fit in a result page.", false, "admissionAndPayload");
+            break;
+        }
+
+        ThrowIfDeadlineExpired(deadlineAt, cancellationToken);
+        string? nextCursor = null;
+        if (page.Count < eligible.Length && !TryCreateCursor(true, queryContext, eligible[page.Count - 1], out nextCursor))
+            return CursorPayloadError();
+        return CreateSuccess(page, result.Diagnostics, nextCursor);
+    }
+
+    private bool TryCreateCursor(
+        bool required,
+        string queryContext,
+        CalendarOccurrenceSnapshot item,
+        out string? cursor)
+    {
+        cursor = null;
+        if (!required)
+            return true;
+        var continuation = CalendarOccurrenceContinuation.FromSnapshot(item);
+        return _cursorProtector.TryProtect(
+            queryContext,
+            continuation.EffectiveStartUtc,
+            JsonSerializer.Serialize(new CalendarOccurrenceContinuationTail(
+                continuation.CalendarHref,
+                continuation.EntityUid,
+                continuation.RecurrenceIdentity)),
+            out cursor);
+    }
+
+    private bool TryDecodeCursor(
+        string cursor,
+        string queryContext,
+        out CalendarOccurrenceContinuation? continuation)
+    {
+        continuation = null;
+        if (!_cursorProtector.TryUnprotect(cursor, queryContext, out var decoded, out _))
+            return false;
+        try
+        {
+            var tail = JsonSerializer.Deserialize<CalendarOccurrenceContinuationTail>(decoded.ResourceHref);
+            if (tail is null || string.IsNullOrEmpty(decoded.CalendarHref)
+                || string.IsNullOrEmpty(tail.CalendarHref)
+                || string.IsNullOrEmpty(tail.EntityUid)
+                || string.IsNullOrEmpty(tail.RecurrenceIdentity))
+                return false;
+            continuation = new CalendarOccurrenceContinuation(
+                decoded.CalendarHref, tail.CalendarHref, tail.EntityUid, tail.RecurrenceIdentity);
+            return true;
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
+    }
+
+    private void ThrowIfDeadlineExpired(DateTimeOffset deadlineAt, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        if (_timeProvider.GetUtcNow() >= deadlineAt)
+            throw new CalendarOccurrenceDeadlineException();
+    }
+
+    private static bool IsAfter(CalendarOccurrenceSnapshot item, CalendarOccurrenceContinuation continuation)
+    {
+        var current = CalendarOccurrenceContinuation.FromSnapshot(item);
+        return Compare(current, continuation) > 0;
+    }
+
+    private static int Compare(CalendarOccurrenceContinuation left, CalendarOccurrenceContinuation right)
+    {
+        var effective = string.CompareOrdinal(left.EffectiveStartUtc, right.EffectiveStartUtc);
+        if (effective != 0)
+            return effective;
+        var calendar = string.CompareOrdinal(left.CalendarHref, right.CalendarHref);
+        if (calendar != 0)
+            return calendar;
+        var uid = string.CompareOrdinal(left.EntityUid, right.EntityUid);
+        return uid != 0 ? uid : string.CompareOrdinal(left.RecurrenceIdentity, right.RecurrenceIdentity);
+    }
+
+    private static CallToolResult CreateSuccess(
+        IReadOnlyList<CalendarOccurrenceSnapshotResult> items,
+        IReadOnlyList<CalendarResourceDiagnostic> diagnostics,
+        string? nextCursor) => new()
+        {
+            IsError = false,
+            StructuredContent = JsonSerializer.SerializeToElement(new CalendarOccurrenceQuerySuccessResult(
+                "success",
+                items,
+                diagnostics.Select(CalendarDiagnosticResult.FromResourceDiagnostic).ToArray(),
+                new CalendarPagination("non_snapshot", nextCursor))),
+            Content = [new TextContentBlock { Text = "Occurrence query completed." }]
+        };
+
+    private static CallToolResult MapQueryFailure(CalendarOccurrenceQueryResult result)
+    {
+        var candidates = result.AuthorizedCandidates.Select(CalendarAuthorizedCandidateResult.FromDescriptor).ToArray();
+        return result.Code switch
+        {
+            CalendarOccurrenceQueryCode.InvalidInput => Error("invalid_input", "input", "The Occurrence query input is invalid.", false, "schemaLexicalDiscriminator"),
+            CalendarOccurrenceQueryCode.UnsafeScope => Error("invalid_input", "input", "The Occurrence query Calendar href is unsafe.", false, "originScopeAuthorization"),
+            CalendarOccurrenceQueryCode.NotFound => Error("not_found", "selection", "No matching authorized Calendar was found.", false, "selectionDiscoveryCapability", candidates: candidates),
+            CalendarOccurrenceQueryCode.Ambiguous => Error("ambiguous", "selection", "The Calendar selector matched more than one authorized Calendar.", false, "selectionDiscoveryCapability", candidates: candidates),
+            CalendarOccurrenceQueryCode.OutsideScope => Error("outside_scope", "selection", "The selected Calendar is outside the configured Calendar Scope.", false, "originScopeAuthorization", candidates: candidates),
+            CalendarOccurrenceQueryCode.UnsupportedCapability => Error("unsupported_capability", "capabilityAndProjection", "The server does not support the required Calendar query capability.", false, "selectionDiscoveryCapability"),
+            CalendarOccurrenceQueryCode.ConcurrencyUnavailable => Error("concurrency_unavailable", "state", "A query candidate did not provide a strong Entity Tag.", false, "targetRevision"),
+            CalendarOccurrenceQueryCode.LimitExhausted => Error("limit_exhausted", "limitsAndAdmission", "The Occurrence query exhausted its execution budget.", false, "execution", ToLimits(result.Limits)),
+            CalendarOccurrenceQueryCode.PayloadTooLarge => Error("payload_too_large", "limitsAndAdmission", "A Calendar Object Resource exceeds the safe payload limit.", false, "admissionAndPayload", ToLimits(result.Limits)),
+            CalendarOccurrenceQueryCode.TemporalUnresolved => Error("temporal_unresolved", "capabilityAndProjection", "Temporal evaluation could not be resolved.", false, "completeResourceSemantics"),
+            CalendarOccurrenceQueryCode.RecurrenceUnevaluable => Error("recurrence_unevaluable", "capabilityAndProjection", "The Recurrence Set could not be evaluated.", false, "completeResourceSemantics"),
+            _ => ProtocolError()
+        };
+    }
+
+    private static CalendarEntityExecutionLimits? ToLimits(CalendarOccurrenceQueryExecutionLimits? limits) => limits is null
+        ? null
+        : new CalendarEntityExecutionLimits(limits.ResourcesInspected, OccurrenceCount: limits.OccurrenceCount, ByteCount: limits.ByteCount);
+
+    private static CallToolResult MapHttpFailure(HttpStatusCode? statusCode) => statusCode switch
+    {
+        HttpStatusCode.Unauthorized => Error("upstream_unauthorized", "upstream", "The Occurrence query was not authorized.", false, "execution"),
+        HttpStatusCode.Forbidden => Error("upstream_forbidden", "upstream", "The Occurrence query was forbidden.", false, "execution"),
+        HttpStatusCode.TooManyRequests => Error("upstream_rate_limited", "upstream", "The Occurrence query is rate limited.", true, "execution"),
+        HttpStatusCode.MethodNotAllowed or HttpStatusCode.NotImplemented => Error("unsupported_capability", "capabilityAndProjection", "The server does not support the required Calendar query capability.", false, "selectionDiscoveryCapability"),
+        HttpStatusCode.NotFound => SelectionProtocolError(),
+        HttpStatusCode.RequestEntityTooLarge => Error("payload_too_large", "limitsAndAdmission", "The Occurrence query response is too large.", false, "admissionAndPayload"),
+        HttpStatusCode.Conflict or HttpStatusCode.PreconditionFailed => Error("conflict", "state", "The Occurrence query encountered an upstream state conflict.", false, "execution"),
+        HttpStatusCode.RequestTimeout => Error("upstream_unavailable", "upstream", "The Occurrence query is temporarily unavailable.", true, "execution"),
+        HttpStatusCode.InsufficientStorage => Error("upstream_unavailable", "upstream", "The Occurrence query is unavailable.", false, "execution"),
+        null => Error("upstream_unavailable", "upstream", "The Occurrence query is temporarily unavailable.", true, "execution"),
+        >= HttpStatusCode.InternalServerError => Error("upstream_unavailable", "upstream", "The Occurrence query is temporarily unavailable.", true, "execution"),
+        _ => ProtocolError()
+    };
+
+    private static CallToolResult ProtocolError() => Error(
+        "upstream_protocol_error", "upstream", "The Occurrence query returned an invalid response.", false, "execution");
+
+    private static CallToolResult SelectionProtocolError() => Error(
+        "upstream_protocol_error", "upstream", "Calendar discovery returned an invalid response.", false,
+        "selectionDiscoveryCapability");
+
+    private static CallToolResult DeadlineError() => Error(
+        "limit_exhausted", "limitsAndAdmission", "The Occurrence query exhausted the elapsed_time execution budget.", false, "execution");
+
+    private static CallToolResult CursorPayloadError() => Error(
+        "payload_too_large", "limitsAndAdmission", "The continuation cursor exceeds the safe payload limit.", false, "admissionAndPayload");
+
+    private static CallToolResult Error(
+        string code,
+        string category,
+        string message,
+        bool retryable,
+        string phase,
+        CalendarEntityExecutionLimits? limits = null,
+        IReadOnlyList<CalendarAuthorizedCandidateResult>? candidates = null) => new()
+        {
+            IsError = true,
+            StructuredContent = JsonSerializer.SerializeToElement(new CalendarOccurrenceQueryErrorResult(
+                code, category, message, retryable, phase, limits,
+                candidates is { Count: > 0 } ? candidates : null)),
+            Content = [new TextContentBlock { Text = "Occurrence query failed." }]
+        };
+
+    private static CallToolResult EnsureBoundedResult(CallToolResult result) =>
+        CalendarQueryToolSupport.EnsureBoundedResult(result, CreatePayloadLimitError);
+
+    private static CallToolResult CreatePayloadLimitError(int byteCount, bool humanReadable) => Error(
+        "payload_too_large",
+        "limitsAndAdmission",
+        humanReadable
+            ? "The Occurrence query human-readable result exceeds the safe payload limit."
+            : "The Occurrence query result exceeds the safe payload limit.",
+        false,
+        "admissionAndPayload",
+        new CalendarEntityExecutionLimits(ByteCount: byteCount));
+
+    private static bool TryPrepareQuery(
+        CalendarEntityScopeArgument scope,
+        CalendarEntityUtcArgument from,
+        CalendarEntityUtcArgument to,
+        string? evaluationTimeZone,
+        int? pageSize,
+        string? cursor,
+        IDictionary<string, JsonElement>? rawArguments,
+        out CalendarOccurrenceQuery query,
+        out int effectivePageSize)
+    {
+        query = null!;
+        effectivePageSize = pageSize ?? DefaultPageSize;
+        if (!HasFrozenRawShape(rawArguments)
+            || !HasValidPagination(effectivePageSize, cursor)
+            || !TryCreateDomainQuery(scope, from, to, evaluationTimeZone, out query))
+            return false;
+        return true;
+    }
+
+    private static bool HasValidPagination(int pageSize, string? cursor) =>
+        pageSize is >= 1 and <= MaximumPageSize
+        && cursor is not { Length: > CalendarEntityCursorProtector.MaximumCursorCharacters };
+
+    private static bool TryCreateDomainQuery(
+        CalendarEntityScopeArgument scope,
+        CalendarEntityUtcArgument from,
+        CalendarEntityUtcArgument to,
+        string? evaluationTimeZone,
+        out CalendarOccurrenceQuery query)
+    {
+        query = null!;
+        if (!CalendarQueryToolSupport.TryCreateScope(scope, out var domainScope)
+            || !CalendarQueryToolSupport.TryParseUtc(from, out var domainFrom)
+            || !CalendarQueryToolSupport.TryParseUtc(to, out var domainTo)
+            || domainFrom is null || domainTo is null
+            || evaluationTimeZone is { Length: 0 })
+            return false;
+        query = new CalendarOccurrenceQuery(domainScope, domainFrom.Value, domainTo.Value, evaluationTimeZone);
+        return true;
+    }
+
+    private static bool TryDeserializeRawArguments(
+        IDictionary<string, JsonElement>? arguments,
+        out CalendarOccurrenceRawArguments parsed)
+    {
+        parsed = null!;
+        if (!TryGetRequiredArguments(arguments, out var scopeElement, out var fromElement, out var toElement))
+            return false;
+        var validArguments = arguments!;
+        try
+        {
+            var scope = scopeElement.Deserialize<CalendarEntityScopeArgument>();
+            var from = fromElement.Deserialize<CalendarEntityUtcArgument>();
+            var to = toElement.Deserialize<CalendarEntityUtcArgument>();
+            if (scope is null || from is null || to is null)
+                return false;
+            parsed = new CalendarOccurrenceRawArguments(
+                scope,
+                from,
+                to,
+                DeserializeOptional<string>(validArguments, "evaluationTimeZone"),
+                DeserializeOptional<int?>(validArguments, "pageSize"),
+                DeserializeOptional<string>(validArguments, "cursor"));
+            return !HasAnyPresentNull(validArguments, "evaluationTimeZone", "pageSize", "cursor");
+        }
+        catch (Exception exception) when (exception is JsonException or InvalidOperationException)
+        {
+            return false;
+        }
+    }
+
+    private static bool TryGetRequiredArguments(
+        IDictionary<string, JsonElement>? arguments,
+        out JsonElement scope,
+        out JsonElement from,
+        out JsonElement to)
+    {
+        scope = default;
+        from = default;
+        to = default;
+        return arguments is not null
+            && arguments.TryGetValue("scope", out scope)
+            && arguments.TryGetValue("from", out from)
+            && arguments.TryGetValue("to", out to)
+            && HasFrozenRawShape(arguments);
+    }
+
+    private static bool HasFrozenRawShape(IDictionary<string, JsonElement>? arguments)
+    {
+        if (arguments is null)
+            return true;
+        var allowed = new[] { "scope", "from", "to", "evaluationTimeZone", "pageSize", "cursor" };
+        return !arguments.Keys.Any(key => !allowed.Contains(key, StringComparer.Ordinal))
+            && (!arguments.TryGetValue("scope", out var scope) || CalendarQueryToolSupport.HasScopeShape(scope))
+            && (!arguments.TryGetValue("from", out var from) || CalendarQueryToolSupport.HasTemporalShape(from))
+            && (!arguments.TryGetValue("to", out var to) || CalendarQueryToolSupport.HasTemporalShape(to));
+    }
+
+    private static T? DeserializeOptional<T>(IDictionary<string, JsonElement> arguments, string name) =>
+        arguments.TryGetValue(name, out var element) ? element.Deserialize<T>() : default;
+
+    private static bool HasPresentNull(IDictionary<string, JsonElement> arguments, string name) =>
+        arguments.TryGetValue(name, out var element) && element.ValueKind == JsonValueKind.Null;
+
+    private static bool HasAnyPresentNull(
+        IDictionary<string, JsonElement> arguments,
+        params string[] names) => names.Any(name => HasPresentNull(arguments, name));
+
+    private static int MeasureArguments(
+        CalendarEntityScopeArgument scope,
+        CalendarEntityUtcArgument from,
+        CalendarEntityUtcArgument to,
+        string? evaluationTimeZone,
+        int? pageSize,
+        string? cursor,
+        IDictionary<string, JsonElement>? rawArguments) => CalendarQueryToolSupport.MeasureArguments(
+            rawArguments,
+            new { scope, from, to, evaluationTimeZone, pageSize, cursor });
+
+    private static string CreateQueryContext(CalendarOccurrenceQuery query, int pageSize)
+    {
+        var selectorKind = query.Scope.Calendar?.Name is not null ? "name" : "href";
+        var selectorValue = query.Scope.Calendar?.Name is not null
+            ? query.Scope.Calendar.Name.ToUpperInvariant()
+            : query.Scope.Calendar?.Href;
+        return JsonSerializer.Serialize(new CalendarOccurrenceCursorQueryBinding(
+            query.Scope.Mode,
+            selectorKind,
+            selectorValue,
+            query.From.ToString("O", CultureInfo.InvariantCulture),
+            query.To.ToString("O", CultureInfo.InvariantCulture),
+            query.EvaluationTimeZone,
+            pageSize));
+    }
+
+    private sealed record CalendarOccurrenceCursorQueryBinding(
+        CalendarEntityScopeMode ScopeMode,
+        string SelectorKind,
+        string? SelectorValue,
+        string From,
+        string To,
+        string? EvaluationTimeZone,
+        int PageSize);
+
+    private sealed record CalendarOccurrenceRawArguments(
+        CalendarEntityScopeArgument Scope,
+        CalendarEntityUtcArgument From,
+        CalendarEntityUtcArgument To,
+        string? EvaluationTimeZone,
+        int? PageSize,
+        string? Cursor);
+
+    private sealed record CalendarOccurrenceContinuationTail(
+        string CalendarHref,
+        string EntityUid,
+        string RecurrenceIdentity);
+
+    private sealed class CalendarOccurrenceDeadlineException : Exception;
+}
+
+public sealed record CalendarOccurrenceQuerySuccessResult(
+    [property: JsonPropertyName("outcome")] string Outcome,
+    [property: JsonPropertyName("items")] IReadOnlyList<CalendarOccurrenceSnapshotResult> Items,
+    [property: JsonPropertyName("diagnostics")] IReadOnlyList<CalendarDiagnosticResult> Diagnostics,
+    [property: JsonPropertyName("pagination")] CalendarPagination Pagination);
+
+public sealed record CalendarOccurrenceQueryErrorResult(
+    [property: JsonPropertyName("code")] string Code,
+    [property: JsonPropertyName("category")] string Category,
+    [property: JsonPropertyName("message")] string Message,
+    [property: JsonPropertyName("retryable")] bool Retryable,
+    [property: JsonPropertyName("phase")] string Phase,
+    [property: JsonPropertyName("limits"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] CalendarEntityExecutionLimits? Limits = null,
+    [property: JsonPropertyName("authorizedCandidates"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] IReadOnlyList<CalendarAuthorizedCandidateResult>? AuthorizedCandidates = null);
+
+public sealed record CalendarOccurrenceSnapshotResult(
+    [property: JsonPropertyName("snapshot")] CalendarSnapshotResult Snapshot,
+    [property: JsonPropertyName("recurrenceIdentity")] CalendarRecurrenceIdentityResult RecurrenceIdentity,
+    [property: JsonPropertyName("timing")] CalendarOccurrenceTimingResult Timing)
+{
+    internal static CalendarOccurrenceSnapshotResult FromSnapshot(CalendarOccurrenceSnapshot snapshot) => new(
+        CalendarSnapshotResult.FromSnapshot(snapshot.Snapshot),
+        new CalendarRecurrenceIdentityResult(CalendarTemporalResult.FromValue(snapshot.RecurrenceIdentity)),
+        CalendarOccurrenceTimingResult.FromTiming(snapshot.Timing));
+}
+
+public sealed record CalendarRecurrenceIdentityResult(
+    [property: JsonPropertyName("value")] CalendarTemporalResult Value);
+
+public sealed record CalendarTemporalResult(
+    [property: JsonPropertyName("kind")] string Kind,
+    [property: JsonPropertyName("value")] string Value,
+    [property: JsonPropertyName("timeZoneId"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] string? TimeZoneId = null)
+{
+    internal static CalendarTemporalResult FromValue(CalendarTemporalValue value) => new(
+        value.Kind switch
+        {
+            CalendarTemporalKind.Date => "date",
+            CalendarTemporalKind.FloatingDateTime => "floatingDateTime",
+            CalendarTemporalKind.UtcDateTime => "utcDateTime",
+            CalendarTemporalKind.ZonedDateTime => "zonedDateTime",
+            _ => throw new ArgumentOutOfRangeException(nameof(value), value.Kind, null)
+        },
+        value.Value,
+        value.TimeZoneId);
+}
+
+public sealed record CalendarOccurrenceTimingResult(
+    [property: JsonPropertyName("sourceStart")] CalendarTemporalResult SourceStart,
+    [property: JsonPropertyName("effectiveStart")] CalendarTemporalResult EffectiveStart,
+    [property: JsonPropertyName("sourceEnd"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] CalendarTemporalResult? SourceEnd = null,
+    [property: JsonPropertyName("effectiveEnd"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] CalendarTemporalResult? EffectiveEnd = null,
+    [property: JsonPropertyName("sourceDuration"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] string? SourceDuration = null,
+    [property: JsonPropertyName("effectiveDuration"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] string? EffectiveDuration = null,
+    [property: JsonPropertyName("evaluatedStartUtc"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] CalendarTemporalResult? EvaluatedStartUtc = null,
+    [property: JsonPropertyName("evaluatedEndUtc"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] CalendarTemporalResult? EvaluatedEndUtc = null,
+    [property: JsonPropertyName("evaluationTimeZone"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] string? EvaluationTimeZone = null)
+{
+    internal static CalendarOccurrenceTimingResult FromTiming(CalendarOccurrenceTiming timing) => new(
+        CalendarTemporalResult.FromValue(timing.SourceStart),
+        CalendarTemporalResult.FromValue(timing.EffectiveStart),
+        timing.SourceEnd is null ? null : CalendarTemporalResult.FromValue(timing.SourceEnd),
+        timing.EffectiveEnd is null ? null : CalendarTemporalResult.FromValue(timing.EffectiveEnd),
+        timing.SourceDuration,
+        timing.EffectiveDuration,
+        timing.EvaluatedStartUtc is null ? null : CalendarTemporalResult.FromValue(timing.EvaluatedStartUtc),
+        timing.EvaluatedEndUtc is null ? null : CalendarTemporalResult.FromValue(timing.EvaluatedEndUtc),
+        timing.EvaluationTimeZone);
+}
+
+internal readonly record struct CalendarOccurrenceContinuation(
+    string EffectiveStartUtc,
+    string CalendarHref,
+    string EntityUid,
+    string RecurrenceIdentity)
+{
+    public static CalendarOccurrenceContinuation FromSnapshot(CalendarOccurrenceSnapshot snapshot) => new(
+        snapshot.Timing.EvaluatedStartUtc!.Value,
+        snapshot.Snapshot.CalendarHref,
+        snapshot.Snapshot.Projection.EntityUid!,
+        snapshot.RecurrenceIdentity.GetCanonicalSortKey());
+}

--- a/src/DotnetAgents.CalDav.Mcp/Tools/CalendarQueryToolSupport.cs
+++ b/src/DotnetAgents.CalDav.Mcp/Tools/CalendarQueryToolSupport.cs
@@ -1,0 +1,194 @@
+using System.Globalization;
+using System.Text.Json;
+using DotnetAgents.CalDav.Core.Models;
+using ModelContextProtocol.Protocol;
+
+namespace DotnetAgents.CalDav.Mcp.Tools;
+
+/// <summary>Shared admission, lexical parsing, and result-budget policy for bounded Calendar queries.</summary>
+internal static class CalendarQueryToolSupport
+{
+    internal const int MaximumArgumentBytes = 256 * 1024;
+    internal const int MaximumHumanReadableBytes = 64 * 1024;
+    internal const int MaximumStructuredResultBytes = 4 * 1024 * 1024;
+
+    internal static int MeasureArguments(
+        IDictionary<string, JsonElement>? rawArguments,
+        object materializedArguments) => rawArguments is { } raw
+            ? JsonSerializer.SerializeToUtf8Bytes(raw).Length
+            : JsonSerializer.SerializeToUtf8Bytes(materializedArguments).Length;
+
+    internal static bool TryCreateScope(
+        CalendarEntityScopeArgument scope,
+        out CalendarEntityScope domainScope)
+    {
+        domainScope = null!;
+        if (scope.Mode == "default" && scope.Calendar is null)
+        {
+            domainScope = CalendarEntityScope.Default;
+            return true;
+        }
+        if (scope.Mode == "all" && scope.Calendar is null)
+        {
+            domainScope = CalendarEntityScope.All;
+            return true;
+        }
+        if (scope.Mode != "selected" || scope.Calendar is null)
+            return false;
+        return scope.Calendar.By switch
+        {
+            "name" => TryCreateNameScope(scope.Calendar, out domainScope),
+            "href" => TryCreateHrefScope(scope.Calendar, out domainScope),
+            _ => false
+        };
+    }
+
+    internal static bool TryParseUtc(CalendarEntityUtcArgument argument, out DateTimeOffset? value)
+    {
+        value = null;
+        if (argument.Kind != "utcDateTime")
+            return false;
+        var lexical = argument.Value;
+        var hasFraction = lexical.Length > 20 && lexical.Length >= 22 && lexical[19] == '.';
+        var secondLexical = hasFraction ? lexical[..19] + "Z" : lexical;
+        if (!DateTimeOffset.TryParseExact(
+                secondLexical,
+                "yyyy-MM-dd'T'HH:mm:ss'Z'",
+                CultureInfo.InvariantCulture,
+                DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
+                out var parsed))
+            return false;
+        if (!hasFraction)
+        {
+            value = parsed;
+            return true;
+        }
+        var fraction = lexical.AsSpan(20, lexical.Length - 21);
+        if (lexical[^1] != 'Z' || fraction.IsEmpty || !fraction.ToString().All(char.IsAsciiDigit))
+            return false;
+        return TryApplyFraction(parsed, fraction, out value);
+    }
+
+    internal static bool HasScopeShape(JsonElement scope)
+    {
+        if (!TryGetUniqueProperties(scope, out var properties)
+            || !properties.TryGetValue("mode", out var modeElement)
+            || modeElement.ValueKind != JsonValueKind.String)
+            return false;
+        var mode = modeElement.GetString();
+        if (mode is "default" or "all")
+            return properties.Count == 1;
+        return mode == "selected"
+            && properties.Count == 2
+            && properties.TryGetValue("calendar", out var calendar)
+            && HasCalendarReferenceShape(calendar);
+    }
+
+    internal static bool HasTemporalShape(JsonElement temporal) =>
+        TryGetUniqueProperties(temporal, out var properties)
+        && properties.Count == 2
+        && properties.ContainsKey("kind")
+        && properties.ContainsKey("value");
+
+    internal static int MeasureResult(CallToolResult result) =>
+        JsonSerializer.SerializeToUtf8Bytes(result).Length;
+
+    internal static CallToolResult EnsureBoundedResult(
+        CallToolResult result,
+        Func<int, bool, CallToolResult> createPayloadError)
+    {
+        var humanReadableBytes = MeasureHumanReadableResult(result);
+        if (humanReadableBytes > MaximumHumanReadableBytes)
+            return createPayloadError(humanReadableBytes, true);
+        var observedBytes = MeasureResult(result);
+        return observedBytes <= MaximumStructuredResultBytes
+            ? result
+            : createPayloadError(observedBytes, false);
+    }
+
+    private static bool TryCreateNameScope(
+        CalendarEntityReferenceArgument reference,
+        out CalendarEntityScope domainScope)
+    {
+        domainScope = null!;
+        if (reference.Name is not { Length: > 0 } name || name != name.Trim() || reference.Href is not null)
+            return false;
+        domainScope = CalendarEntityScope.Selected(new CalendarReference(Name: name));
+        return true;
+    }
+
+    private static bool TryCreateHrefScope(
+        CalendarEntityReferenceArgument reference,
+        out CalendarEntityScope domainScope)
+    {
+        domainScope = null!;
+        if (reference.Href is not { Length: > 0 } href || reference.Name is not null)
+            return false;
+        domainScope = CalendarEntityScope.Selected(new CalendarReference(Href: href));
+        return true;
+    }
+
+    private static bool TryApplyFraction(
+        DateTimeOffset parsed,
+        ReadOnlySpan<char> fraction,
+        out DateTimeOffset? value)
+    {
+        value = null;
+        var representedDigits = Math.Min(7, fraction.Length);
+        var ticksText = fraction[..representedDigits].ToString().PadRight(7, '0');
+        var ticks = int.Parse(ticksText, CultureInfo.InvariantCulture);
+        if (fraction[representedDigits..].ContainsAnyExcept('0'))
+            ticks++;
+        if (ticks == TimeSpan.TicksPerSecond)
+        {
+            if (parsed.Ticks > DateTimeOffset.MaxValue.Ticks - TimeSpan.TicksPerSecond)
+                return false;
+            parsed = parsed.AddSeconds(1);
+            ticks = 0;
+        }
+        value = parsed.AddTicks(ticks);
+        return true;
+    }
+
+    private static bool HasCalendarReferenceShape(JsonElement calendar)
+    {
+        if (!TryGetUniqueProperties(calendar, out var properties)
+            || !properties.TryGetValue("by", out var byElement)
+            || byElement.ValueKind != JsonValueKind.String
+            || properties.Count != 2)
+            return false;
+        var by = byElement.GetString();
+        return by == "name" && properties.ContainsKey("name")
+            || by == "href" && properties.ContainsKey("href");
+    }
+
+    private static bool TryGetUniqueProperties(
+        JsonElement element,
+        out Dictionary<string, JsonElement> properties)
+    {
+        properties = new Dictionary<string, JsonElement>(StringComparer.Ordinal);
+        if (element.ValueKind != JsonValueKind.Object)
+            return false;
+        foreach (var property in element.EnumerateObject())
+        {
+            if (!properties.TryAdd(property.Name, property.Value))
+                return false;
+        }
+        return true;
+    }
+
+    internal static int MeasureHumanReadableResult(CallToolResult result)
+    {
+        var diagnostics = result.StructuredContent is { ValueKind: JsonValueKind.Object } structured
+            && structured.TryGetProperty("diagnostics", out var value)
+            ? value
+            : JsonSerializer.SerializeToElement(Array.Empty<object>());
+        return JsonSerializer.SerializeToUtf8Bytes(new CalendarHumanReadableBudget(
+            result.Content.OfType<TextContentBlock>().Select(block => block.Text).ToArray(),
+            diagnostics)).Length;
+    }
+
+    private sealed record CalendarHumanReadableBudget(
+        IReadOnlyList<string> Text,
+        JsonElement Diagnostics);
+}

--- a/tests/DotnetAgents.CalDav.Core.Tests.Unit/DependencyInjection/CalDavServiceCollectionExtensionsTests.cs
+++ b/tests/DotnetAgents.CalDav.Core.Tests.Unit/DependencyInjection/CalDavServiceCollectionExtensionsTests.cs
@@ -33,6 +33,29 @@ public sealed class CalDavServiceCollectionExtensionsTests
     }
 
     [Fact]
+    public void AddCalDavTasks_RecyclesIdleConnectionsBeforePinnedRadicaleTimeout()
+    {
+        SocketsHttpHandler? handler = null;
+        var services = new ServiceCollection();
+        services.AddSingleton<IHttpMessageHandlerBuilderFilter>(
+            new CapturingHandlerFilter(candidate => handler = candidate as SocketsHttpHandler));
+        services.AddCalDavTasks(options =>
+        {
+            options.BaseUrl = "https://cal.example";
+            options.Username = "user";
+            options.Password = "password";
+        });
+        using var provider = services.BuildServiceProvider();
+
+        _ = provider.GetRequiredService<ICalDavClient>();
+
+        handler.ShouldNotBeNull();
+        handler.PooledConnectionIdleTimeout.ShouldBe(TimeSpan.FromSeconds(20));
+        handler.PooledConnectionIdleTimeout.ShouldBeLessThan(TimeSpan.FromSeconds(30));
+        handler.PooledConnectionLifetime.ShouldBe(TimeSpan.FromMinutes(2));
+    }
+
+    [Fact]
     public async Task AddCalDavTasks_RetriesTransientReadsAtMostThreeTotalAttempts()
     {
         var handler = new CountingUnavailableHandler();

--- a/tests/DotnetAgents.CalDav.Core.Tests.Unit/Internal/Ical/CalendarContentDocumentTests.cs
+++ b/tests/DotnetAgents.CalDav.Core.Tests.Unit/Internal/Ical/CalendarContentDocumentTests.cs
@@ -29,6 +29,38 @@ public sealed class CalendarContentDocumentTests
     }
 
     [Fact]
+    public void ReplayForOccurrenceEvaluation_PreservesEveryObservanceRecurrenceDate()
+    {
+        const string content = "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Example//EN\r\n"
+            + "BEGIN:VTIMEZONE\r\nTZID:Private/Zone\r\nBEGIN:STANDARD\r\n"
+            + "DTSTART:20261025T030000\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0100\r\n"
+            + "RDATE:20271031T030000\r\nRDATE;VALUE=DATE-TIME:20281029T030000\r\n"
+            + "RDATE;VALUE=PERIOD:20291028T030000/20291028T040000\r\n"
+            + "END:STANDARD\r\nEND:VTIMEZONE\r\n"
+            + "BEGIN:VEVENT\r\nUID:u1\r\nDTSTAMP:20260815T120000Z\r\n"
+            + "DTSTART;TZID=Private/Zone:20260816T090000\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n";
+        var document = CalendarContentDocument.Parse(Encoding.UTF8.GetBytes(content));
+
+        document.ReplayForOccurrenceEvaluation().ShouldBe(Encoding.UTF8.GetBytes(content));
+        document.ReplayForTypedValidation().ShouldBe(Encoding.UTF8.GetBytes(content));
+    }
+
+    [Fact]
+    public void TypedReplayRetainsEntityPeriodWhileOccurrenceReplayDelegatesItToTheLocalEvaluator()
+    {
+        const string periodLine = "RDATE;VALUE=PERIOD:20260816T100000Z/PT1H\r\n";
+        const string content = "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Example//EN\r\n"
+            + "BEGIN:VEVENT\r\nUID:u1\r\nDTSTAMP:20260815T120000Z\r\n"
+            + "DTSTART:20260816T090000Z\r\n" + periodLine
+            + "END:VEVENT\r\nEND:VCALENDAR\r\n";
+        var document = CalendarContentDocument.Parse(Encoding.UTF8.GetBytes(content));
+
+        Encoding.UTF8.GetString(document.ReplayForTypedValidation()).ShouldContain(periodLine);
+        Encoding.UTF8.GetString(document.ReplayForOccurrenceEvaluation()).ShouldNotContain(periodLine);
+        Encoding.UTF8.GetString(document.ReplayForProjectionValidation()).ShouldNotContain(periodLine);
+    }
+
+    [Fact]
     public void Parse_DecodesRfc6868ParameterEscapesInOnePass()
     {
         const string content = "BEGIN:VCALENDAR\r\nX-PROP;X-P=^^n,^n,^',^^:value\r\nEND:VCALENDAR\r\n";

--- a/tests/DotnetAgents.CalDav.Core.Tests.Unit/Services/CalendarServiceTests.cs
+++ b/tests/DotnetAgents.CalDav.Core.Tests.Unit/Services/CalendarServiceTests.cs
@@ -4,6 +4,7 @@ using System.Text.Json;
 using DotnetAgents.CalDav.Core.Abstractions;
 using DotnetAgents.CalDav.Core.Configuration;
 using DotnetAgents.CalDav.Core.Internal;
+using DotnetAgents.CalDav.Core.Internal.Ical;
 using DotnetAgents.CalDav.Core.Models;
 using DotnetAgents.CalDav.Core.Services;
 using Microsoft.Extensions.Logging;
@@ -16,6 +17,1730 @@ namespace DotnetAgents.CalDav.Core.Tests.Unit.Services;
 
 public sealed class CalendarServiceTests
 {
+    [Fact]
+    public async Task QueryOccurrencesAsync_ExpandsBoundedUtcEventRecurrenceLocally()
+    {
+        const string calendarHref = "https://cal.example/events/";
+        const string resourceHref = "https://cal.example/events/recurring.ics";
+        var client = Substitute.For<ICalendarClient>();
+        var sut = new CalendarService(
+            client,
+            Options.Create(new CalDavOptions { BaseUrl = "https://cal.example", DefaultEventCalendarName = "Events" }),
+            Substitute.For<ILogger<CalendarService>>());
+        client.GetCalendarsAsync(Arg.Any<CancellationToken>()).Returns(
+            [EntityCalendar(calendarHref, "Events", EntityKindSupport.Advertised, EntityKindSupport.NotAdvertised)]);
+        client.QueryCalendarResourceHrefsAsync(
+                calendarHref,
+                CalendarEntityKind.Event,
+                null,
+                null,
+                Arg.Any<CancellationToken>())
+            .Returns([resourceHref]);
+        client.QueryCalendarResourceHrefsAsync(
+                calendarHref,
+                CalendarEntityKind.Todo,
+                null,
+                null,
+                Arg.Any<CancellationToken>())
+            .Returns([]);
+        client.GetCalendarResourceAsync(resourceHref, Arg.Any<CancellationToken>()).Returns(
+            CalendarResourceRead.Success(resourceHref, "\"r1\"", RecurringEvent("recurring", null)));
+
+        var result = await sut.QueryOccurrencesAsync(
+            new CalendarOccurrenceQuery(
+                CalendarEntityScope.Selected(new CalendarReference(Href: calendarHref)),
+                DateTimeOffset.Parse("2026-08-15T00:00:00Z"),
+                DateTimeOffset.Parse("2026-08-17T00:00:00Z")),
+            CancellationToken.None);
+
+        result.Code.ShouldBe(CalendarOccurrenceQueryCode.Success);
+        result.Items.Select(item => item.RecurrenceIdentity.Value)
+            .ShouldBe(["2026-08-15T10:00:00Z", "2026-08-16T10:00:00Z"]);
+        result.Items.Select(item => item.Timing.EffectiveStart.Value)
+            .ShouldBe(["2026-08-15T10:00:00Z", "2026-08-16T10:00:00Z"]);
+    }
+
+    [Fact]
+    public async Task QueryOccurrencesAsync_SelectedScopeIncludesEventsAndEveryTimedTodoForm()
+    {
+        const string calendarHref = "https://cal.example/mixed/";
+        var hrefs = new[] { "event", "todo-span", "todo-due", "todo-start", "todo-none" }
+            .ToDictionary(name => name, name => $"{calendarHref}{name}.ics");
+        var client = Substitute.For<ICalendarClient>();
+        var sut = new CalendarService(
+            client,
+            Options.Create(new CalDavOptions { BaseUrl = "https://cal.example" }),
+            Substitute.For<ILogger<CalendarService>>());
+        client.GetCalendarsAsync(Arg.Any<CancellationToken>()).Returns(
+            [EntityCalendar(calendarHref, "Mixed", EntityKindSupport.Advertised, EntityKindSupport.Advertised)]);
+        client.QueryCalendarResourceHrefsAsync(calendarHref, CalendarEntityKind.Event, null, null, Arg.Any<CancellationToken>())
+            .Returns([hrefs["event"]]);
+        client.QueryCalendarResourceHrefsAsync(calendarHref, CalendarEntityKind.Todo, null, null, Arg.Any<CancellationToken>())
+            .Returns([hrefs["todo-span"], hrefs["todo-due"], hrefs["todo-start"], hrefs["todo-none"]]);
+        client.GetCalendarResourceAsync(hrefs["event"], Arg.Any<CancellationToken>()).Returns(
+            CalendarResourceRead.Success(hrefs["event"], "\"e1\"", Event("event", "20260816T101500Z", "Event")));
+        client.GetCalendarResourceAsync(hrefs["todo-span"], Arg.Any<CancellationToken>()).Returns(
+            CalendarResourceRead.Success(hrefs["todo-span"], "\"t1\"", TodoWithTemporalLines(
+                "todo-span", "DTSTART:20260816T094500Z\r\nDUE:20260816T101500Z\r\n")));
+        client.GetCalendarResourceAsync(hrefs["todo-due"], Arg.Any<CancellationToken>()).Returns(
+            CalendarResourceRead.Success(hrefs["todo-due"], "\"t2\"", TodoWithTemporalLines(
+                "todo-due", "DUE:20260816T102000Z\r\n")));
+        client.GetCalendarResourceAsync(hrefs["todo-start"], Arg.Any<CancellationToken>()).Returns(
+            CalendarResourceRead.Success(hrefs["todo-start"], "\"t3\"", TodoWithTemporalLines(
+                "todo-start", "DTSTART:20260816T103000Z\r\n")));
+        client.GetCalendarResourceAsync(hrefs["todo-none"], Arg.Any<CancellationToken>()).Returns(
+            CalendarResourceRead.Success(hrefs["todo-none"], "\"t4\"", Todo("todo-none", "No timing")));
+
+        var result = await sut.QueryOccurrencesAsync(
+            new CalendarOccurrenceQuery(
+                CalendarEntityScope.Selected(new CalendarReference(Href: calendarHref)),
+                DateTimeOffset.Parse("2026-08-16T10:00:00Z"),
+                DateTimeOffset.Parse("2026-08-16T11:00:00Z")),
+            CancellationToken.None);
+
+        result.Code.ShouldBe(CalendarOccurrenceQueryCode.Success);
+        result.Items.Select(item => item.Snapshot.Projection.EntityUid)
+            .ShouldBe(["todo-span", "event", "todo-due", "todo-start"]);
+        result.Items.ShouldNotContain(item => item.Snapshot.Projection.EntityUid == "todo-none");
+    }
+
+    [Fact]
+    public async Task QueryOccurrencesAsync_ExdateAndCancellationSuppressWhileMovedTimingRetainsOriginalIdentity()
+    {
+        const string calendarHref = "https://cal.example/events/";
+        const string resourceHref = "https://cal.example/events/overrides.ics";
+        var client = Substitute.For<ICalendarClient>();
+        var sut = new CalendarService(
+            client,
+            Options.Create(new CalDavOptions { BaseUrl = "https://cal.example" }),
+            Substitute.For<ILogger<CalendarService>>());
+        client.GetCalendarsAsync(Arg.Any<CancellationToken>()).Returns(
+            [EntityCalendar(calendarHref, "Events", EntityKindSupport.Advertised, EntityKindSupport.NotAdvertised)]);
+        client.QueryCalendarResourceHrefsAsync(calendarHref, CalendarEntityKind.Event, null, null, Arg.Any<CancellationToken>())
+            .Returns([resourceHref]);
+        client.QueryCalendarResourceHrefsAsync(calendarHref, CalendarEntityKind.Todo, null, null, Arg.Any<CancellationToken>())
+            .Returns([]);
+        client.GetCalendarResourceAsync(resourceHref, Arg.Any<CancellationToken>()).Returns(
+            CalendarResourceRead.Success(resourceHref, "\"r1\"", OverrideEvent()));
+
+        var result = await sut.QueryOccurrencesAsync(
+            new CalendarOccurrenceQuery(
+                CalendarEntityScope.Selected(new CalendarReference(Href: calendarHref)),
+                DateTimeOffset.Parse("2026-08-17T20:30:00Z"),
+                DateTimeOffset.Parse("2026-08-17T20:45:00Z")),
+            CancellationToken.None);
+
+        result.Code.ShouldBe(CalendarOccurrenceQueryCode.Success);
+        var occurrence = result.Items.ShouldHaveSingleItem();
+        occurrence.RecurrenceIdentity.Value.ShouldBe("2026-08-17T10:00:00Z");
+        occurrence.Timing.SourceStart.Value.ShouldBe("2026-08-17T10:00:00Z");
+        occurrence.Timing.SourceEnd!.Value.ShouldBe("2026-08-17T11:00:00Z");
+        occurrence.Timing.SourceDuration.ShouldBe("PT1H");
+        occurrence.Timing.EffectiveStart.Value.ShouldBe("2026-08-17T20:00:00Z");
+        occurrence.Timing.EffectiveEnd!.Value.ShouldBe("2026-08-17T21:00:00Z");
+
+        var broad = await sut.QueryOccurrencesAsync(
+            new CalendarOccurrenceQuery(
+                CalendarEntityScope.Selected(new CalendarReference(Href: calendarHref)),
+                DateTimeOffset.Parse("2026-08-14T00:00:00Z"),
+                DateTimeOffset.Parse("2026-08-18T00:00:00Z")),
+            CancellationToken.None);
+        broad.Items.Select(item => item.RecurrenceIdentity.Value)
+            .ShouldBe(["2026-08-14T10:00:00Z", "2026-08-17T10:00:00Z"]);
+    }
+
+    [Fact]
+    public async Task QueryOccurrencesAsync_NearestRangeReplacesEarlierAndIndividualOverrideWins()
+    {
+        const string calendarHref = "https://cal.example/events/";
+        const string resourceHref = "https://cal.example/events/ranges.ics";
+        var client = Substitute.For<ICalendarClient>();
+        var sut = new CalendarService(
+            client,
+            Options.Create(new CalDavOptions { BaseUrl = "https://cal.example" }),
+            Substitute.For<ILogger<CalendarService>>());
+        client.GetCalendarsAsync(Arg.Any<CancellationToken>()).Returns(
+            [EntityCalendar(calendarHref, "Events", EntityKindSupport.Advertised, EntityKindSupport.NotAdvertised)]);
+        client.QueryCalendarResourceHrefsAsync(calendarHref, CalendarEntityKind.Event, null, null, Arg.Any<CancellationToken>())
+            .Returns([resourceHref]);
+        client.QueryCalendarResourceHrefsAsync(calendarHref, CalendarEntityKind.Todo, null, null, Arg.Any<CancellationToken>())
+            .Returns([]);
+        client.GetCalendarResourceAsync(resourceHref, Arg.Any<CancellationToken>()).Returns(
+            CalendarResourceRead.Success(resourceHref, "\"r1\"", RangeOverrideEvent()));
+
+        var result = await sut.QueryOccurrencesAsync(
+            new CalendarOccurrenceQuery(
+                CalendarEntityScope.Selected(new CalendarReference(Href: calendarHref)),
+                DateTimeOffset.Parse("2026-08-16T00:00:00Z"),
+                DateTimeOffset.Parse("2026-08-19T00:00:00Z")),
+            CancellationToken.None);
+
+        result.Code.ShouldBe(CalendarOccurrenceQueryCode.Success);
+        result.Items.Select(item => (item.RecurrenceIdentity.Value, item.Timing.EffectiveStart.Value, item.Timing.EffectiveEnd!.Value))
+            .ShouldBe([
+                ("2026-08-16T09:00:00Z", "2026-08-16T11:00:00Z", "2026-08-16T12:00:00Z"),
+                ("2026-08-17T09:00:00Z", "2026-08-17T13:00:00Z", "2026-08-17T15:00:00Z"),
+                ("2026-08-18T09:00:00Z", "2026-08-18T16:00:00Z", "2026-08-18T17:00:00Z")
+            ]);
+    }
+
+    [Fact]
+    public async Task QueryOccurrencesAsync_MovedRangeMatchesEffectiveWindowAndRetainsOriginalIdentity()
+    {
+        var result = await QuerySingleOccurrenceEventAsync(
+            "DTSTART:20260814T090000Z\r\nDURATION:PT1H\r\nRRULE:FREQ=DAILY;COUNT=5\r\n"
+            + "END:VEVENT\r\nBEGIN:VEVENT\r\nUID:occurrence\r\nDTSTAMP:20260815T120000Z\r\n"
+            + "RECURRENCE-ID;RANGE=THISANDFUTURE:20260817T090000Z\r\n"
+            + "DTSTART:20260817T130000Z\r\nDURATION:PT2H\r\n",
+            "2026-08-17T13:30:00Z",
+            "2026-08-17T13:45:00Z");
+
+        var occurrence = result.Items.ShouldHaveSingleItem();
+        occurrence.RecurrenceIdentity.Value.ShouldBe("2026-08-17T09:00:00Z");
+        occurrence.Timing.SourceStart.Value.ShouldBe("2026-08-17T09:00:00Z");
+        occurrence.Timing.EffectiveStart.Value.ShouldBe("2026-08-17T13:00:00Z");
+        occurrence.Timing.EffectiveEnd!.Value.ShouldBe("2026-08-17T15:00:00Z");
+    }
+
+    [Fact]
+    public async Task QueryOccurrencesAsync_CancelledRangeOmitsUntilLaterRangeWhileExactOverrideWins()
+    {
+        var result = await QuerySingleOccurrenceEventAsync(
+            "DTSTART:20260814T090000Z\r\nDURATION:PT1H\r\nRRULE:FREQ=DAILY;COUNT=5\r\n"
+            + "END:VEVENT\r\nBEGIN:VEVENT\r\nUID:occurrence\r\nDTSTAMP:20260815T120000Z\r\n"
+            + "RECURRENCE-ID;RANGE=THISANDFUTURE:20260815T090000Z\r\n"
+            + "DTSTART:20260815T090000Z\r\nSTATUS:CANCELLED\r\n"
+            + "END:VEVENT\r\nBEGIN:VEVENT\r\nUID:occurrence\r\nDTSTAMP:20260815T120000Z\r\n"
+            + "RECURRENCE-ID:20260816T090000Z\r\nDTSTART:20260816T200000Z\r\nDURATION:PT1H\r\n"
+            + "END:VEVENT\r\nBEGIN:VEVENT\r\nUID:occurrence\r\nDTSTAMP:20260815T120000Z\r\n"
+            + "RECURRENCE-ID;RANGE=THISANDFUTURE:20260817T090000Z\r\n"
+            + "DTSTART:20260817T130000Z\r\nDURATION:PT1H\r\n",
+            "2026-08-14T00:00:00Z",
+            "2026-08-19T00:00:00Z");
+
+        result.Items.Select(item => (item.RecurrenceIdentity.Value, item.Timing.EffectiveStart.Value)).ShouldBe([
+            ("2026-08-14T09:00:00Z", "2026-08-14T09:00:00Z"),
+            ("2026-08-16T09:00:00Z", "2026-08-16T20:00:00Z"),
+            ("2026-08-17T09:00:00Z", "2026-08-17T13:00:00Z"),
+            ("2026-08-18T09:00:00Z", "2026-08-18T13:00:00Z")
+        ]);
+    }
+
+    [Fact]
+    public async Task QueryOccurrencesAsync_DetachedEventOverridesAreEnumeratedWithCancellationAndExdatePrecedence()
+    {
+        var bytes = System.Text.Encoding.UTF8.GetBytes(
+            "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Example//EN\r\n"
+            + "BEGIN:VEVENT\r\nUID:detached\r\nDTSTAMP:20260815T120000Z\r\n"
+            + "DTSTART:20260814T100000Z\r\nDURATION:PT1H\r\nRRULE:FREQ=DAILY;COUNT=1\r\n"
+            + "EXDATE:20260823T100000Z\r\nEND:VEVENT\r\n"
+            + "BEGIN:VEVENT\r\nUID:detached\r\nDTSTAMP:20260815T120000Z\r\n"
+            + "RECURRENCE-ID:20260820T100000Z\r\nDTSTART:20260821T150000Z\r\nDURATION:PT2H\r\nEND:VEVENT\r\n"
+            + "BEGIN:VEVENT\r\nUID:detached\r\nDTSTAMP:20260815T120000Z\r\n"
+            + "RECURRENCE-ID:20260822T100000Z\r\nSTATUS:CANCELLED\r\nEND:VEVENT\r\n"
+            + "BEGIN:VEVENT\r\nUID:detached\r\nDTSTAMP:20260815T120000Z\r\n"
+            + "RECURRENCE-ID:20260823T100000Z\r\nDTSTART:20260824T150000Z\r\nDURATION:PT2H\r\nEND:VEVENT\r\n"
+            + "END:VCALENDAR\r\n");
+
+        var result = await QuerySingleOccurrenceAsync(
+            bytes,
+            CalendarEntityKind.Event,
+            "2026-08-21T00:00:00Z",
+            "2026-08-25T00:00:00Z");
+
+        result.Code.ShouldBe(CalendarOccurrenceQueryCode.Success);
+        var occurrence = result.Items.ShouldHaveSingleItem();
+        occurrence.RecurrenceIdentity.Value.ShouldBe("2026-08-20T10:00:00Z");
+        occurrence.Timing.SourceStart.Value.ShouldBe("2026-08-20T10:00:00Z");
+        occurrence.Timing.EffectiveStart.Value.ShouldBe("2026-08-21T15:00:00Z");
+    }
+
+    [Fact]
+    public async Task QueryOccurrencesAsync_DetachedTodoOverridesWithoutDtstartRemainObservable()
+    {
+        var bytes = System.Text.Encoding.UTF8.GetBytes(
+            "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Example//EN\r\n"
+            + "BEGIN:VTODO\r\nUID:todo-detached\r\nDTSTAMP:20260815T120000Z\r\n"
+            + "DTSTART:20260814T100000Z\r\nDUE:20260814T110000Z\r\nRRULE:FREQ=DAILY;COUNT=1\r\n"
+            + "EXDATE:20260823T100000Z\r\nEND:VTODO\r\n"
+            + "BEGIN:VTODO\r\nUID:todo-detached\r\nDTSTAMP:20260815T120000Z\r\n"
+            + "RECURRENCE-ID:20260820T100000Z\r\nDUE:20260821T150000Z\r\nEND:VTODO\r\n"
+            + "BEGIN:VTODO\r\nUID:todo-detached\r\nDTSTAMP:20260815T120000Z\r\n"
+            + "RECURRENCE-ID:20260822T100000Z\r\nSTATUS:CANCELLED\r\nEND:VTODO\r\n"
+            + "BEGIN:VTODO\r\nUID:todo-detached\r\nDTSTAMP:20260815T120000Z\r\n"
+            + "RECURRENCE-ID:20260823T100000Z\r\nDUE:20260824T150000Z\r\nEND:VTODO\r\n"
+            + "END:VCALENDAR\r\n");
+
+        var result = await QuerySingleOccurrenceAsync(
+            bytes,
+            CalendarEntityKind.Todo,
+            "2026-08-21T00:00:00Z",
+            "2026-08-25T00:00:00Z");
+
+        result.Code.ShouldBe(CalendarOccurrenceQueryCode.Success);
+        var occurrence = result.Items.ShouldHaveSingleItem();
+        occurrence.RecurrenceIdentity.Value.ShouldBe("2026-08-20T10:00:00Z");
+        occurrence.Timing.EffectiveStart.Value.ShouldBe("2026-08-21T15:00:00Z");
+        occurrence.Timing.EffectiveEnd.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task QueryOccurrencesAsync_DueOnlyRecurringTodoIsTypedRecurrenceUnevaluable()
+    {
+        var bytes = TodoWithTemporalLines(
+            "due-only",
+            "DUE:20260815T100000Z\r\nRRULE:FREQ=DAILY;COUNT=2\r\n");
+
+        var result = await QuerySingleOccurrenceAsync(
+            bytes,
+            CalendarEntityKind.Todo,
+            "2026-08-15T00:00:00Z",
+            "2026-08-20T00:00:00Z");
+
+        result.Code.ShouldBe(CalendarOccurrenceQueryCode.RecurrenceUnevaluable);
+        result.Items.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task QueryOccurrencesAsync_OldResourceLocalSeriesStartsNearBoundedWindow()
+    {
+        var result = await QuerySingleOccurrenceEventAsync(
+            "DTSTART;TZID=Private/Zurich:20000101T100000\r\nDURATION:PT1H\r\nRRULE:FREQ=DAILY\r\n",
+            "2026-08-16T08:30:00Z",
+            "2026-08-16T08:45:00Z",
+            calendarLines: ResourceLocalFixedZone());
+
+        result.Code.ShouldBe(CalendarOccurrenceQueryCode.Success);
+        result.Items.ShouldHaveSingleItem().RecurrenceIdentity.Value.ShouldBe("2026-08-16T10:00:00");
+    }
+
+    [Fact]
+    public async Task QueryOccurrencesAsync_OldTodoRangeMovedByDueIsIncludedInBoundedSearch()
+    {
+        var bytes = System.Text.Encoding.UTF8.GetBytes(
+            "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Example//EN\r\n"
+            + ResourceLocalFixedZone()
+            + "BEGIN:VTODO\r\nUID:todo-range\r\nDTSTAMP:20260815T120000Z\r\n"
+            + "DTSTART;TZID=Private/Zurich:20000101T100000\r\nRRULE:FREQ=DAILY\r\nEND:VTODO\r\n"
+            + "BEGIN:VTODO\r\nUID:todo-range\r\nDTSTAMP:20260815T120000Z\r\n"
+            + "RECURRENCE-ID;TZID=Private/Zurich;RANGE=THISANDFUTURE:20260801T100000\r\n"
+            + "DUE;TZID=Private/Zurich:20260816T100000\r\nEND:VTODO\r\nEND:VCALENDAR\r\n");
+
+        var result = await QuerySingleOccurrenceAsync(
+            bytes,
+            CalendarEntityKind.Todo,
+            "2026-08-17T07:59:00Z",
+            "2026-08-17T08:01:00Z");
+
+        var occurrence = result.Items.ShouldHaveSingleItem();
+        occurrence.RecurrenceIdentity.Value.ShouldBe("2026-08-02T10:00:00");
+        occurrence.Timing.EffectiveStart.Value.ShouldBe("2026-08-17T10:00:00");
+    }
+
+    [Fact]
+    public async Task QueryOccurrencesAsync_DateEventIndividualOverrideDefaultsToOneDay()
+    {
+        var result = await QuerySingleOccurrenceEventAsync(
+            "DTSTART;VALUE=DATE:20260814\r\nRRULE:FREQ=DAILY;COUNT=1\r\n"
+            + "END:VEVENT\r\nBEGIN:VEVENT\r\nUID:occurrence\r\nDTSTAMP:20260815T120000Z\r\n"
+            + "RECURRENCE-ID;VALUE=DATE:20260820\r\nDTSTART;VALUE=DATE:20260822\r\n",
+            "2026-08-22T12:00:00Z",
+            "2026-08-22T13:00:00Z",
+            "UTC");
+
+        var occurrence = result.Items.ShouldHaveSingleItem();
+        occurrence.RecurrenceIdentity.Value.ShouldBe("2026-08-20");
+        occurrence.Timing.EffectiveEnd.ShouldBe(new CalendarTemporalValue(CalendarTemporalKind.Date, "2026-08-23"));
+    }
+
+    [Fact]
+    public async Task QueryOccurrencesAsync_DateEventRangeOverrideDefaultsEachOccurrenceToOneDay()
+    {
+        var result = await QuerySingleOccurrenceEventAsync(
+            "DTSTART;VALUE=DATE:20260820\r\nRRULE:FREQ=DAILY;COUNT=2\r\n"
+            + "END:VEVENT\r\nBEGIN:VEVENT\r\nUID:occurrence\r\nDTSTAMP:20260815T120000Z\r\n"
+            + "RECURRENCE-ID;VALUE=DATE;RANGE=THISANDFUTURE:20260820\r\n"
+            + "DTSTART;VALUE=DATE:20260822\r\n",
+            "2026-08-23T12:00:00Z",
+            "2026-08-23T13:00:00Z",
+            "UTC");
+
+        var occurrence = result.Items.ShouldHaveSingleItem();
+        occurrence.RecurrenceIdentity.Value.ShouldBe("2026-08-21");
+        occurrence.Timing.EffectiveStart.Value.ShouldBe("2026-08-23");
+        occurrence.Timing.EffectiveEnd.ShouldBe(new CalendarTemporalValue(CalendarTemporalKind.Date, "2026-08-24"));
+    }
+
+    [Fact]
+    public async Task QueryOccurrencesAsync_DateEventOverrideDefaultsToNextLocalDayAcrossDst()
+    {
+        var result = await QuerySingleOccurrenceEventAsync(
+            "DTSTART;VALUE=DATE:20260301\r\nRRULE:FREQ=DAILY;COUNT=1\r\n"
+            + "END:VEVENT\r\nBEGIN:VEVENT\r\nUID:occurrence\r\nDTSTAMP:20260815T120000Z\r\n"
+            + "RECURRENCE-ID;VALUE=DATE:20260308\r\nDTSTART;VALUE=DATE:20260308\r\n",
+            "2026-03-08T00:00:00Z",
+            "2026-03-10T00:00:00Z",
+            "America/New_York");
+
+        var timing = result.Items.ShouldHaveSingleItem().Timing;
+        timing.EvaluatedStartUtc!.Value.ShouldBe("2026-03-08T05:00:00Z");
+        timing.EvaluatedEndUtc!.Value.ShouldBe("2026-03-09T04:00:00Z");
+    }
+
+    [Theory]
+    [InlineData("P1D", "2026-03-08T14:00:00Z", "2026-03-08T10:00:00")]
+    [InlineData("PT24H", "2026-03-08T15:00:00Z", "2026-03-08T11:00:00")]
+    public async Task QueryOccurrencesAsync_IanaMasterDistinguishesNominalDayFromAccurateHours(
+        string duration,
+        string expectedEndUtc,
+        string expectedEndLocal)
+    {
+        var result = await QuerySingleOccurrenceEventAsync(
+            $"DTSTART;TZID=America/New_York:20260307T100000\r\nDURATION:{duration}\r\n",
+            "2026-03-07T14:59:00Z",
+            "2026-03-07T15:01:00Z");
+
+        var timing = result.Items.ShouldHaveSingleItem().Timing;
+        timing.EvaluatedEndUtc!.Value.ShouldBe(expectedEndUtc);
+        timing.EffectiveEnd!.Value.ShouldBe(expectedEndLocal);
+    }
+
+    [Theory]
+    [InlineData("P1D", "2026-03-08T14:00:00Z", "2026-03-08T10:00:00")]
+    [InlineData("PT24H", "2026-03-08T15:00:00Z", "2026-03-08T11:00:00")]
+    public async Task QueryOccurrencesAsync_IanaOverrideDistinguishesNominalDayFromAccurateHours(
+        string duration,
+        string expectedEndUtc,
+        string expectedEndLocal)
+    {
+        var result = await QuerySingleOccurrenceEventAsync(
+            "DTSTART;TZID=America/New_York:20260301T100000\r\nRRULE:FREQ=DAILY;COUNT=1\r\n"
+            + "END:VEVENT\r\nBEGIN:VEVENT\r\nUID:occurrence\r\nDTSTAMP:20260815T120000Z\r\n"
+            + "RECURRENCE-ID;TZID=America/New_York:20260307T100000\r\n"
+            + $"DTSTART;TZID=America/New_York:20260307T100000\r\nDURATION:{duration}\r\n",
+            "2026-03-07T14:59:00Z",
+            "2026-03-07T15:01:00Z");
+
+        var timing = result.Items.ShouldHaveSingleItem().Timing;
+        timing.EvaluatedEndUtc!.Value.ShouldBe(expectedEndUtc);
+        timing.EffectiveEnd!.Value.ShouldBe(expectedEndLocal);
+    }
+
+    [Fact]
+    public async Task QueryOccurrencesAsync_DetachedOverrideRetainsAccurateMasterSourceSpanAcrossDst()
+    {
+        var result = await QuerySingleOccurrenceEventAsync(
+            "DTSTART;TZID=America/New_York:20260306T100000\r\n"
+            + "DTEND;TZID=America/New_York:20260307T100000\r\nRRULE:FREQ=DAILY;COUNT=1\r\n"
+            + "END:VEVENT\r\nBEGIN:VEVENT\r\nUID:occurrence\r\nDTSTAMP:20260815T120000Z\r\n"
+            + "RECURRENCE-ID;TZID=America/New_York:20260307T100000\r\n"
+            + "DTSTART;TZID=America/New_York:20260310T100000\r\nDURATION:PT1H\r\n",
+            "2026-03-10T13:59:00Z",
+            "2026-03-10T14:01:00Z");
+
+        var timing = result.Items.ShouldHaveSingleItem().Timing;
+        timing.SourceEnd!.Value.ShouldBe("2026-03-08T11:00:00");
+        timing.EffectiveEnd!.Value.ShouldBe("2026-03-10T11:00:00");
+    }
+
+    [Theory]
+    [InlineData("P1D", "2026-03-29T08:00:00Z", "2026-03-29T10:00:00")]
+    [InlineData("PT24H", "2026-03-29T09:00:00Z", "2026-03-29T11:00:00")]
+    public async Task QueryOccurrencesAsync_ResourceLocalMasterUsesTheSameDurationArithmetic(
+        string duration,
+        string expectedEndUtc,
+        string expectedEndLocal)
+    {
+        var result = await QuerySingleOccurrenceEventAsync(
+            $"DTSTART;TZID=Private/Zurich:20260328T100000\r\nDURATION:{duration}\r\n",
+            "2026-03-28T08:59:00Z",
+            "2026-03-28T09:01:00Z",
+            calendarLines: ResourceLocalDstZone());
+
+        var timing = result.Items.ShouldHaveSingleItem().Timing;
+        timing.EvaluatedEndUtc!.Value.ShouldBe(expectedEndUtc);
+        timing.EffectiveEnd!.Value.ShouldBe(expectedEndLocal);
+    }
+
+    [Theory]
+    [InlineData("P1D", "2026-03-29T08:00:00Z", "2026-03-29T10:00:00")]
+    [InlineData("PT24H", "2026-03-29T09:00:00Z", "2026-03-29T11:00:00")]
+    public async Task QueryOccurrencesAsync_RdatePeriodUsesNominalThenAccurateDurationArithmetic(
+        string duration,
+        string expectedEndUtc,
+        string expectedEndLocal)
+    {
+        var result = await QuerySingleOccurrenceEventAsync(
+            "DTSTART;TZID=Private/Zurich:20260301T100000\r\nDURATION:PT1H\r\n"
+            + $"RDATE;TZID=Private/Zurich;VALUE=PERIOD:20260328T100000/{duration}\r\n",
+            "2026-03-28T08:59:00Z",
+            "2026-03-28T09:01:00Z",
+            calendarLines: ResourceLocalDstZone());
+
+        var timing = result.Items.ShouldHaveSingleItem().Timing;
+        timing.EvaluatedEndUtc!.Value.ShouldBe(expectedEndUtc);
+        timing.SourceEnd!.Value.ShouldBe(expectedEndLocal);
+    }
+
+    [Theory]
+    [InlineData("+P1D", "2026-03-29T08:00:00Z", "2026-03-29T10:00:00")]
+    [InlineData("+P1W", "2026-04-04T08:00:00Z", "2026-04-04T10:00:00")]
+    public async Task QueryOccurrencesAsync_RdatePeriodAcceptsPositiveDurationAndPreservesLexicalValue(
+        string duration,
+        string expectedEndUtc,
+        string expectedEndLocal)
+    {
+        var result = await QuerySingleOccurrenceEventAsync(
+            "DTSTART;TZID=Europe/Zurich:20260301T100000\r\nDURATION:PT1H\r\n"
+            + $"RDATE;TZID=Europe/Zurich;VALUE=PERIOD:20260328T100000/{duration}\r\n",
+            "2026-03-28T08:59:00Z",
+            "2026-03-28T09:01:00Z");
+
+        var timing = result.Items.ShouldHaveSingleItem().Timing;
+        timing.SourceDuration.ShouldBe(duration);
+        timing.EffectiveDuration.ShouldBe(duration);
+        timing.SourceEnd!.Value.ShouldBe(expectedEndLocal);
+        timing.EvaluatedEndUtc!.Value.ShouldBe(expectedEndUtc);
+    }
+
+    [Theory]
+    [InlineData("DTSTART;TZID=Europe/Zurich:20260328T100000\r\nDURATION:P2147483647D\r\nRRULE:FREQ=DAILY;COUNT=1\r\n")]
+    [InlineData("DTSTART;TZID=Europe/Zurich:20260301T100000\r\nDURATION:PT1H\r\nRDATE;TZID=Europe/Zurich;VALUE=PERIOD:20260328T100000/P2147483647D\r\n")]
+    public async Task QueryOccurrencesAsync_ExtremeDurationIsTypedRecurrenceUnevaluableWithoutPartialItems(
+        string temporalLines)
+    {
+        var result = await QuerySingleOccurrenceEventAsync(
+            temporalLines,
+            "2026-03-28T08:59:00Z",
+            "2026-03-28T09:01:00Z");
+
+        result.Code.ShouldBe(CalendarOccurrenceQueryCode.RecurrenceUnevaluable);
+        result.Items.ShouldBeEmpty();
+    }
+
+    [Theory]
+    [InlineData("DURATION:PT0S")]
+    [InlineData("DURATION:-PT1H")]
+    public async Task QueryOccurrencesAsync_EventDurationMustBeStrictlyPositive(string durationLine)
+    {
+        var result = await QuerySingleOccurrenceEventAsync(
+            $"DTSTART:20260816T100000Z\r\n{durationLine}\r\n",
+            "2026-08-16T09:59:00Z",
+            "2026-08-16T10:01:00Z");
+
+        result.Code.ShouldBe(CalendarOccurrenceQueryCode.RecurrenceUnevaluable);
+        result.Items.ShouldBeEmpty();
+    }
+
+    [Theory]
+    [InlineData("PT0S")]
+    [InlineData("-PT1H")]
+    public async Task QueryOccurrencesAsync_TodoDurationMustBeStrictlyPositive(string duration)
+    {
+        var bytes = System.Text.Encoding.UTF8.GetBytes(
+            "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Example//EN\r\n"
+            + "BEGIN:VTODO\r\nUID:todo-duration\r\nDTSTAMP:20260815T120000Z\r\n"
+            + $"DTSTART:20260816T100000Z\r\nDURATION:{duration}\r\n"
+            + "END:VTODO\r\nEND:VCALENDAR\r\n");
+
+        var result = await QuerySingleOccurrenceAsync(
+            bytes,
+            CalendarEntityKind.Todo,
+            "2026-08-16T09:59:00Z",
+            "2026-08-16T10:01:00Z");
+
+        result.Code.ShouldBe(CalendarOccurrenceQueryCode.RecurrenceUnevaluable);
+        result.Items.ShouldBeEmpty();
+    }
+
+    [Theory]
+    [InlineData("P0D")]
+    [InlineData("-P1D")]
+    public async Task QueryOccurrencesAsync_RdatePeriodDurationMustBeStrictlyPositive(string duration)
+    {
+        var result = await QuerySingleOccurrenceEventAsync(
+            "DTSTART:20260801T100000Z\r\nDURATION:PT1H\r\n"
+            + $"RDATE;VALUE=PERIOD:20260816T100000Z/{duration}\r\n",
+            "2026-08-16T09:59:00Z",
+            "2026-08-16T10:01:00Z");
+
+        result.Code.ShouldBe(CalendarOccurrenceQueryCode.RecurrenceUnevaluable);
+        result.Items.ShouldBeEmpty();
+    }
+
+    [Theory]
+    [InlineData("20260816T100000Z/20260816T100000Z")]
+    [InlineData("20260816T100000Z/20260816T095959Z")]
+    [InlineData("20260816T100000Z/not-a-date-time")]
+    [InlineData("20260816T100000Z/P1Q")]
+    public async Task QueryOccurrencesAsync_RdatePeriodMustHaveAValidPositiveSpan(string period)
+    {
+        var result = await QuerySingleOccurrenceEventAsync(
+            "DTSTART:20260801T100000Z\r\nDURATION:PT1H\r\n"
+            + $"RDATE;VALUE=PERIOD:{period}\r\n",
+            "2026-08-16T09:59:00Z",
+            "2026-08-16T10:01:00Z");
+
+        result.Code.ShouldBe(CalendarOccurrenceQueryCode.RecurrenceUnevaluable);
+        result.Items.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task QueryOccurrencesAsync_RdatePeriodUnknownZoneRemainsTemporalUnresolved()
+    {
+        var result = await QuerySingleOccurrenceEventAsync(
+            "DTSTART:20260801T100000Z\r\nDURATION:PT1H\r\n"
+            + "RDATE;TZID=Private/Unknown;VALUE=PERIOD:20260816T100000/20260816T110000\r\n",
+            "2026-08-16T09:59:00Z",
+            "2026-08-16T10:01:00Z");
+
+        result.Code.ShouldBe(CalendarOccurrenceQueryCode.TemporalUnresolved);
+        result.Items.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task QueryOccurrencesAsync_PeriodRecurrenceDateInTimeZoneObservanceIsTypedUnevaluable()
+    {
+        var result = await QuerySingleOccurrenceEventAsync(
+            "DTSTART;TZID=Private/Zone:20260816T100000\r\nDURATION:PT1H\r\n",
+            "2026-08-16T07:59:00Z",
+            "2026-08-16T08:01:00Z",
+            calendarLines: "BEGIN:VTIMEZONE\r\nTZID:Private/Zone\r\nBEGIN:STANDARD\r\n"
+                + "DTSTART:20200101T000000\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0200\r\n"
+                + "RDATE;VALUE=PERIOD:20261025T030000/20261025T040000\r\n"
+                + "END:STANDARD\r\nEND:VTIMEZONE\r\n");
+
+        result.Code.ShouldBe(CalendarOccurrenceQueryCode.RecurrenceUnevaluable);
+        result.Items.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task QueryOccurrencesAsync_LocalDateTimeObservanceRecurrenceDateRemainsEffective()
+    {
+        var result = await QuerySingleOccurrenceEventAsync(
+            "DTSTART;TZID=Custom/Shift:20260816T100000\r\nDURATION:PT30M\r\n",
+            "2026-08-16T06:29:00Z",
+            "2026-08-16T06:31:00Z",
+            calendarLines: "BEGIN:VTIMEZONE\r\nTZID:Custom/Shift\r\nBEGIN:STANDARD\r\n"
+                + "DTSTART:20200101T000000\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0200\r\nEND:STANDARD\r\n"
+                + "BEGIN:DAYLIGHT\r\nDTSTART:20260816T020000\r\nRDATE:20260816T020000\r\n"
+                + "TZOFFSETFROM:+0200\r\nTZOFFSETTO:+0330\r\nEND:DAYLIGHT\r\nEND:VTIMEZONE\r\n");
+
+        var timing = result.Items.ShouldHaveSingleItem().Timing;
+        timing.EvaluatedStartUtc!.Value.ShouldBe("2026-08-16T06:30:00Z");
+    }
+
+    [Theory]
+    [InlineData("VEVENT", "DTEND:20260816T110000Z")]
+    [InlineData("VTODO", "DUE:20260816T110000Z")]
+    public async Task QueryOccurrencesAsync_DurationAndExplicitEndAreMutuallyExclusive(
+        string component,
+        string endLine)
+    {
+        var bytes = System.Text.Encoding.UTF8.GetBytes(
+            "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Example//EN\r\n"
+            + $"BEGIN:{component}\r\nUID:exclusive\r\nDTSTAMP:20260815T120000Z\r\n"
+            + $"DTSTART:20260816T100000Z\r\n{endLine}\r\nDURATION:PT1H\r\n"
+            + $"END:{component}\r\nEND:VCALENDAR\r\n");
+
+        var result = await QuerySingleOccurrenceAsync(
+            bytes,
+            component == "VEVENT" ? CalendarEntityKind.Event : CalendarEntityKind.Todo,
+            "2026-08-16T09:59:00Z",
+            "2026-08-16T10:01:00Z");
+
+        result.Code.ShouldBe(CalendarOccurrenceQueryCode.RecurrenceUnevaluable);
+        result.Items.ShouldBeEmpty();
+    }
+
+    [Theory]
+    [InlineData("VEVENT")]
+    [InlineData("VTODO")]
+    public async Task QueryOccurrencesAsync_DurationRequiresDtstart(string component)
+    {
+        var bytes = System.Text.Encoding.UTF8.GetBytes(
+            "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Example//EN\r\n"
+            + $"BEGIN:{component}\r\nUID:missing-start\r\nDTSTAMP:20260815T120000Z\r\nDURATION:PT1H\r\n"
+            + $"END:{component}\r\nEND:VCALENDAR\r\n");
+
+        var result = await QuerySingleOccurrenceAsync(
+            bytes,
+            component == "VEVENT" ? CalendarEntityKind.Event : CalendarEntityKind.Todo,
+            "2026-08-16T09:59:00Z",
+            "2026-08-16T10:01:00Z");
+
+        result.Code.ShouldBe(CalendarOccurrenceQueryCode.RecurrenceUnevaluable);
+        result.Items.ShouldBeEmpty();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(";RANGE=THISANDFUTURE")]
+    public async Task QueryOccurrencesAsync_OverrideDurationAndEndAreMutuallyExclusive(string rangeParameter)
+    {
+        var result = await QuerySingleOccurrenceEventAsync(
+            "DTSTART:20260815T100000Z\r\nDURATION:PT1H\r\nRRULE:FREQ=DAILY;COUNT=2\r\n"
+            + "END:VEVENT\r\nBEGIN:VEVENT\r\nUID:occurrence\r\nDTSTAMP:20260815T120000Z\r\n"
+            + $"RECURRENCE-ID{rangeParameter}:20260816T100000Z\r\n"
+            + "DTSTART:20260816T100000Z\r\nDTEND:20260816T110000Z\r\nDURATION:PT1H\r\n",
+            "2026-08-16T09:59:00Z",
+            "2026-08-16T10:01:00Z");
+
+        result.Code.ShouldBe(CalendarOccurrenceQueryCode.RecurrenceUnevaluable);
+        result.Items.ShouldBeEmpty();
+    }
+
+    [Theory]
+    [InlineData("PT24H")]
+    [InlineData("P1DT1H")]
+    public async Task QueryOccurrencesAsync_DateEventDurationMustUseOnlyDaysOrWeeks(string duration)
+    {
+        var result = await QuerySingleOccurrenceEventAsync(
+            $"DTSTART;VALUE=DATE:20260816\r\nDURATION:{duration}\r\n",
+            "2026-08-16T00:00:00Z",
+            "2026-08-17T00:00:00Z",
+            "UTC");
+
+        result.Code.ShouldBe(CalendarOccurrenceQueryCode.RecurrenceUnevaluable);
+        result.Items.ShouldBeEmpty();
+    }
+
+    [Theory]
+    [InlineData("P1D")]
+    [InlineData("P1W")]
+    public async Task QueryOccurrencesAsync_DateEventAcceptsDayOrWeekDuration(string duration)
+    {
+        var result = await QuerySingleOccurrenceEventAsync(
+            $"DTSTART;VALUE=DATE:20260816\r\nDURATION:{duration}\r\n",
+            "2026-08-16T00:00:00Z",
+            "2026-08-17T00:00:00Z",
+            "UTC");
+
+        result.Code.ShouldBe(CalendarOccurrenceQueryCode.Success);
+        result.Items.ShouldHaveSingleItem();
+    }
+
+    [Fact]
+    public async Task QueryOccurrencesAsync_DateTodoDurationMustUseOnlyDaysOrWeeks()
+    {
+        var bytes = System.Text.Encoding.UTF8.GetBytes(
+            "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Example//EN\r\n"
+            + "BEGIN:VTODO\r\nUID:date-duration\r\nDTSTAMP:20260815T120000Z\r\n"
+            + "DTSTART;VALUE=DATE:20260816\r\nDURATION:PT24H\r\n"
+            + "END:VTODO\r\nEND:VCALENDAR\r\n");
+
+        var result = await QuerySingleOccurrenceAsync(
+            bytes,
+            CalendarEntityKind.Todo,
+            "2026-08-16T00:00:00Z",
+            "2026-08-17T00:00:00Z",
+            "UTC");
+
+        result.Code.ShouldBe(CalendarOccurrenceQueryCode.RecurrenceUnevaluable);
+        result.Items.ShouldBeEmpty();
+    }
+
+    [Theory]
+    [InlineData("P1D")]
+    [InlineData("P1W")]
+    public async Task QueryOccurrencesAsync_DateTodoAcceptsDayOrWeekDuration(string duration)
+    {
+        var bytes = System.Text.Encoding.UTF8.GetBytes(
+            "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Example//EN\r\n"
+            + "BEGIN:VTODO\r\nUID:date-duration\r\nDTSTAMP:20260815T120000Z\r\n"
+            + $"DTSTART;VALUE=DATE:20260816\r\nDURATION:{duration}\r\n"
+            + "END:VTODO\r\nEND:VCALENDAR\r\n");
+
+        var result = await QuerySingleOccurrenceAsync(
+            bytes,
+            CalendarEntityKind.Todo,
+            "2026-08-16T00:00:00Z",
+            "2026-08-17T00:00:00Z",
+            "UTC");
+
+        result.Code.ShouldBe(CalendarOccurrenceQueryCode.Success);
+        result.Items.ShouldHaveSingleItem();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(";RANGE=THISANDFUTURE")]
+    public async Task QueryOccurrencesAsync_DateOverrideDurationMustUseOnlyDaysOrWeeks(string rangeParameter)
+    {
+        var result = await QuerySingleOccurrenceEventAsync(
+            "DTSTART;VALUE=DATE:20260815\r\nDURATION:P1D\r\nRRULE:FREQ=DAILY;COUNT=2\r\n"
+            + "END:VEVENT\r\nBEGIN:VEVENT\r\nUID:occurrence\r\nDTSTAMP:20260815T120000Z\r\n"
+            + $"RECURRENCE-ID;VALUE=DATE{rangeParameter}:20260816\r\n"
+            + "DTSTART;VALUE=DATE:20260816\r\nDURATION:P1DT1H\r\n",
+            "2026-08-16T00:00:00Z",
+            "2026-08-17T00:00:00Z",
+            "UTC");
+
+        result.Code.ShouldBe(CalendarOccurrenceQueryCode.RecurrenceUnevaluable);
+        result.Items.ShouldBeEmpty();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(";RANGE=THISANDFUTURE")]
+    public async Task QueryOccurrencesAsync_OverrideDurationMustBeStrictlyPositive(string rangeParameter)
+    {
+        var result = await QuerySingleOccurrenceEventAsync(
+            "DTSTART:20260801T100000Z\r\nDURATION:PT1H\r\nRRULE:FREQ=DAILY;COUNT=1\r\n"
+            + "END:VEVENT\r\nBEGIN:VEVENT\r\nUID:occurrence\r\nDTSTAMP:20260815T120000Z\r\n"
+            + $"RECURRENCE-ID{rangeParameter}:20260816T100000Z\r\n"
+            + "DTSTART:20260816T100000Z\r\nDURATION:-PT1H\r\n",
+            "2026-08-16T09:59:00Z",
+            "2026-08-16T10:01:00Z");
+
+        result.Code.ShouldBe(CalendarOccurrenceQueryCode.RecurrenceUnevaluable);
+        result.Items.ShouldBeEmpty();
+    }
+
+    [Theory]
+    [InlineData("20260307", "20260308", "2026-03-08T05:00:00Z", "2026-03-09", "2026-03-09T01:00:00", "2026-03-09T05:00:00Z")]
+    [InlineData("20261031", "20261101", "2026-11-01T04:00:00Z", "2026-11-02", "2026-11-01T23:00:00", "2026-11-02T04:00:00Z")]
+    public async Task QueryOccurrencesAsync_RecurringDateExactDurationKeepsSourceDateAndTruthfulEffectiveInstant(
+        string masterStart,
+        string masterEnd,
+        string secondStartUtc,
+        string expectedSourceEnd,
+        string expectedEffectiveEnd,
+        string expectedEndUtc)
+    {
+        var secondStart = DateTimeOffset.Parse(secondStartUtc);
+        var result = await QuerySingleOccurrenceEventAsync(
+            $"DTSTART;VALUE=DATE:{masterStart}\r\nDTEND;VALUE=DATE:{masterEnd}\r\n"
+            + "RRULE:FREQ=DAILY;COUNT=2\r\n",
+            secondStart.ToString("O"),
+            secondStart.AddMinutes(1).ToString("O"),
+            "America/New_York");
+
+        var timing = result.Items.ShouldHaveSingleItem().Timing;
+        timing.SourceEnd.ShouldBe(new CalendarTemporalValue(CalendarTemporalKind.Date, expectedSourceEnd));
+        timing.EffectiveEnd.ShouldBe(new CalendarTemporalValue(
+            CalendarTemporalKind.ZonedDateTime,
+            expectedEffectiveEnd,
+            "America/New_York"));
+        timing.EvaluatedEndUtc!.Value.ShouldBe(expectedEndUtc);
+    }
+
+    [Fact]
+    public async Task QueryOccurrencesAsync_RecurringTodoDateExactDurationUsesTruthfulEffectiveInstant()
+    {
+        var bytes = System.Text.Encoding.UTF8.GetBytes(
+            "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Example//EN\r\n"
+            + "BEGIN:VTODO\r\nUID:todo-duration\r\nDTSTAMP:20260815T120000Z\r\n"
+            + "DTSTART;VALUE=DATE:20260307\r\nDUE;VALUE=DATE:20260308\r\nRRULE:FREQ=DAILY;COUNT=2\r\n"
+            + "END:VTODO\r\nEND:VCALENDAR\r\n");
+
+        var result = await QuerySingleOccurrenceAsync(
+            bytes,
+            CalendarEntityKind.Todo,
+            "2026-03-08T05:00:00Z",
+            "2026-03-08T05:01:00Z",
+            "America/New_York");
+
+        var timing = result.Items.ShouldHaveSingleItem().Timing;
+        timing.SourceEnd.ShouldBe(new CalendarTemporalValue(CalendarTemporalKind.Date, "2026-03-09"));
+        timing.EffectiveEnd.ShouldBe(new CalendarTemporalValue(
+            CalendarTemporalKind.ZonedDateTime,
+            "2026-03-09T01:00:00",
+            "America/New_York"));
+        timing.EvaluatedEndUtc!.Value.ShouldBe("2026-03-09T05:00:00Z");
+    }
+
+    [Fact]
+    public async Task QueryOccurrencesAsync_RangeDateExactDurationKeepsSourceDateAndTruthfulEffectiveInstant()
+    {
+        var result = await QuerySingleOccurrenceEventAsync(
+            "DTSTART;VALUE=DATE:20260307\r\nDTEND;VALUE=DATE:20260308\r\n"
+            + "RRULE:FREQ=DAILY;COUNT=2\r\n"
+            + "END:VEVENT\r\nBEGIN:VEVENT\r\nUID:occurrence\r\nDTSTAMP:20260815T120000Z\r\n"
+            + "RECURRENCE-ID;VALUE=DATE;RANGE=THISANDFUTURE:20260307\r\n"
+            + "DTSTART;VALUE=DATE:20260307\r\nDTEND;VALUE=DATE:20260308\r\n",
+            "2026-03-08T05:00:00Z",
+            "2026-03-08T05:01:00Z",
+            "America/New_York");
+
+        var timing = result.Items.ShouldHaveSingleItem().Timing;
+        timing.SourceEnd.ShouldBe(new CalendarTemporalValue(CalendarTemporalKind.Date, "2026-03-09"));
+        timing.EffectiveEnd.ShouldBe(new CalendarTemporalValue(
+            CalendarTemporalKind.ZonedDateTime,
+            "2026-03-09T01:00:00",
+            "America/New_York"));
+        timing.EvaluatedEndUtc!.Value.ShouldBe("2026-03-09T05:00:00Z");
+    }
+
+    [Theory]
+    [InlineData("P1D", "2026-03-08T14:00:00Z", "2026-03-08T10:00:00")]
+    [InlineData("PT24H", "2026-03-08T15:00:00Z", "2026-03-08T11:00:00")]
+    public async Task QueryOccurrencesAsync_RangeDurationUsesPerInstanceNominalThenAccurateArithmetic(
+        string duration,
+        string expectedEndUtc,
+        string expectedEndLocal)
+    {
+        var result = await QuerySingleOccurrenceEventAsync(
+            "DTSTART;TZID=America/New_York:20260301T100000\r\nRRULE:FREQ=DAILY;COUNT=1\r\n"
+            + "END:VEVENT\r\nBEGIN:VEVENT\r\nUID:occurrence\r\nDTSTAMP:20260815T120000Z\r\n"
+            + "RECURRENCE-ID;TZID=America/New_York;RANGE=THISANDFUTURE:20260307T100000\r\n"
+            + $"DTSTART;TZID=America/New_York:20260307T100000\r\nDURATION:{duration}\r\n",
+            "2026-03-07T14:59:00Z",
+            "2026-03-07T15:01:00Z");
+
+        var timing = result.Items.ShouldHaveSingleItem().Timing;
+        timing.EvaluatedEndUtc!.Value.ShouldBe(expectedEndUtc);
+        timing.EffectiveEnd!.Value.ShouldBe(expectedEndLocal);
+    }
+
+    [Fact]
+    public async Task QueryOccurrencesAsync_RecurringExplicitEndPropagatesExactDurationAcrossDst()
+    {
+        var result = await QuerySingleOccurrenceEventAsync(
+            "DTSTART;TZID=America/New_York:20260306T100000\r\n"
+            + "DTEND;TZID=America/New_York:20260307T100000\r\nRRULE:FREQ=DAILY;COUNT=2\r\n",
+            "2026-03-07T15:00:00Z",
+            "2026-03-07T15:01:00Z");
+
+        var timing = result.Items.ShouldHaveSingleItem().Timing;
+        timing.EffectiveEnd!.Value.ShouldBe("2026-03-08T11:00:00");
+        timing.EvaluatedEndUtc!.Value.ShouldBe("2026-03-08T15:00:00Z");
+    }
+
+    [Fact]
+    public async Task QueryOccurrencesAsync_RangeExplicitEndPropagatesExactDurationAfterAnchor()
+    {
+        var result = await QuerySingleOccurrenceEventAsync(
+            "DTSTART;TZID=America/New_York:20260306T100000\r\nRRULE:FREQ=DAILY;COUNT=2\r\n"
+            + "END:VEVENT\r\nBEGIN:VEVENT\r\nUID:occurrence\r\nDTSTAMP:20260815T120000Z\r\n"
+            + "RECURRENCE-ID;TZID=America/New_York;RANGE=THISANDFUTURE:20260306T100000\r\n"
+            + "DTSTART;TZID=America/New_York:20260306T100000\r\n"
+            + "DTEND;TZID=America/New_York:20260307T100000\r\n",
+            "2026-03-07T15:00:00Z",
+            "2026-03-07T15:01:00Z");
+
+        var timing = result.Items.ShouldHaveSingleItem().Timing;
+        timing.EffectiveEnd!.Value.ShouldBe("2026-03-08T11:00:00");
+        timing.EvaluatedEndUtc!.Value.ShouldBe("2026-03-08T15:00:00Z");
+    }
+
+    [Fact]
+    public async Task QueryOccurrencesAsync_RecurringTodoDuePropagatesExactDurationAcrossDst()
+    {
+        var bytes = System.Text.Encoding.UTF8.GetBytes(
+            "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Example//EN\r\n"
+            + "BEGIN:VTODO\r\nUID:todo-duration\r\nDTSTAMP:20260815T120000Z\r\n"
+            + "DTSTART;TZID=America/New_York:20260306T100000\r\n"
+            + "DUE;TZID=America/New_York:20260307T100000\r\nRRULE:FREQ=DAILY;COUNT=2\r\n"
+            + "END:VTODO\r\nEND:VCALENDAR\r\n");
+
+        var result = await QuerySingleOccurrenceAsync(
+            bytes,
+            CalendarEntityKind.Todo,
+            "2026-03-07T15:00:00Z",
+            "2026-03-07T15:01:00Z");
+
+        var timing = result.Items.ShouldHaveSingleItem().Timing;
+        timing.EffectiveEnd!.Value.ShouldBe("2026-03-08T11:00:00");
+        timing.EvaluatedEndUtc!.Value.ShouldBe("2026-03-08T15:00:00Z");
+    }
+
+    [Fact]
+    public async Task QueryOccurrencesAsync_WeekDurationRemainsNominalAcrossDst()
+    {
+        var result = await QuerySingleOccurrenceEventAsync(
+            "DTSTART;TZID=Europe/Zurich:20260328T100000\r\nDURATION:P1W\r\n",
+            "2026-03-28T08:59:00Z",
+            "2026-03-28T09:01:00Z");
+
+        var timing = result.Items.ShouldHaveSingleItem().Timing;
+        timing.EffectiveEnd!.Value.ShouldBe("2026-04-04T10:00:00");
+        timing.EvaluatedEndUtc!.Value.ShouldBe("2026-04-04T08:00:00Z");
+    }
+
+    [Theory]
+    [InlineData("P")]
+    [InlineData("PT")]
+    [InlineData("P1W1D")]
+    [InlineData("P1WT1H")]
+    [InlineData("P1H")]
+    [InlineData("PT1H30S")]
+    [InlineData("P1D1H")]
+    [InlineData("P-1D")]
+    public void CalendarDurationParser_RejectsNonRfcGrammar(string rawDuration)
+    {
+        CalendarDurationArithmetic.TryParse(rawDuration, out _).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void CalendarDurationParser_RecognizesNominalWeek()
+    {
+        CalendarDurationArithmetic.TryParse("P1W", out var duration).ShouldBeTrue();
+        duration.NominalDays.ShouldBe(7);
+        duration.Accurate.ShouldBe(TimeSpan.Zero);
+    }
+
+    [Theory]
+    [InlineData("+P1D", 1, 0)]
+    [InlineData("-P2D", -2, 0)]
+    [InlineData("P0D", 0, 0)]
+    [InlineData("-PT0S", 0, 0)]
+    [InlineData("PT1H", 0, 3600)]
+    [InlineData("PT2M3S", 0, 123)]
+    [InlineData("PT3S", 0, 3)]
+    [InlineData("P1DT2H3M4S", 1, 7384)]
+    public void CalendarDurationParser_PreservesNominalAndAccurateComponents(
+        string rawDuration,
+        int expectedNominalDays,
+        int expectedAccurateSeconds)
+    {
+        CalendarDurationArithmetic.TryParse(rawDuration, out var duration).ShouldBeTrue();
+        duration.NominalDays.ShouldBe(expectedNominalDays);
+        duration.Accurate.ShouldBe(TimeSpan.FromSeconds(expectedAccurateSeconds));
+    }
+
+    [Fact]
+    public async Task QueryOccurrencesAsync_RecurringDateSearchIncludesTwentyFiveHourFallBackSpan()
+    {
+        var result = await QuerySingleOccurrenceEventAsync(
+            "DTSTART;VALUE=DATE:20261101\r\nRRULE:FREQ=DAILY;COUNT=1\r\n",
+            "2026-11-02T04:30:00Z",
+            "2026-11-02T04:45:00Z",
+            "America/New_York");
+
+        var timing = result.Items.ShouldHaveSingleItem().Timing;
+        timing.EvaluatedStartUtc!.Value.ShouldBe("2026-11-01T04:00:00Z");
+        timing.EvaluatedEndUtc!.Value.ShouldBe("2026-11-02T05:00:00Z");
+    }
+
+    [Fact]
+    public async Task QueryOccurrencesAsync_MultipleRrulesAreTypedRecurrenceUnevaluableWithNoPartialItems()
+    {
+        var result = await QuerySingleOccurrenceEventAsync(
+            "DTSTART:20260815T100000Z\r\nDURATION:PT1H\r\n"
+            + "RRULE:FREQ=DAILY;COUNT=2\r\nRRULE:FREQ=WEEKLY;COUNT=2\r\n",
+            "2026-08-15T00:00:00Z",
+            "2026-08-20T00:00:00Z");
+
+        result.Code.ShouldBe(CalendarOccurrenceQueryCode.RecurrenceUnevaluable);
+        result.Items.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task QueryOccurrencesAsync_FloatingComparisonRequiresExplicitEvaluationTimeZoneOnlyWhenEncountered()
+    {
+        const string calendarHref = "https://cal.example/events/";
+        const string resourceHref = "https://cal.example/events/floating.ics";
+        var client = Substitute.For<ICalendarClient>();
+        var sut = new CalendarService(
+            client,
+            Options.Create(new CalDavOptions { BaseUrl = "https://cal.example" }),
+            Substitute.For<ILogger<CalendarService>>());
+        client.GetCalendarsAsync(Arg.Any<CancellationToken>()).Returns(
+            [EntityCalendar(calendarHref, "Events", EntityKindSupport.Advertised, EntityKindSupport.NotAdvertised)]);
+        client.QueryCalendarResourceHrefsAsync(calendarHref, CalendarEntityKind.Event, null, null, Arg.Any<CancellationToken>())
+            .Returns([resourceHref]);
+        client.QueryCalendarResourceHrefsAsync(calendarHref, CalendarEntityKind.Todo, null, null, Arg.Any<CancellationToken>())
+            .Returns([]);
+        client.GetCalendarResourceAsync(resourceHref, Arg.Any<CancellationToken>()).Returns(
+            CalendarResourceRead.Success(resourceHref, "\"r1\"", EventWithRawStart("floating", string.Empty, "20260816T100000")));
+        var scope = CalendarEntityScope.Selected(new CalendarReference(Href: calendarHref));
+        var from = DateTimeOffset.Parse("2026-08-16T13:30:00Z");
+        var to = DateTimeOffset.Parse("2026-08-16T14:30:00Z");
+
+        var unresolved = await sut.QueryOccurrencesAsync(
+            new CalendarOccurrenceQuery(scope, from, to),
+            CancellationToken.None);
+        var evaluated = await sut.QueryOccurrencesAsync(
+            new CalendarOccurrenceQuery(scope, from, to, "America/New_York"),
+            CancellationToken.None);
+
+        unresolved.Code.ShouldBe(CalendarOccurrenceQueryCode.TemporalUnresolved);
+        unresolved.Items.ShouldBeEmpty();
+        var occurrence = evaluated.Items.ShouldHaveSingleItem();
+        occurrence.Timing.EffectiveStart.Kind.ShouldBe(CalendarTemporalKind.FloatingDateTime);
+        occurrence.Timing.EffectiveStart.Value.ShouldBe("2026-08-16T10:00:00");
+        occurrence.Timing.EvaluatedStartUtc!.Value.ShouldBe("2026-08-16T14:00:00Z");
+        occurrence.Timing.EvaluationTimeZone.ShouldBe("America/New_York");
+    }
+
+    [Fact]
+    public async Task QueryOccurrencesAsync_RejectsInvalidEvaluationTimeZoneBeforeDiscovery()
+    {
+        var client = Substitute.For<ICalendarClient>();
+        var sut = new CalendarService(
+            client,
+            Options.Create(new CalDavOptions { BaseUrl = "https://cal.example" }),
+            Substitute.For<ILogger<CalendarService>>());
+
+        var result = await sut.QueryOccurrencesAsync(
+            new CalendarOccurrenceQuery(
+                CalendarEntityScope.Default,
+                DateTimeOffset.Parse("2026-08-16T00:00:00Z"),
+                DateTimeOffset.Parse("2026-08-17T00:00:00Z"),
+                "Central Standard Time"),
+            CancellationToken.None);
+
+        result.Code.ShouldBe(CalendarOccurrenceQueryCode.InvalidInput);
+        result.Items.ShouldBeEmpty();
+        await client.DidNotReceive().GetCalendarsAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Theory]
+    [InlineData("20260329T023000", "2026-03-29T01:30:00Z")]
+    [InlineData("20261025T023000", "2026-10-25T00:30:00Z")]
+    public async Task QueryOccurrencesAsync_ExplicitIanaGapUsesPriorOffsetAndOverlapUsesFirstOccurrence(
+        string localStart,
+        string expectedUtc)
+    {
+        var expected = DateTimeOffset.Parse(expectedUtc);
+        var result = await QuerySingleOccurrenceEventAsync(
+            $"DTSTART;TZID=Europe/Zurich:{localStart}\r\nDURATION:PT30M\r\n",
+            expected.AddMinutes(-1).ToString("O"),
+            expected.AddMinutes(1).ToString("O"));
+
+        result.Code.ShouldBe(CalendarOccurrenceQueryCode.Success);
+        result.Items.ShouldHaveSingleItem().Timing.EvaluatedStartUtc!.Value.ShouldBe(expectedUtc);
+    }
+
+    [Fact]
+    public async Task QueryOccurrencesAsync_IanaRruleSkipsGapWithoutConsumingCount()
+    {
+        const string recurrence = "DTSTART;TZID=Europe/Zurich:20260328T023000\r\n"
+            + "DURATION:PT30M\r\nRRULE:FREQ=DAILY;COUNT=2\r\n";
+        var gap = await QuerySingleOccurrenceEventAsync(
+            recurrence,
+            "2026-03-29T01:29:00Z",
+            "2026-03-29T01:31:00Z");
+        var afterGap = await QuerySingleOccurrenceEventAsync(
+            recurrence,
+            "2026-03-30T00:29:00Z",
+            "2026-03-30T00:31:00Z");
+
+        gap.Code.ShouldBe(CalendarOccurrenceQueryCode.Success);
+        gap.Items.ShouldBeEmpty();
+        afterGap.Items.ShouldHaveSingleItem().RecurrenceIdentity.Value.ShouldBe("2026-03-30T02:30:00");
+    }
+
+    [Fact]
+    public async Task QueryOccurrencesAsync_ExplicitFloatingGapUsesPriorEvaluationZoneOffset()
+    {
+        var result = await QuerySingleOccurrenceEventAsync(
+            "DTSTART:20260329T023000\r\nDURATION:PT30M\r\n",
+            "2026-03-29T01:29:00Z",
+            "2026-03-29T01:31:00Z",
+            "Europe/Zurich");
+
+        result.Code.ShouldBe(CalendarOccurrenceQueryCode.Success);
+        result.Items.ShouldHaveSingleItem().Timing.EvaluatedStartUtc!.Value.ShouldBe("2026-03-29T01:30:00Z");
+    }
+
+    [Fact]
+    public async Task QueryOccurrencesAsync_FloatingRruleSkipsEvaluationZoneGapWithoutConsumingCount()
+    {
+        const string recurrence = "DTSTART:20260328T023000\r\n"
+            + "DURATION:PT30M\r\nRRULE:FREQ=DAILY;COUNT=2\r\n";
+        var gap = await QuerySingleOccurrenceEventAsync(
+            recurrence,
+            "2026-03-29T01:29:00Z",
+            "2026-03-29T01:31:00Z",
+            "Europe/Zurich");
+        var afterGap = await QuerySingleOccurrenceEventAsync(
+            recurrence,
+            "2026-03-30T00:29:00Z",
+            "2026-03-30T00:31:00Z",
+            "Europe/Zurich");
+
+        gap.Code.ShouldBe(CalendarOccurrenceQueryCode.Success);
+        gap.Items.ShouldBeEmpty();
+        afterGap.Items.ShouldHaveSingleItem().RecurrenceIdentity.Value.ShouldBe("2026-03-30T02:30:00");
+    }
+
+    [Theory]
+    [InlineData("20260329T023000", "2026-03-29T01:30:00Z")]
+    [InlineData("20261025T023000", "2026-10-25T00:30:00Z")]
+    public async Task QueryOccurrencesAsync_ExplicitResourceLocalGapAndOverlapFollowRfc5545(
+        string localStart,
+        string expectedUtc)
+    {
+        var expected = DateTimeOffset.Parse(expectedUtc);
+        var result = await QuerySingleOccurrenceEventAsync(
+            $"DTSTART;TZID=Private/Zurich:{localStart}\r\nDURATION:PT30M\r\n",
+            expected.AddMinutes(-1).ToString("O"),
+            expected.AddMinutes(1).ToString("O"),
+            calendarLines: ResourceLocalDstZone());
+
+        result.Code.ShouldBe(CalendarOccurrenceQueryCode.Success);
+        result.Items.ShouldHaveSingleItem().Timing.EvaluatedStartUtc!.Value.ShouldBe(expectedUtc);
+    }
+
+    [Fact]
+    public async Task QueryOccurrencesAsync_ResourceLocalRruleSkipsGapWithoutConsumingCount()
+    {
+        const string recurrence = "DTSTART;TZID=Private/Zurich:20260328T023000\r\n"
+            + "DURATION:PT30M\r\nRRULE:FREQ=DAILY;COUNT=2\r\n";
+        var gap = await QuerySingleOccurrenceEventAsync(
+            recurrence,
+            "2026-03-29T01:29:00Z",
+            "2026-03-29T01:31:00Z",
+            calendarLines: ResourceLocalDstZone());
+        var afterGap = await QuerySingleOccurrenceEventAsync(
+            recurrence,
+            "2026-03-30T00:29:00Z",
+            "2026-03-30T00:31:00Z",
+            calendarLines: ResourceLocalDstZone());
+
+        gap.Code.ShouldBe(CalendarOccurrenceQueryCode.Success);
+        gap.Items.ShouldBeEmpty();
+        afterGap.Items.ShouldHaveSingleItem().RecurrenceIdentity.Value.ShouldBe("2026-03-30T02:30:00");
+    }
+
+    [Theory]
+    [InlineData("Europe/Zurich", null, false)]
+    [InlineData("Private/Zurich", null, true)]
+    [InlineData(null, "Europe/Zurich", false)]
+    public async Task QueryOccurrencesAsync_RruleOverlapUsesFirstOccurrenceExactlyOnce(
+        string? timeZoneId,
+        string? evaluationTimeZone,
+        bool resourceLocal)
+    {
+        var parameter = timeZoneId is null ? string.Empty : $";TZID={timeZoneId}";
+        var result = await QuerySingleOccurrenceEventAsync(
+            $"DTSTART{parameter}:20261024T023000\r\nDURATION:PT30M\r\nRRULE:FREQ=DAILY;COUNT=2\r\n",
+            "2026-10-25T00:29:00Z",
+            "2026-10-25T00:31:00Z",
+            evaluationTimeZone,
+            resourceLocal ? ResourceLocalDstZone() : string.Empty);
+
+        var occurrence = result.Items.ShouldHaveSingleItem();
+        occurrence.Timing.EvaluatedStartUtc!.Value.ShouldBe("2026-10-25T00:30:00Z");
+    }
+
+    [Fact]
+    public async Task QueryOccurrencesAsync_IanaDailyRecurrencePreservesWallTimeAcrossDst()
+    {
+        var result = await QuerySingleOccurrenceEventAsync(
+            "DTSTART;TZID=America/New_York:20260307T100000\r\nDURATION:PT1H\r\nRRULE:FREQ=DAILY;COUNT=3\r\n",
+            "2026-03-08T14:30:00Z",
+            "2026-03-08T14:45:00Z");
+
+        var occurrence = result.Items.ShouldHaveSingleItem();
+        occurrence.RecurrenceIdentity.ShouldBe(new CalendarTemporalValue(
+            CalendarTemporalKind.ZonedDateTime,
+            "2026-03-08T10:00:00",
+            "America/New_York"));
+        occurrence.Timing.EvaluatedStartUtc!.Value.ShouldBe("2026-03-08T14:00:00Z");
+    }
+
+    [Fact]
+    public async Task QueryOccurrencesAsync_LeapRuleFindsNextLeapDayWithoutServerExpansion()
+    {
+        var result = await QuerySingleOccurrenceEventAsync(
+            "DTSTART:20240229T100000Z\r\nDURATION:PT1H\r\nRRULE:FREQ=YEARLY;COUNT=3\r\n",
+            "2028-02-29T10:30:00Z",
+            "2028-02-29T10:45:00Z");
+
+        result.Items.ShouldHaveSingleItem().RecurrenceIdentity.Value.ShouldBe("2028-02-29T10:00:00Z");
+    }
+
+    [Fact]
+    public async Task QueryOccurrencesAsync_UnknownNamedZoneIsTypedTemporalUnresolved()
+    {
+        var result = await QuerySingleOccurrenceEventAsync(
+            "DTSTART;TZID=Private/Office:20260816T100000\r\nDURATION:PT1H\r\n",
+            "2026-08-16T00:00:00Z",
+            "2026-08-17T00:00:00Z");
+
+        result.Code.ShouldBe(CalendarOccurrenceQueryCode.TemporalUnresolved);
+        result.Items.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task QueryOccurrencesAsync_ExdateSuppressedUnknownZoneOverrideDoesNotRequireResolution()
+    {
+        var result = await QuerySingleOccurrenceEventAsync(
+            "DTSTART:20260815T100000Z\r\nDURATION:PT1H\r\nRRULE:FREQ=DAILY;COUNT=1\r\n"
+            + "EXDATE:20260820T100000Z\r\n"
+            + "END:VEVENT\r\nBEGIN:VEVENT\r\nUID:occurrence\r\nDTSTAMP:20260815T120000Z\r\n"
+            + "RECURRENCE-ID:20260820T100000Z\r\n"
+            + "DTSTART;TZID=Mars/Base:20260821T100000\r\nDURATION:PT1H\r\n",
+            "2026-08-20T00:00:00Z",
+            "2026-08-22T00:00:00Z");
+
+        result.Code.ShouldBe(CalendarOccurrenceQueryCode.Success);
+        result.Items.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task QueryOccurrencesAsync_CancelledUnknownZoneOverrideDoesNotRequireResolution()
+    {
+        var result = await QuerySingleOccurrenceEventAsync(
+            "DTSTART:20260815T100000Z\r\nDURATION:PT1H\r\nRRULE:FREQ=DAILY;COUNT=1\r\n"
+            + "END:VEVENT\r\nBEGIN:VEVENT\r\nUID:occurrence\r\nDTSTAMP:20260815T120000Z\r\n"
+            + "RECURRENCE-ID:20260820T100000Z\r\n"
+            + "DTSTART;TZID=Mars/Base:20260821T100000\r\nSTATUS:CANCELLED\r\n",
+            "2026-08-20T00:00:00Z",
+            "2026-08-22T00:00:00Z");
+
+        result.Code.ShouldBe(CalendarOccurrenceQueryCode.Success);
+        result.Items.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task QueryOccurrencesAsync_ActiveUnknownZoneOverrideRemainsTypedTemporalUnresolved()
+    {
+        var result = await QuerySingleOccurrenceEventAsync(
+            "DTSTART:20260815T100000Z\r\nDURATION:PT1H\r\nRRULE:FREQ=DAILY;COUNT=1\r\n"
+            + "END:VEVENT\r\nBEGIN:VEVENT\r\nUID:occurrence\r\nDTSTAMP:20260815T120000Z\r\n"
+            + "RECURRENCE-ID:20260820T100000Z\r\n"
+            + "DTSTART;TZID=Mars/Base:20260821T100000\r\nDURATION:PT1H\r\n",
+            "2026-08-20T00:00:00Z",
+            "2026-08-22T00:00:00Z");
+
+        result.Code.ShouldBe(CalendarOccurrenceQueryCode.TemporalUnresolved);
+        result.Items.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task QueryOccurrencesAsync_ConflictingResourceLocalZonesAreTypedTemporalUnresolved()
+    {
+        const string zone = "BEGIN:VTIMEZONE\r\nTZID:Private/Office\r\nBEGIN:STANDARD\r\n"
+            + "DTSTART:20200101T000000\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0200\r\n"
+            + "END:STANDARD\r\nEND:VTIMEZONE\r\n";
+        var result = await QuerySingleOccurrenceEventAsync(
+            "DTSTART;TZID=Private/Office:20260816T100000\r\nDURATION:PT1H\r\n",
+            "2026-08-16T00:00:00Z",
+            "2026-08-17T00:00:00Z",
+            calendarLines: zone + zone);
+
+        result.Code.ShouldBe(CalendarOccurrenceQueryCode.TemporalUnresolved);
+        result.Items.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task QueryOccurrencesAsync_ResourceLocalRecurringZoneIsEvaluatedWithoutIanaFallback()
+    {
+        const string zone = "BEGIN:VTIMEZONE\r\nTZID:Private/Office\r\nBEGIN:STANDARD\r\n"
+            + "DTSTART:20200101T000000\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0200\r\n"
+            + "END:STANDARD\r\nEND:VTIMEZONE\r\n";
+        var result = await QuerySingleOccurrenceEventAsync(
+            "DTSTART;TZID=Private/Office:20260815T100000\r\nDURATION:PT1H\r\nRRULE:FREQ=DAILY;COUNT=2\r\n",
+            "2026-08-16T08:30:00Z",
+            "2026-08-16T08:45:00Z",
+            calendarLines: zone);
+
+        result.Code.ShouldBe(CalendarOccurrenceQueryCode.Success);
+        var occurrence = result.Items.ShouldHaveSingleItem();
+        occurrence.RecurrenceIdentity.TimeZoneId.ShouldBe("Private/Office");
+        occurrence.Timing.EvaluatedStartUtc!.Value.ShouldBe("2026-08-16T08:00:00Z");
+    }
+
+    [Fact]
+    public async Task QueryOccurrencesAsync_UnambiguousResourceLocalTimeZonePrecedesIanaDefinition()
+    {
+        const string calendarHref = "https://cal.example/events/";
+        const string resourceHref = "https://cal.example/events/local-zone.ics";
+        var client = Substitute.For<ICalendarClient>();
+        var sut = new CalendarService(
+            client,
+            Options.Create(new CalDavOptions { BaseUrl = "https://cal.example" }),
+            Substitute.For<ILogger<CalendarService>>());
+        client.GetCalendarsAsync(Arg.Any<CancellationToken>()).Returns(
+            [EntityCalendar(calendarHref, "Events", EntityKindSupport.Advertised, EntityKindSupport.NotAdvertised)]);
+        client.QueryCalendarResourceHrefsAsync(calendarHref, CalendarEntityKind.Event, null, null, Arg.Any<CancellationToken>())
+            .Returns([resourceHref]);
+        client.QueryCalendarResourceHrefsAsync(calendarHref, CalendarEntityKind.Todo, null, null, Arg.Any<CancellationToken>())
+            .Returns([]);
+        client.GetCalendarResourceAsync(resourceHref, Arg.Any<CancellationToken>()).Returns(
+            CalendarResourceRead.Success(resourceHref, "\"r1\"", ResourceLocalZoneEvent()));
+
+        var result = await sut.QueryOccurrencesAsync(
+            new CalendarOccurrenceQuery(
+                CalendarEntityScope.Selected(new CalendarReference(Href: calendarHref)),
+                DateTimeOffset.Parse("2026-08-16T07:30:00Z"),
+                DateTimeOffset.Parse("2026-08-16T08:30:00Z")),
+            CancellationToken.None);
+
+        var occurrence = result.Items.ShouldHaveSingleItem();
+        occurrence.Timing.EffectiveStart.Kind.ShouldBe(CalendarTemporalKind.ZonedDateTime);
+        occurrence.Timing.EffectiveStart.TimeZoneId.ShouldBe("America/New_York");
+        occurrence.Timing.EvaluatedStartUtc!.Value.ShouldBe("2026-08-16T08:00:00Z");
+    }
+
+    [Fact]
+    public async Task QueryOccurrencesAsync_RdatePeriodSuppliesOccurrenceSpecificSpan()
+    {
+        var result = await QuerySingleOccurrenceEventAsync(
+            "DTSTART:20260814T100000Z\r\nDURATION:PT1H\r\n"
+            + "RDATE;VALUE=PERIOD:20260816T100000Z/20260816T130000Z\r\n",
+            "2026-08-16T12:30:00Z",
+            "2026-08-16T12:45:00Z");
+
+        var occurrence = result.Items.ShouldHaveSingleItem();
+        occurrence.RecurrenceIdentity.Value.ShouldBe("2026-08-16T10:00:00Z");
+        occurrence.Timing.SourceEnd!.Value.ShouldBe("2026-08-16T13:00:00Z");
+        occurrence.Timing.EffectiveEnd!.Value.ShouldBe("2026-08-16T13:00:00Z");
+    }
+
+    [Fact]
+    public async Task QueryOccurrencesAsync_RdatePeriodDeduplicatesAndOverrideUsesOccurrenceSpecificSourceSpan()
+    {
+        var result = await QuerySingleOccurrenceEventAsync(
+            "DTSTART:20260815T100000Z\r\nDURATION:PT1H\r\nRRULE:FREQ=DAILY;COUNT=2\r\n"
+            + "RDATE;VALUE=PERIOD:20260816T100000Z/PT3H\r\n"
+            + "END:VEVENT\r\nBEGIN:VEVENT\r\nUID:occurrence\r\nDTSTAMP:20260815T120000Z\r\n"
+            + "RECURRENCE-ID:20260816T100000Z\r\nDTSTART:20260816T150000Z\r\nDURATION:PT2H\r\n",
+            "2026-08-16T15:30:00Z",
+            "2026-08-16T15:45:00Z");
+
+        result.Code.ShouldBe(CalendarOccurrenceQueryCode.Success);
+        var occurrence = result.Items.ShouldHaveSingleItem();
+        occurrence.RecurrenceIdentity.Value.ShouldBe("2026-08-16T10:00:00Z");
+        occurrence.Timing.SourceEnd!.Value.ShouldBe("2026-08-16T13:00:00Z");
+        occurrence.Timing.SourceDuration.ShouldBe("PT3H");
+        occurrence.Timing.EffectiveStart.Value.ShouldBe("2026-08-16T15:00:00Z");
+        occurrence.Timing.EffectiveEnd!.Value.ShouldBe("2026-08-16T17:00:00Z");
+        occurrence.Timing.EffectiveDuration.ShouldBe("PT2H");
+    }
+
+    [Fact]
+    public async Task QueryOccurrencesAsync_ExdateSuppressesDuplicateRdatePeriodAndItsOverride()
+    {
+        var result = await QuerySingleOccurrenceEventAsync(
+            "DTSTART:20260815T100000Z\r\nDURATION:PT1H\r\nRRULE:FREQ=DAILY;COUNT=2\r\n"
+            + "RDATE;VALUE=PERIOD:20260816T100000Z/PT3H\r\nEXDATE:20260816T100000Z\r\n"
+            + "END:VEVENT\r\nBEGIN:VEVENT\r\nUID:occurrence\r\nDTSTAMP:20260815T120000Z\r\n"
+            + "RECURRENCE-ID:20260816T100000Z\r\nDTSTART:20260816T150000Z\r\nDURATION:PT2H\r\n",
+            "2026-08-16T00:00:00Z",
+            "2026-08-17T00:00:00Z");
+
+        result.Code.ShouldBe(CalendarOccurrenceQueryCode.Success);
+        result.Items.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task QueryOccurrencesAsync_DateOnlyEventDefaultsToOneLocalDay()
+    {
+        var result = await QuerySingleOccurrenceEventAsync(
+            "DTSTART;VALUE=DATE:20260816\r\n",
+            "2026-08-17T03:30:00Z",
+            "2026-08-17T03:45:00Z",
+            "America/New_York");
+
+        var occurrence = result.Items.ShouldHaveSingleItem();
+        occurrence.RecurrenceIdentity.ShouldBe(new CalendarTemporalValue(CalendarTemporalKind.Date, "2026-08-16"));
+        occurrence.Timing.EffectiveEnd.ShouldBe(new CalendarTemporalValue(CalendarTemporalKind.Date, "2026-08-17"));
+        occurrence.Timing.EvaluatedStartUtc!.Value.ShouldBe("2026-08-16T04:00:00Z");
+        occurrence.Timing.EvaluatedEndUtc!.Value.ShouldBe("2026-08-17T04:00:00Z");
+    }
+
+    [Fact]
+    public async Task QueryOccurrencesAsync_DateOnlyTodoStartAndDueAreLocalPoints()
+    {
+        const string calendarHref = "https://cal.example/todos/";
+        var startHref = $"{calendarHref}start.ics";
+        var dueHref = $"{calendarHref}due.ics";
+        var client = Substitute.For<ICalendarClient>();
+        var sut = new CalendarService(
+            client,
+            Options.Create(new CalDavOptions { BaseUrl = "https://cal.example" }),
+            Substitute.For<ILogger<CalendarService>>());
+        client.GetCalendarsAsync(Arg.Any<CancellationToken>()).Returns(
+            [EntityCalendar(calendarHref, "To-dos", EntityKindSupport.NotAdvertised, EntityKindSupport.Advertised)]);
+        client.QueryCalendarResourceHrefsAsync(calendarHref, CalendarEntityKind.Event, null, null, Arg.Any<CancellationToken>())
+            .Returns([]);
+        client.QueryCalendarResourceHrefsAsync(calendarHref, CalendarEntityKind.Todo, null, null, Arg.Any<CancellationToken>())
+            .Returns([startHref, dueHref]);
+        client.GetCalendarResourceAsync(startHref, Arg.Any<CancellationToken>()).Returns(
+            CalendarResourceRead.Success(startHref, "\"s1\"", TodoWithTemporalLines("start", "DTSTART;VALUE=DATE:20260816\r\n")));
+        client.GetCalendarResourceAsync(dueHref, Arg.Any<CancellationToken>()).Returns(
+            CalendarResourceRead.Success(dueHref, "\"d1\"", TodoWithTemporalLines("due", "DUE;VALUE=DATE:20260816\r\n")));
+
+        var result = await sut.QueryOccurrencesAsync(
+            new CalendarOccurrenceQuery(
+                CalendarEntityScope.Selected(new CalendarReference(Href: calendarHref)),
+                DateTimeOffset.Parse("2026-08-16T03:59:59Z"),
+                DateTimeOffset.Parse("2026-08-16T04:00:01Z"),
+                "America/New_York"),
+            CancellationToken.None);
+
+        result.Items.Select(item => item.Snapshot.Projection.EntityUid).ShouldBe(["due", "start"]);
+        result.Items.ShouldAllBe(item => item.Timing.EffectiveStart.Kind == CalendarTemporalKind.Date);
+        result.Items.ShouldAllBe(item => item.Timing.EvaluatedStartUtc!.Value == "2026-08-16T04:00:00Z");
+        result.Items.ShouldAllBe(item => item.Timing.EffectiveEnd == null);
+    }
+
+    [Fact]
+    public async Task QueryOccurrencesAsync_DateOnlyExdateListResolvesEachIdentity()
+    {
+        var result = await QuerySingleOccurrenceEventAsync(
+            "DTSTART;VALUE=DATE:20260815\r\nRRULE:FREQ=DAILY;COUNT=4\r\n"
+            + "EXDATE;VALUE=DATE:20260816,20260817\r\n",
+            "2026-08-15T00:00:00Z",
+            "2026-08-19T00:00:00Z",
+            "UTC");
+
+        result.Code.ShouldBe(CalendarOccurrenceQueryCode.Success);
+        result.Items.Select(item => item.RecurrenceIdentity.Value).ShouldBe(["2026-08-15", "2026-08-18"]);
+    }
+
+    [Theory]
+    [InlineData(2000, CalendarOccurrenceQueryCode.Success, 2000, null)]
+    [InlineData(2001, CalendarOccurrenceQueryCode.LimitExhausted, 0, 2001)]
+    public async Task QueryOccurrencesAsync_EnforcesExactPerEntityOccurrenceBoundaryWithZeroPartial(
+        int occurrenceCount,
+        CalendarOccurrenceQueryCode expectedCode,
+        int expectedItems,
+        int? expectedObservedCount)
+    {
+        var result = await QueryOccurrenceCountsAsync(occurrenceCount);
+
+        result.Code.ShouldBe(expectedCode);
+        result.Items.Count.ShouldBe(expectedItems);
+        result.Limits?.OccurrenceCount.ShouldBe(expectedObservedCount);
+    }
+
+    [Fact]
+    public async Task QueryOccurrencesAsync_PerEntityBoundaryIncludesUniqueRdatePeriods()
+    {
+        var start = DateTimeOffset.Parse("2026-08-15T12:00:00Z");
+        var periods = string.Join(',', Enumerable.Range(0, 2001).Select(index =>
+            $"{start.AddSeconds(index):yyyyMMdd'T'HHmmss'Z'}/PT1S"));
+
+        var result = await QuerySingleOccurrenceEventAsync(
+            $"DTSTART:20200101T120000Z\r\nDURATION:PT1S\r\nRDATE;VALUE=PERIOD:{periods}\r\n",
+            "2026-08-15T12:00:00Z",
+            "2026-08-15T13:00:00Z");
+
+        result.Code.ShouldBe(CalendarOccurrenceQueryCode.LimitExhausted);
+        result.Items.ShouldBeEmpty();
+        result.Limits!.OccurrenceCount.ShouldBe(2001);
+    }
+
+    [Theory]
+    [InlineData(2000, CalendarOccurrenceQueryCode.Success, null)]
+    [InlineData(2001, CalendarOccurrenceQueryCode.LimitExhausted, 2001)]
+    public async Task QueryOccurrencesAsync_PeriodBoundaryCountsUniqueDerivedWorkOutsideWindow(
+        int periodCount,
+        CalendarOccurrenceQueryCode expectedCode,
+        int? expectedObservedCount)
+    {
+        var start = DateTimeOffset.Parse("2026-08-15T12:00:00Z");
+        var periods = string.Join(',', Enumerable.Range(0, periodCount).Select(index =>
+            $"{start.AddSeconds(index):yyyyMMdd'T'HHmmss'Z'}/PT1S"));
+
+        var result = await QuerySingleOccurrenceEventAsync(
+            $"DTSTART:20200101T120000Z\r\nDURATION:PT1S\r\nRDATE;VALUE=PERIOD:{periods}\r\n",
+            "2027-08-15T12:00:00Z",
+            "2027-08-15T13:00:00Z");
+
+        result.Code.ShouldBe(expectedCode);
+        result.Items.ShouldBeEmpty();
+        result.Limits?.OccurrenceCount.ShouldBe(expectedObservedCount);
+    }
+
+    [Fact]
+    public async Task QueryOccurrencesAsync_DuplicatePeriodIdentityDoesNotInflateDerivedWork()
+    {
+        var start = DateTimeOffset.Parse("2026-08-15T12:00:00Z");
+        var unique = Enumerable.Range(0, 2000)
+            .Select(index => $"{start.AddSeconds(index):yyyyMMdd'T'HHmmss'Z'}/PT1S")
+            .ToArray();
+        var periods = string.Join(',', unique.Append(unique[^1]));
+
+        var result = await QuerySingleOccurrenceEventAsync(
+            $"DTSTART:20200101T120000Z\r\nDURATION:PT1S\r\nRDATE;VALUE=PERIOD:{periods}\r\n",
+            "2027-08-15T12:00:00Z",
+            "2027-08-15T13:00:00Z");
+
+        result.Code.ShouldBe(CalendarOccurrenceQueryCode.Success);
+        result.Items.ShouldBeEmpty();
+    }
+
+    [Theory]
+    [InlineData(2000, CalendarOccurrenceQueryCode.Success, null)]
+    [InlineData(2001, CalendarOccurrenceQueryCode.LimitExhausted, 2001)]
+    public async Task QueryOccurrencesAsync_DetachedOverrideBoundaryCountsUniqueDerivedWorkOutsideWindow(
+        int overrideCount,
+        CalendarOccurrenceQueryCode expectedCode,
+        int? expectedObservedCount)
+    {
+        var result = await QuerySingleOccurrenceAsync(
+            EventWithDetachedOverrides(overrideCount),
+            CalendarEntityKind.Event,
+            "2027-08-15T12:00:00Z",
+            "2027-08-15T13:00:00Z");
+
+        result.Code.ShouldBe(expectedCode);
+        result.Items.ShouldBeEmpty();
+        result.Limits?.OccurrenceCount.ShouldBe(expectedObservedCount);
+    }
+
+    [Theory]
+    [InlineData(500, CalendarOccurrenceQueryCode.Success, 1500, null)]
+    [InlineData(501, CalendarOccurrenceQueryCode.LimitExhausted, 0, 2001)]
+    public async Task QueryOccurrencesAsync_PerEntityBoundaryUnionsRrulePeriodAndDetachedIdentities(
+        int detachedCount,
+        CalendarOccurrenceQueryCode expectedCode,
+        int expectedItems,
+        int? expectedObservedCount)
+    {
+        var result = await QuerySingleOccurrenceAsync(
+            EventWithCompositeDerivedWork(detachedCount),
+            CalendarEntityKind.Event,
+            "2026-08-15T12:00:00Z",
+            "2026-08-15T13:00:00Z");
+
+        result.Code.ShouldBe(expectedCode);
+        result.Items.Count.ShouldBe(expectedItems);
+        result.Limits?.OccurrenceCount.ShouldBe(expectedObservedCount);
+    }
+
+    [Theory]
+    [InlineData(5000, CalendarOccurrenceQueryCode.Success, 5000, null)]
+    [InlineData(5001, CalendarOccurrenceQueryCode.LimitExhausted, 0, 5001)]
+    public async Task QueryOccurrencesAsync_EnforcesExactTotalOccurrenceBoundaryWithZeroPartial(
+        int totalOccurrences,
+        CalendarOccurrenceQueryCode expectedCode,
+        int expectedItems,
+        int? expectedObservedCount)
+    {
+        var result = await QueryOccurrenceCountsAsync(2000, 2000, totalOccurrences - 4000);
+
+        result.Code.ShouldBe(expectedCode);
+        result.Items.Count.ShouldBe(expectedItems);
+        result.Limits?.OccurrenceCount.ShouldBe(expectedObservedCount);
+    }
+
+    [Theory]
+    [InlineData("20531231T100000Z", CalendarOccurrenceQueryCode.Success)]
+    [InlineData("20540101T100000Z", CalendarOccurrenceQueryCode.LimitExhausted)]
+    public async Task QueryOccurrencesAsync_EnforcesExactUnmatchedIncrementBoundaryWithoutPartialOrInventedOccurrenceCount(
+        string until,
+        CalendarOccurrenceQueryCode expectedCode)
+    {
+        var result = await QuerySingleOccurrenceEventAsync(
+            $"DTSTART:20260816T100000Z\r\nDURATION:PT1H\r\nRRULE:FREQ=DAILY;BYMONTH=2;BYMONTHDAY=30;UNTIL={until}\r\n",
+            "2026-08-16T10:00:00Z",
+            "2026-08-16T11:00:00Z");
+
+        result.Code.ShouldBe(expectedCode);
+        result.Items.ShouldBeEmpty();
+        result.Limits.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task QueryOccurrencesAsync_OrdersByEffectiveStartCalendarHrefUidThenRecurrenceIdentity()
+    {
+        const string firstCalendar = "https://cal.example/a/";
+        const string laterCalendar = "https://cal.example/z/";
+        var recurringHref = $"{firstCalendar}recurring.ics";
+        var laterUidHref = $"{firstCalendar}single.ics";
+        var laterCalendarHref = $"{laterCalendar}single.ics";
+        var client = Substitute.For<ICalendarClient>();
+        var sut = new CalendarService(
+            client,
+            Options.Create(new CalDavOptions { BaseUrl = "https://cal.example" }),
+            Substitute.For<ILogger<CalendarService>>());
+        client.GetCalendarsAsync(Arg.Any<CancellationToken>()).Returns([
+            EntityCalendar(laterCalendar, "Z", EntityKindSupport.Advertised, EntityKindSupport.NotAdvertised),
+            EntityCalendar(firstCalendar, "A", EntityKindSupport.Advertised, EntityKindSupport.NotAdvertised)
+        ]);
+        client.QueryCalendarResourceHrefsAsync(firstCalendar, CalendarEntityKind.Event, null, null, Arg.Any<CancellationToken>())
+            .Returns([laterUidHref, recurringHref]);
+        client.QueryCalendarResourceHrefsAsync(laterCalendar, CalendarEntityKind.Event, null, null, Arg.Any<CancellationToken>())
+            .Returns([laterCalendarHref]);
+        client.QueryCalendarResourceHrefsAsync(Arg.Any<string>(), CalendarEntityKind.Todo, null, null, Arg.Any<CancellationToken>())
+            .Returns([]);
+        client.GetCalendarResourceAsync(recurringHref, Arg.Any<CancellationToken>()).Returns(
+            CalendarResourceRead.Success(recurringHref, "\"r1\"", SameEffectiveStartRecurrence("a")));
+        client.GetCalendarResourceAsync(laterUidHref, Arg.Any<CancellationToken>()).Returns(
+            CalendarResourceRead.Success(laterUidHref, "\"r2\"", Event("z", "20260820T100000Z", "Z")));
+        client.GetCalendarResourceAsync(laterCalendarHref, Arg.Any<CancellationToken>()).Returns(
+            CalendarResourceRead.Success(laterCalendarHref, "\"r3\"", Event("0", "20260820T100000Z", "Zero")));
+
+        var result = await sut.QueryOccurrencesAsync(
+            new CalendarOccurrenceQuery(
+                CalendarEntityScope.All,
+                DateTimeOffset.Parse("2026-08-20T09:59:00Z"),
+                DateTimeOffset.Parse("2026-08-20T10:01:00Z")),
+            CancellationToken.None);
+
+        result.Items.Select(item => (
+            item.Snapshot.CalendarHref,
+            item.Snapshot.Projection.EntityUid,
+            item.RecurrenceIdentity.Value)).ShouldBe([
+                (firstCalendar, "a", "2026-08-15T10:00:00Z"),
+                (firstCalendar, "a", "2026-08-16T10:00:00Z"),
+                (firstCalendar, "z", "2026-08-20T10:00:00Z"),
+                (laterCalendar, "0", "2026-08-20T10:00:00Z")
+            ]);
+    }
+
+    [Fact]
+    public async Task QueryOccurrencesAsync_DirectCandidate404ContinuesWithDiagnosticInsteadOfWholeQueryFailure()
+    {
+        const string calendarHref = "https://cal.example/events/";
+        var vanished = $"{calendarHref}vanished.ics";
+        var current = $"{calendarHref}current.ics";
+        var client = Substitute.For<ICalendarClient>();
+        var sut = new CalendarService(
+            client,
+            Options.Create(new CalDavOptions { BaseUrl = "https://cal.example" }),
+            Substitute.For<ILogger<CalendarService>>());
+        client.GetCalendarsAsync(Arg.Any<CancellationToken>()).Returns(
+            [EntityCalendar(calendarHref, "Events", EntityKindSupport.Advertised, EntityKindSupport.NotAdvertised)]);
+        client.QueryCalendarResourceHrefsAsync(calendarHref, CalendarEntityKind.Event, null, null, Arg.Any<CancellationToken>())
+            .Returns([vanished, current]);
+        client.QueryCalendarResourceHrefsAsync(calendarHref, CalendarEntityKind.Todo, null, null, Arg.Any<CancellationToken>())
+            .Returns([]);
+        client.GetCalendarResourceAsync(vanished, Arg.Any<CancellationToken>()).Returns(
+            new CalendarResourceRead(CalendarResourceReadCode.NotFound));
+        client.GetCalendarResourceAsync(current, Arg.Any<CancellationToken>()).Returns(
+            CalendarResourceRead.Success(current, "\"r1\"", Event("current", "20260816T100000Z", "Current")));
+
+        var result = await sut.QueryOccurrencesAsync(
+            new CalendarOccurrenceQuery(
+                CalendarEntityScope.Selected(new CalendarReference(Href: calendarHref)),
+                DateTimeOffset.Parse("2026-08-16T09:00:00Z"),
+                DateTimeOffset.Parse("2026-08-16T11:00:00Z")),
+            CancellationToken.None);
+
+        result.Code.ShouldBe(CalendarOccurrenceQueryCode.Success);
+        result.Items.ShouldHaveSingleItem().Snapshot.ResourceHref.ShouldBe(current);
+        result.Diagnostics.Select(item => item.Code).ShouldContain("resource_disappeared_during_query");
+    }
+
+    [Fact]
+    public async Task QueryOccurrencesAsync_CandidateProtocolFailureIsAnExecutionFailure()
+    {
+        const string calendarHref = "https://cal.example/events/";
+        const string resourceHref = "https://cal.example/events/invalid.ics";
+        var client = Substitute.For<ICalendarClient>();
+        var sut = new CalendarService(
+            client,
+            Options.Create(new CalDavOptions { BaseUrl = "https://cal.example" }),
+            Substitute.For<ILogger<CalendarService>>());
+        client.GetCalendarsAsync(Arg.Any<CancellationToken>()).Returns(
+            [EntityCalendar(calendarHref, "Events", EntityKindSupport.Advertised, EntityKindSupport.NotAdvertised)]);
+        client.QueryCalendarResourceHrefsAsync(calendarHref, CalendarEntityKind.Event, null, null, Arg.Any<CancellationToken>())
+            .Returns([resourceHref]);
+        client.QueryCalendarResourceHrefsAsync(calendarHref, CalendarEntityKind.Todo, null, null, Arg.Any<CancellationToken>())
+            .Returns([]);
+        client.GetCalendarResourceAsync(resourceHref, Arg.Any<CancellationToken>())
+            .Returns<Task<CalendarResourceRead>>(_ => throw new CalendarDiscoveryProtocolException("candidate failure"));
+
+        var result = await sut.QueryOccurrencesAsync(
+            new CalendarOccurrenceQuery(
+                CalendarEntityScope.Selected(new CalendarReference(Href: calendarHref)),
+                DateTimeOffset.Parse("2026-08-16T09:00:00Z"),
+                DateTimeOffset.Parse("2026-08-16T11:00:00Z")),
+            CancellationToken.None);
+
+        result.Code.ShouldBe(CalendarOccurrenceQueryCode.UpstreamProtocolError);
+        result.Items.ShouldBeEmpty();
+    }
+
     [Fact]
     public async Task QueryEntitiesAsync_DefaultScopeUsesOnlyTheRequestedIndependentDefault()
     {
@@ -753,17 +2478,20 @@ public sealed class CalendarServiceTests
     }
 
     [Theory]
-    [InlineData("20260329T023000")]
-    [InlineData("20261025T023000")]
-    public async Task QueryEntitiesAsync_IanaGapOrOverlapIsUnresolved(string localStart)
+    [InlineData("20260329T023000", "2026-03-29T01:30:00Z")]
+    [InlineData("20261025T023000", "2026-10-25T00:30:00Z")]
+    public async Task QueryEntitiesAsync_ExplicitIanaGapAndOverlapFollowRfc5545(
+        string localStart,
+        string expectedUtc)
     {
+        var expected = DateTimeOffset.Parse(expectedUtc);
         var result = await QuerySingleEventAsync(
             $"DTSTART;TZID=Europe/Zurich:{localStart}\r\nDURATION:PT30M\r\n",
-            "2026-03-01T00:00:00Z",
-            "2026-11-01T00:00:00Z");
+            expected.AddMinutes(-1).ToString("O"),
+            expected.AddMinutes(1).ToString("O"));
 
-        result.Code.ShouldBe(CalendarEntityQueryCode.TemporalUnresolved);
-        result.Items.ShouldBeEmpty();
+        result.Code.ShouldBe(CalendarEntityQueryCode.Success);
+        result.Items.ShouldHaveSingleItem();
     }
 
     [Fact]
@@ -902,20 +2630,21 @@ public sealed class CalendarServiceTests
     }
 
     [Theory]
-    [InlineData("DTSTART:20260329T020000\r\nRRULE:FREQ=YEARLY;COUNT=3;BYMONTH=3;BYDAY=-1SU\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0200\r\n", "20260329T023000")]
-    [InlineData("DTSTART:20261025T030000\r\nRRULE:FREQ=YEARLY;UNTIL=20281025T030000Z;BYMONTH=10;BYDAY=-1SU\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0100\r\n", "20261025T023000")]
-    public async Task QueryEntitiesAsync_LocalTimeZoneGapOrOverlapIsUnresolved(
-        string observance,
-        string localStart)
+    [InlineData("20260329T023000", "2026-03-29T01:30:00Z")]
+    [InlineData("20261025T023000", "2026-10-25T00:30:00Z")]
+    public async Task QueryEntitiesAsync_ExplicitLocalTimeZoneGapAndOverlapFollowRfc5545(
+        string localStart,
+        string expectedUtc)
     {
+        var expected = DateTimeOffset.Parse(expectedUtc);
         var result = await QuerySingleEventAsync(
             $"DTSTART;TZID=Custom/Dst:{localStart}\r\nDURATION:PT30M\r\n",
-            "2026-03-01T00:00:00Z",
-            "2026-11-01T00:00:00Z",
-            $"BEGIN:VTIMEZONE\r\nTZID:Custom/Dst\r\nBEGIN:DAYLIGHT\r\n{observance}END:DAYLIGHT\r\nEND:VTIMEZONE\r\n");
+            expected.AddMinutes(-1).ToString("O"),
+            expected.AddMinutes(1).ToString("O"),
+            ResourceLocalDstZone().Replace("Private/Zurich", "Custom/Dst", StringComparison.Ordinal));
 
-        result.Code.ShouldBe(CalendarEntityQueryCode.TemporalUnresolved);
-        result.Items.ShouldBeEmpty();
+        result.Code.ShouldBe(CalendarEntityQueryCode.Success);
+        result.Items.ShouldHaveSingleItem();
     }
 
     [Fact]
@@ -1629,6 +3358,9 @@ public sealed class CalendarServiceTests
     private static byte[] Todo(string uid, string summary) => System.Text.Encoding.UTF8.GetBytes(
         $"BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Example//EN\r\nBEGIN:VTODO\r\nUID:{uid}\r\nDTSTAMP:20260815T120000Z\r\nSUMMARY:{summary}\r\nEND:VTODO\r\nEND:VCALENDAR\r\n");
 
+    private static byte[] TodoWithTemporalLines(string uid, string temporalLines) => System.Text.Encoding.UTF8.GetBytes(
+        $"BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Example//EN\r\nBEGIN:VTODO\r\nUID:{uid}\r\nDTSTAMP:20260815T120000Z\r\n{temporalLines}END:VTODO\r\nEND:VCALENDAR\r\n");
+
     private static byte[] TodoWithTiming(string uid, string? start, string due)
     {
         var startLine = start is null ? string.Empty : $"DTSTART:{start}\r\n";
@@ -1646,11 +3378,104 @@ public sealed class CalendarServiceTests
             $"BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Example//EN\r\nBEGIN:VEVENT\r\nUID:{uid}\r\nDTSTAMP:20260815T120000Z\r\nDTSTART:20260814T100000Z\r\nDURATION:PT1H\r\nRRULE:FREQ=DAILY;COUNT=4\r\n{exceptionLine}END:VEVENT\r\nEND:VCALENDAR\r\n");
     }
 
+    private static byte[] OverrideEvent() => System.Text.Encoding.UTF8.GetBytes(
+        "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Example//EN\r\n"
+        + "BEGIN:VEVENT\r\nUID:overrides\r\nDTSTAMP:20260815T120000Z\r\nDTSTART:20260814T100000Z\r\nDURATION:PT1H\r\n"
+        + "RRULE:FREQ=DAILY;COUNT=4\r\nEXDATE:20260815T100000Z\r\nEND:VEVENT\r\n"
+        + "BEGIN:VEVENT\r\nUID:overrides\r\nDTSTAMP:20260815T120000Z\r\nRECURRENCE-ID:20260815T100000Z\r\n"
+        + "DTSTART:20260815T120000Z\r\nDTEND:20260815T130000Z\r\nEND:VEVENT\r\n"
+        + "BEGIN:VEVENT\r\nUID:overrides\r\nDTSTAMP:20260815T120000Z\r\nRECURRENCE-ID:20260816T100000Z\r\n"
+        + "DTSTART:20260816T100000Z\r\nDTEND:20260816T110000Z\r\nSTATUS:CANCELLED\r\nEND:VEVENT\r\n"
+        + "BEGIN:VEVENT\r\nUID:overrides\r\nDTSTAMP:20260815T120000Z\r\nRECURRENCE-ID:20260817T100000Z\r\n"
+        + "DTSTART:20260817T200000Z\r\nDTEND:20260817T210000Z\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n");
+
+    private static byte[] RangeOverrideEvent() => System.Text.Encoding.UTF8.GetBytes(
+        "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Example//EN\r\n"
+        + "BEGIN:VEVENT\r\nUID:ranges\r\nDTSTAMP:20260815T120000Z\r\nDTSTART:20260814T090000Z\r\nDURATION:PT1H\r\n"
+        + "RRULE:FREQ=DAILY;COUNT=5\r\nEND:VEVENT\r\n"
+        + "BEGIN:VEVENT\r\nUID:ranges\r\nDTSTAMP:20260815T120000Z\r\nRECURRENCE-ID;RANGE=THISANDFUTURE:20260815T090000Z\r\n"
+        + "DTSTART:20260815T110000Z\r\nDTEND:20260815T120000Z\r\nEND:VEVENT\r\n"
+        + "BEGIN:VEVENT\r\nUID:ranges\r\nDTSTAMP:20260815T120000Z\r\nRECURRENCE-ID;RANGE=THISANDFUTURE:20260817T090000Z\r\n"
+        + "DTSTART:20260817T130000Z\r\nDTEND:20260817T150000Z\r\nEND:VEVENT\r\n"
+        + "BEGIN:VEVENT\r\nUID:ranges\r\nDTSTAMP:20260815T120000Z\r\nRECURRENCE-ID:20260818T090000Z\r\n"
+        + "DTSTART:20260818T160000Z\r\nDTEND:20260818T170000Z\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n");
+
+    private static byte[] SameEffectiveStartRecurrence(string uid) => System.Text.Encoding.UTF8.GetBytes(
+        $"BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Example//EN\r\n"
+        + $"BEGIN:VEVENT\r\nUID:{uid}\r\nDTSTAMP:20260815T120000Z\r\nDTSTART:20260815T100000Z\r\n"
+        + "DURATION:PT1H\r\nRRULE:FREQ=DAILY;COUNT=2\r\nEND:VEVENT\r\n"
+        + $"BEGIN:VEVENT\r\nUID:{uid}\r\nDTSTAMP:20260815T120000Z\r\nRECURRENCE-ID:20260815T100000Z\r\n"
+        + "DTSTART:20260820T100000Z\r\nDURATION:PT1M\r\nEND:VEVENT\r\n"
+        + $"BEGIN:VEVENT\r\nUID:{uid}\r\nDTSTAMP:20260815T120000Z\r\nRECURRENCE-ID:20260816T100000Z\r\n"
+        + "DTSTART:20260820T100000Z\r\nDURATION:PT1M\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n");
+
+    private static byte[] ResourceLocalZoneEvent() => System.Text.Encoding.UTF8.GetBytes(
+        "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Example//EN\r\n"
+        + "BEGIN:VTIMEZONE\r\nTZID:America/New_York\r\nBEGIN:STANDARD\r\n"
+        + "DTSTART:20200101T000000\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0200\r\n"
+        + "END:STANDARD\r\nEND:VTIMEZONE\r\n"
+        + "BEGIN:VEVENT\r\nUID:local-zone\r\nDTSTAMP:20260815T120000Z\r\n"
+        + "DTSTART;TZID=America/New_York:20260816T100000\r\nDURATION:PT30M\r\n"
+        + "END:VEVENT\r\nEND:VCALENDAR\r\n");
+
+    private static string ResourceLocalDstZone() =>
+        "BEGIN:VTIMEZONE\r\nTZID:Private/Zurich\r\n"
+        + "BEGIN:DAYLIGHT\r\nDTSTART:20260329T020000\r\n"
+        + "TZOFFSETFROM:+0100\r\nTZOFFSETTO:+0200\r\nEND:DAYLIGHT\r\n"
+        + "BEGIN:STANDARD\r\nDTSTART:20261025T030000\r\n"
+        + "TZOFFSETFROM:+0200\r\nTZOFFSETTO:+0100\r\nEND:STANDARD\r\n"
+        + "END:VTIMEZONE\r\n";
+
+    private static string ResourceLocalFixedZone() =>
+        "BEGIN:VTIMEZONE\r\nTZID:Private/Zurich\r\nBEGIN:STANDARD\r\n"
+        + "DTSTART:19900101T000000\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0200\r\n"
+        + "END:STANDARD\r\nEND:VTIMEZONE\r\n";
+
     private static byte[] RecurringTodo(string uid) => System.Text.Encoding.UTF8.GetBytes(
         $"BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Example//EN\r\nBEGIN:VTODO\r\nUID:{uid}\r\nDTSTAMP:20260815T120000Z\r\nDTSTART:20260815T100000Z\r\nDUE:20260815T103000Z\r\nRRULE:FREQ=DAILY;COUNT=2\r\nEND:VTODO\r\nEND:VCALENDAR\r\n");
 
     private static byte[] RecurringEventWithRule(string uid, string recurrenceLines) => System.Text.Encoding.UTF8.GetBytes(
         $"BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Example//EN\r\nBEGIN:VEVENT\r\nUID:{uid}\r\nDTSTAMP:20260815T120000Z\r\nDTSTART:20260815T120000Z\r\nDURATION:PT1S\r\n{recurrenceLines}END:VEVENT\r\nEND:VCALENDAR\r\n");
+
+    private static byte[] EventWithDetachedOverrides(int overrideCount)
+    {
+        var content = new System.Text.StringBuilder(
+            "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Example//EN\r\n"
+            + "BEGIN:VEVENT\r\nUID:detached-limit\r\nDTSTAMP:20260815T120000Z\r\n"
+            + "DTSTART:20200101T000000Z\r\nDURATION:PT1S\r\nRRULE:FREQ=DAILY;COUNT=1\r\n"
+            + "EXDATE:20200101T000000Z\r\nEND:VEVENT\r\n");
+        var identity = DateTimeOffset.Parse("2026-01-01T00:00:00Z");
+        for (var index = 0; index < overrideCount; index++)
+        {
+            var value = identity.AddSeconds(index);
+            content.Append("BEGIN:VEVENT\r\nUID:detached-limit\r\nDTSTAMP:20260815T120000Z\r\n")
+                .Append($"RECURRENCE-ID:{value:yyyyMMdd'T'HHmmss'Z'}\r\n")
+                .Append($"DTSTART:{value.AddYears(4):yyyyMMdd'T'HHmmss'Z'}\r\nDURATION:PT1S\r\nEND:VEVENT\r\n");
+        }
+        content.Append("END:VCALENDAR\r\n");
+        return System.Text.Encoding.UTF8.GetBytes(content.ToString());
+    }
+
+    private static byte[] EventWithCompositeDerivedWork(int detachedCount)
+    {
+        var start = DateTimeOffset.Parse("2026-08-15T12:00:00Z");
+        var periods = string.Join(',', Enumerable.Range(2000, 500).Select(index =>
+            $"{start.AddSeconds(index):yyyyMMdd'T'HHmmss'Z'}/PT1S"));
+        var content = new System.Text.StringBuilder(
+            "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Example//EN\r\n"
+            + "BEGIN:VEVENT\r\nUID:composite-limit\r\nDTSTAMP:20260815T120000Z\r\n"
+            + "DTSTART:20260815T120000Z\r\nDURATION:PT1S\r\nRRULE:FREQ=SECONDLY;COUNT=1000\r\n"
+            + $"RDATE;VALUE=PERIOD:{periods}\r\nEND:VEVENT\r\n");
+        for (var index = 0; index < detachedCount; index++)
+        {
+            var identity = start.AddSeconds(4000 + index);
+            content.Append("BEGIN:VEVENT\r\nUID:composite-limit\r\nDTSTAMP:20260815T120000Z\r\n")
+                .Append($"RECURRENCE-ID:{identity:yyyyMMdd'T'HHmmss'Z'}\r\n")
+                .Append($"DTSTART:{identity.AddYears(1):yyyyMMdd'T'HHmmss'Z'}\r\nDURATION:PT1S\r\nEND:VEVENT\r\n");
+        }
+        content.Append("END:VCALENDAR\r\n");
+        return System.Text.Encoding.UTF8.GetBytes(content.ToString());
+    }
 
     private static byte[] Mixed(string eventUid, string todoUid) => System.Text.Encoding.UTF8.GetBytes(
         $"BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Example//EN\r\nBEGIN:VEVENT\r\nUID:{eventUid}\r\nDTSTAMP:20260815T120000Z\r\nDTSTART:20260816T090000Z\r\nEND:VEVENT\r\nBEGIN:VTODO\r\nUID:{todoUid}\r\nDTSTAMP:20260815T120000Z\r\nEND:VTODO\r\nEND:VCALENDAR\r\n");
@@ -1681,6 +3506,113 @@ public sealed class CalendarServiceTests
             .Returns(CalendarResourceRead.Success(resourceHref, "\"r1\"", bytes));
         return await sut.QueryEntitiesAsync(
             new CalendarEntityQuery(CalendarEntityScope.Default, [CalendarEntityKind.Event], start, end),
+            CancellationToken.None);
+    }
+
+    private static async Task<CalendarOccurrenceQueryResult> QuerySingleOccurrenceEventAsync(
+        string temporalLines,
+        string from,
+        string to,
+        string? evaluationTimeZone = null,
+        string calendarLines = "")
+    {
+        const string calendarHref = "https://cal.example/events/";
+        const string resourceHref = "https://cal.example/events/occurrence.ics";
+        var client = Substitute.For<ICalendarClient>();
+        var sut = new CalendarService(
+            client,
+            Options.Create(new CalDavOptions { BaseUrl = "https://cal.example" }),
+            Substitute.For<ILogger<CalendarService>>());
+        client.GetCalendarsAsync(Arg.Any<CancellationToken>()).Returns(
+            [EntityCalendar(calendarHref, "Events", EntityKindSupport.Advertised, EntityKindSupport.NotAdvertised)]);
+        client.QueryCalendarResourceHrefsAsync(calendarHref, CalendarEntityKind.Event, null, null, Arg.Any<CancellationToken>())
+            .Returns([resourceHref]);
+        client.QueryCalendarResourceHrefsAsync(calendarHref, CalendarEntityKind.Todo, null, null, Arg.Any<CancellationToken>())
+            .Returns([]);
+        var bytes = System.Text.Encoding.UTF8.GetBytes(
+            "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Example//EN\r\n" + calendarLines
+            + $"BEGIN:VEVENT\r\nUID:occurrence\r\nDTSTAMP:20260815T120000Z\r\n{temporalLines}END:VEVENT\r\nEND:VCALENDAR\r\n");
+        client.GetCalendarResourceAsync(resourceHref, Arg.Any<CancellationToken>())
+            .Returns(CalendarResourceRead.Success(resourceHref, "\"r1\"", bytes));
+        return await sut.QueryOccurrencesAsync(
+            new CalendarOccurrenceQuery(
+                CalendarEntityScope.Selected(new CalendarReference(Href: calendarHref)),
+                DateTimeOffset.Parse(from),
+                DateTimeOffset.Parse(to),
+                evaluationTimeZone),
+            CancellationToken.None);
+    }
+
+    private static async Task<CalendarOccurrenceQueryResult> QuerySingleOccurrenceAsync(
+        byte[] authoritativeBytes,
+        CalendarEntityKind kind,
+        string from,
+        string to,
+        string? evaluationTimeZone = null)
+    {
+        const string calendarHref = "https://cal.example/calendar/";
+        const string resourceHref = "https://cal.example/calendar/occurrence.ics";
+        var client = Substitute.For<ICalendarClient>();
+        var sut = new CalendarService(
+            client,
+            Options.Create(new CalDavOptions { BaseUrl = "https://cal.example" }),
+            Substitute.For<ILogger<CalendarService>>());
+        client.GetCalendarsAsync(Arg.Any<CancellationToken>()).Returns([
+            EntityCalendar(
+                calendarHref,
+                "Calendar",
+                kind == CalendarEntityKind.Event ? EntityKindSupport.Advertised : EntityKindSupport.NotAdvertised,
+                kind == CalendarEntityKind.Todo ? EntityKindSupport.Advertised : EntityKindSupport.NotAdvertised)
+        ]);
+        client.QueryCalendarResourceHrefsAsync(calendarHref, kind, null, null, Arg.Any<CancellationToken>())
+            .Returns([resourceHref]);
+        client.QueryCalendarResourceHrefsAsync(
+                calendarHref,
+                kind == CalendarEntityKind.Event ? CalendarEntityKind.Todo : CalendarEntityKind.Event,
+                null,
+                null,
+                Arg.Any<CancellationToken>())
+            .Returns([]);
+        client.GetCalendarResourceAsync(resourceHref, Arg.Any<CancellationToken>()).Returns(
+            CalendarResourceRead.Success(resourceHref, "\"r1\"", authoritativeBytes));
+        return await sut.QueryOccurrencesAsync(
+            new CalendarOccurrenceQuery(
+                CalendarEntityScope.Selected(new CalendarReference(Href: calendarHref)),
+                DateTimeOffset.Parse(from),
+                DateTimeOffset.Parse(to),
+                evaluationTimeZone),
+            CancellationToken.None);
+    }
+
+    private static async Task<CalendarOccurrenceQueryResult> QueryOccurrenceCountsAsync(params int[] occurrenceCounts)
+    {
+        const string calendarHref = "https://cal.example/events/";
+        var hrefs = occurrenceCounts.Select((_, index) => $"{calendarHref}{index}.ics").ToArray();
+        var client = Substitute.For<ICalendarClient>();
+        var sut = new CalendarService(
+            client,
+            Options.Create(new CalDavOptions { BaseUrl = "https://cal.example" }),
+            Substitute.For<ILogger<CalendarService>>());
+        client.GetCalendarsAsync(Arg.Any<CancellationToken>()).Returns(
+            [EntityCalendar(calendarHref, "Events", EntityKindSupport.Advertised, EntityKindSupport.NotAdvertised)]);
+        client.QueryCalendarResourceHrefsAsync(calendarHref, CalendarEntityKind.Event, null, null, Arg.Any<CancellationToken>())
+            .Returns(hrefs);
+        client.QueryCalendarResourceHrefsAsync(calendarHref, CalendarEntityKind.Todo, null, null, Arg.Any<CancellationToken>())
+            .Returns([]);
+        for (var index = 0; index < hrefs.Length; index++)
+        {
+            var count = occurrenceCounts[index];
+            client.GetCalendarResourceAsync(hrefs[index], Arg.Any<CancellationToken>()).Returns(
+                CalendarResourceRead.Success(
+                    hrefs[index],
+                    $"\"r{index}\"",
+                    RecurringEventWithRule($"occurrence-{index}", $"RRULE:FREQ=SECONDLY;COUNT={count}\r\n")));
+        }
+        return await sut.QueryOccurrencesAsync(
+            new CalendarOccurrenceQuery(
+                CalendarEntityScope.Selected(new CalendarReference(Href: calendarHref)),
+                DateTimeOffset.Parse("2026-08-15T12:00:00Z"),
+                DateTimeOffset.Parse("2026-08-15T14:00:00Z")),
             CancellationToken.None);
     }
 

--- a/tests/DotnetAgents.CalDav.IntegrationTests/CalendarMcpRawStdioTests.cs
+++ b/tests/DotnetAgents.CalDav.IntegrationTests/CalendarMcpRawStdioTests.cs
@@ -10,6 +10,30 @@ namespace DotnetAgents.CalDav.IntegrationTests;
 public sealed class CalendarMcpRawStdioTests
 {
     [Fact]
+    public async Task CalendarOccurrenceQuery_NormalRawCallReachesServiceAndReturnsTypedExecutionFailure()
+    {
+        const string request = """
+            {"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"calendar_occurrences.query","arguments":{"scope":{"mode":"default"},"from":{"kind":"utcDateTime","value":"2026-08-15T12:00:00Z"},"to":{"kind":"utcDateTime","value":"2026-08-16T12:00:00Z"}}}}
+            """;
+
+        var result = await InvokeRawAsync(request);
+
+        AssertTypedError(result, "upstream_unavailable", "execution");
+    }
+
+    [Fact]
+    public async Task CalendarOccurrenceQuery_RootDuplicateArgumentsReturnTypedInvalidInputBeforeNetwork()
+    {
+        const string request = """
+            {"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"calendar_occurrences.query","arguments":{"scope":{"mode":"default"},"scope":{"mode":"all"},"from":{"kind":"utcDateTime","value":"2026-08-15T12:00:00Z"},"to":{"kind":"utcDateTime","value":"2026-08-16T12:00:00Z"}}}}
+            """;
+
+        var result = await InvokeRawAsync(request);
+
+        AssertTypedError(result, "invalid_input", "schemaLexicalDiscriminator");
+    }
+
+    [Fact]
     public async Task CalendarEntityQuery_NormalInvalidArgumentsReturnTypedInvalidInputBeforeNetwork()
     {
         const string request = """

--- a/tests/DotnetAgents.CalDav.IntegrationTests/CalendarMcpStdioIntegrationTests.cs
+++ b/tests/DotnetAgents.CalDav.IntegrationTests/CalendarMcpStdioIntegrationTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Net;
 using System.Net.Http.Headers;
 using System.Text;
 using DotnetAgents.CalDav.IntegrationTests.Fixtures;
@@ -50,6 +51,7 @@ public sealed class CalendarMcpStdioIntegrationTests
         [
             "calendars.list",
             "calendar_entities.query",
+            "calendar_occurrences.query",
             "calendar_resources.get",
             "list_task_lists",
             "show_tasks",
@@ -152,6 +154,122 @@ public sealed class CalendarMcpStdioIntegrationTests
     }
 
     [Fact]
+    public async Task CalendarOccurrenceQuery_ExpandsAuthoritativeRecurringTodoOverRealStdioAndRadicale()
+    {
+        const string content = "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Integration//EN\r\n"
+            + "BEGIN:VTODO\r\nUID:occurrence-stdio-1\r\nDTSTAMP:20260815T120000Z\r\n"
+            + "DTSTART:20260815T100000Z\r\nDUE:20260815T103000Z\r\nRRULE:FREQ=DAILY;COUNT=3\r\n"
+            + "END:VTODO\r\nEND:VCALENDAR\r\n";
+        var href = await PutResourceAsync("occurrence-stdio-1.ics", content);
+        var stderr = new ConcurrentQueue<string>();
+        await using var client = await CreateClientAsync(stderr, exposeExact: false);
+        var tools = await client.ListToolsAsync(new ListToolsRequestParams(), TestContext.Current.CancellationToken);
+        var advertised = tools.Tools.Single(tool => tool.Name == "calendar_occurrences.query");
+
+        var result = await client.CallToolAsync(
+            "calendar_occurrences.query",
+            new Dictionary<string, object?>
+            {
+                ["scope"] = new Dictionary<string, object?>
+                {
+                    ["mode"] = "selected",
+                    ["calendar"] = new Dictionary<string, object?>
+                    {
+                        ["by"] = "href",
+                        ["href"] = $"{_fixture.BaseUrl}{_fixture.TaskListHref}"
+                    }
+                },
+                ["from"] = new Dictionary<string, object?>
+                {
+                    ["kind"] = "utcDateTime",
+                    ["value"] = "2026-08-16T10:15:00Z"
+                },
+                ["to"] = new Dictionary<string, object?>
+                {
+                    ["kind"] = "utcDateTime",
+                    ["value"] = "2026-08-16T10:20:00Z"
+                }
+            },
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        result.IsError.ShouldBe(false);
+        var occurrence = result.StructuredContent!.Value.GetProperty("items").EnumerateArray().ShouldHaveSingleItem();
+        occurrence.GetProperty("snapshot").GetProperty("resourceRevision").GetProperty("href").GetString().ShouldBe(href);
+        occurrence.GetProperty("snapshot").GetProperty("projection").GetProperty("kind").GetString().ShouldBe("todo");
+        occurrence.GetProperty("recurrenceIdentity").GetProperty("value").GetProperty("value").GetString()
+            .ShouldBe("2026-08-16T10:00:00Z");
+        occurrence.GetProperty("timing").GetProperty("effectiveEnd").GetProperty("value").GetString()
+            .ShouldBe("2026-08-16T10:30:00Z");
+        advertised.InputSchema.GetProperty("required").EnumerateArray().Select(item => item.GetString())
+            .ShouldBe(["scope", "from", "to"]);
+        advertised.Meta!["cache"]!["ttlMs"]!.GetValue<int>().ShouldBe(5000);
+        advertised.Meta!["cache"]!["cacheScope"]!.GetValue<string>().ShouldBe("private");
+        stderr.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task CalendarOccurrenceQuery_ProvesBoundaryDstLeapRangeAndTypedFailuresOverRealStdioAndRadicale()
+    {
+        var boundaryHref = await PutResourceAsync("occurrence-boundary.ics", Todo(
+            "occurrence-boundary", "DUE:20260816T100000Z\r\n"));
+        _ = await PutResourceAsync("occurrence-boundary-to.ics", Todo(
+            "occurrence-boundary-to", "DUE:20260816T110000Z\r\n"));
+        _ = await PutResourceAsync("occurrence-dst.ics", Todo(
+            "occurrence-dst", "DTSTART;TZID=America/New_York:20260307T100000\r\n"
+            + "DURATION:PT1H\r\nRRULE:FREQ=DAILY;COUNT=3\r\n"));
+        _ = await PutResourceAsync("occurrence-leap.ics", Todo(
+            "occurrence-leap", "DTSTART:20240229T100000Z\r\nDURATION:PT1H\r\nRRULE:FREQ=YEARLY;COUNT=3\r\n"));
+        var rangeHref = await PutResourceAsync("occurrence-range.ics", RangeTodo());
+        var rangeObserved = await GetResourceAsync(rangeHref);
+        var stderr = new ConcurrentQueue<string>();
+        await using var client = await CreateClientAsync(stderr, exposeExact: false);
+
+        var boundary = await CallOccurrenceAsync(client, "2026-08-16T10:00:00Z", "2026-08-16T11:00:00Z");
+        var dst = await CallOccurrenceAsync(client, "2026-03-08T14:30:00Z", "2026-03-08T14:45:00Z");
+        var leap = await CallOccurrenceAsync(client, "2028-02-29T10:30:00Z", "2028-02-29T10:45:00Z");
+        var moved = await CallOccurrenceAsync(client, "2026-08-17T13:30:00Z", "2026-08-17T13:45:00Z");
+
+        boundary.IsError.ShouldBe(false);
+        var boundaryItems = boundary.StructuredContent!.Value.GetProperty("items").EnumerateArray().ToArray();
+        boundaryItems.ShouldContain(item => item.GetProperty("snapshot").GetProperty("resourceRevision")
+            .GetProperty("href").GetString() == boundaryHref);
+        boundaryItems.ShouldNotContain(item => item.GetProperty("snapshot").GetProperty("projection")
+            .GetProperty("uid").GetString() == "occurrence-boundary-to");
+        dst.StructuredContent!.Value.GetProperty("items").EnumerateArray()
+            .Single(item => item.GetProperty("snapshot").GetProperty("projection").GetProperty("uid").GetString() == "occurrence-dst")
+            .GetProperty("timing").GetProperty("evaluatedStartUtc").GetProperty("value").GetString()
+            .ShouldBe("2026-03-08T14:00:00Z");
+        leap.StructuredContent!.Value.GetProperty("items").EnumerateArray()
+            .Single(item => item.GetProperty("snapshot").GetProperty("projection").GetProperty("uid").GetString() == "occurrence-leap")
+            .GetProperty("recurrenceIdentity").GetProperty("value").GetProperty("value").GetString()
+            .ShouldBe("2028-02-29T10:00:00Z");
+        var movedOccurrence = moved.StructuredContent!.Value.GetProperty("items").EnumerateArray()
+            .Single(item => item.GetProperty("snapshot").GetProperty("projection").GetProperty("uid").GetString() == "occurrence-range");
+        movedOccurrence.GetProperty("recurrenceIdentity").GetProperty("value").GetProperty("value").GetString()
+            .ShouldBe("2026-08-17T09:00:00Z");
+        movedOccurrence.GetProperty("timing").GetProperty("effectiveStart").GetProperty("value").GetString()
+            .ShouldBe("2026-08-17T13:00:00Z");
+        Convert.FromBase64String(movedOccurrence.GetProperty("snapshot").GetProperty("authoritativePayload")
+            .GetProperty("base64Utf8").GetString()!).ShouldBe(rangeObserved.Utf8);
+
+        var unresolvedHref = await PutResourceAsync("occurrence-unresolved.ics", Todo(
+            "occurrence-unresolved", "DTSTART;TZID=Private/Unknown:20260816T100000\r\nDURATION:PT1H\r\n"));
+        var unresolved = await CallOccurrenceAsync(client, "2026-08-16T00:00:00Z", "2026-08-17T00:00:00Z");
+        unresolved.IsError.ShouldBe(true);
+        unresolved.StructuredContent!.Value.GetProperty("code").GetString().ShouldBe("temporal_unresolved");
+        await DeleteResourceAsync(unresolvedHref);
+
+        var unevaluableHref = await PutResourceAsync("occurrence-unevaluable.ics", Todo(
+            "occurrence-unevaluable", "DTSTART:20260816T100000Z\r\nDURATION:PT1H\r\n"
+            + "RRULE:FREQ=DAILY;COUNT=2\r\nRRULE:FREQ=WEEKLY;COUNT=2\r\n"));
+        var unevaluable = await CallOccurrenceAsync(client, "2026-08-16T00:00:00Z", "2026-08-17T00:00:00Z");
+        unevaluable.IsError.ShouldBe(true);
+        unevaluable.StructuredContent!.Value.GetProperty("code").GetString().ShouldBe("recurrence_unevaluable");
+        await DeleteResourceAsync(unevaluableHref);
+        stderr.ShouldBeEmpty();
+    }
+
+    [Fact]
     public async Task CalendarEntityQuery_InvalidRawShapesReturnTypedErrorsWithoutNetwork()
     {
         var stderr = new ConcurrentQueue<string>();
@@ -247,6 +365,7 @@ public sealed class CalendarMcpStdioIntegrationTests
         [
             "calendars.list",
             "calendar_entities.query",
+            "calendar_occurrences.query",
             "calendar_resources.get",
             "calendar_resources.exact_get",
             "list_task_lists",
@@ -305,6 +424,32 @@ public sealed class CalendarMcpStdioIntegrationTests
         return $"{_fixture.BaseUrl}{href}";
     }
 
+    private async Task<CallToolResult> CallOccurrenceAsync(McpClient client, string from, string to) =>
+        await client.CallToolAsync(
+            "calendar_occurrences.query",
+            new Dictionary<string, object?>
+            {
+                ["scope"] = new Dictionary<string, object?>
+                {
+                    ["mode"] = "selected",
+                    ["calendar"] = new Dictionary<string, object?>
+                    {
+                        ["by"] = "href",
+                        ["href"] = $"{_fixture.BaseUrl}{_fixture.TaskListHref}"
+                    }
+                },
+                ["from"] = new Dictionary<string, object?> { ["kind"] = "utcDateTime", ["value"] = from },
+                ["to"] = new Dictionary<string, object?> { ["kind"] = "utcDateTime", ["value"] = to }
+            },
+            cancellationToken: TestContext.Current.CancellationToken);
+
+    private async Task DeleteResourceAsync(string href)
+    {
+        using var client = CreateAuthenticatedClient();
+        using var response = await client.DeleteAsync(href, TestContext.Current.CancellationToken);
+        response.StatusCode.ShouldBeOneOf(HttpStatusCode.OK, HttpStatusCode.NoContent);
+    }
+
     private async Task<ObservedResource> GetResourceAsync(string href)
     {
         using var client = CreateAuthenticatedClient();
@@ -333,6 +478,21 @@ public sealed class CalendarMcpStdioIntegrationTests
         ["CALDAV_PASSWORD"] = "caldavtest123",
         ["CALDAV_CALENDAR_HREFS"] = $"{_fixture.BaseUrl}{_fixture.TaskListHref}"
     };
+
+    private static string Todo(string uid, string temporalLines) =>
+        $"BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Integration//EN\r\nBEGIN:VTODO\r\n"
+        + $"UID:{uid}\r\nDTSTAMP:20260815T120000Z\r\n{temporalLines}END:VTODO\r\nEND:VCALENDAR\r\n";
+
+    private static string RangeTodo() =>
+        "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Integration//EN\r\n"
+        + "BEGIN:VTODO\r\nUID:occurrence-range\r\nDTSTAMP:20260815T120000Z\r\nDTSTART:20260814T090000Z\r\n"
+        + "DUE:20260814T100000Z\r\nRRULE:FREQ=DAILY;COUNT=5\r\nEND:VTODO\r\n"
+        + "BEGIN:VTODO\r\nUID:occurrence-range\r\nDTSTAMP:20260815T120000Z\r\n"
+        + "RECURRENCE-ID;RANGE=THISANDFUTURE:20260816T090000Z\r\n"
+        + "DTSTART:20260816T110000Z\r\nDUE:20260816T120000Z\r\nEND:VTODO\r\n"
+        + "BEGIN:VTODO\r\nUID:occurrence-range\r\nDTSTAMP:20260815T120000Z\r\n"
+        + "RECURRENCE-ID;RANGE=THISANDFUTURE:20260817T090000Z\r\n"
+        + "DTSTART:20260817T130000Z\r\nDUE:20260817T150000Z\r\nEND:VTODO\r\nEND:VCALENDAR\r\n";
 
     private static string GetServerAssemblyPath()
     {

--- a/tests/DotnetAgents.CalDav.IntegrationTests/Fixtures/RadicaleConformanceFixture.cs
+++ b/tests/DotnetAgents.CalDav.IntegrationTests/Fixtures/RadicaleConformanceFixture.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using System.Text.Json;
 using DotNet.Testcontainers.Builders;
 using DotNet.Testcontainers.Configurations;
 using DotNet.Testcontainers.Containers;
@@ -12,6 +13,8 @@ namespace DotnetAgents.CalDav.IntegrationTests.Fixtures;
 /// </summary>
 public sealed class RadicaleConformanceFixture : IAsyncLifetime
 {
+    public const string Username = "conformance";
+    public const string Password = "conformance";
     public const string Image = "ghcr.io/kozea/radicale@sha256:3a0080ea51ac69dcd74e345b9587dc14a8c8af0652046069005749f9a75c5c80";
     public const string IndexDigest = "sha256:3a0080ea51ac69dcd74e345b9587dc14a8c8af0652046069005749f9a75c5c80";
     public const string Amd64ManifestDigest = "sha256:7e2d729c434574762b058d57c7c81641ade11655da6d0eede948512d53873e71";
@@ -23,6 +26,8 @@ public sealed class RadicaleConformanceFixture : IAsyncLifetime
     public RadicaleConformanceVariant Variant { get; } = RadicaleConformanceVariant.FromEnvironment();
 
     public RadicaleRuntimeEvidence Runtime { get; private set; } = null!;
+
+    public string BaseUrl { get; private set; } = null!;
 
     public async ValueTask InitializeAsync()
     {
@@ -36,10 +41,20 @@ public sealed class RadicaleConformanceFixture : IAsyncLifetime
                 UnixFileModes.UserRead | UnixFileModes.UserWrite |
                 UnixFileModes.GroupRead | UnixFileModes.OtherRead)
             .WithWaitStrategy(Wait.ForUnixContainer()
-                .UntilInternalTcpPortIsAvailable(RadicalePort))
+                .UntilInternalTcpPortIsAvailable(RadicalePort)
+                .UntilHttpRequestIsSucceeded(
+                    request => request
+                        .ForPort(RadicalePort)
+                        .ForPath("/")
+                        .ForStatusCodeMatching(status => (int)status < 500),
+                    strategy => strategy
+                        .WithInterval(TimeSpan.FromMilliseconds(250))
+                        .WithRetries(60)
+                        .WithTimeout(TimeSpan.FromSeconds(30))))
             .Build();
 
         await _container.StartAsync();
+        BaseUrl = $"http://localhost:{_container.GetMappedPublicPort(RadicalePort)}";
 
         var configuredStrictPreconditions = await ReadConfigurationValueAsync("strict_preconditions");
         var strictPreconditionsApplied = await ObserveStrictPreconditionsAsync();
@@ -67,6 +82,97 @@ public sealed class RadicaleConformanceFixture : IAsyncLifetime
         if (_container is not null)
         {
             await _container.DisposeAsync();
+        }
+    }
+
+    public async Task<RadicaleConformanceResource> SeedResourceAsync(
+        string resourceName,
+        string content,
+        CancellationToken cancellationToken)
+    {
+        const string script = """
+            import base64
+            import json
+            import sys
+            import urllib.parse
+            import urllib.request
+
+            name = urllib.parse.quote(sys.argv[1], safe='')
+            content = base64.b64decode(sys.argv[2])
+            authorization = 'Basic ' + sys.argv[3]
+            url = 'http://127.0.0.1:5232/conformance/conformance/' + name
+            headers = {'Authorization': authorization, 'Connection': 'close'}
+
+            put = urllib.request.Request(
+                url,
+                data=content,
+                headers=headers | {'Content-Type': 'text/calendar; charset=utf-8'},
+                method='PUT')
+            with urllib.request.urlopen(put) as response:
+                if response.status not in (201, 204):
+                    raise RuntimeError(f'PUT returned {response.status}')
+
+            get = urllib.request.Request(url, headers=headers, method='GET')
+            with urllib.request.urlopen(get) as response:
+                etag = response.headers.get('ETag')
+                if not etag or etag.startswith('W/'):
+                    raise RuntimeError('GET did not return a strong ETag')
+                observed = response.read()
+
+            print(json.dumps({
+                'entityTag': etag,
+                'content': base64.b64encode(observed).decode('ascii')
+            }))
+            """;
+        var contentBase64 = Convert.ToBase64String(Encoding.UTF8.GetBytes(content));
+        var credentialsBase64 = Convert.ToBase64String(Encoding.UTF8.GetBytes($"{Username}:{Password}"));
+        var result = await _container!.ExecAsync(
+            ["/app/bin/python", "-c", script, resourceName, contentBase64, credentialsBase64],
+            cancellationToken);
+        if (result.ExitCode != 0)
+        {
+            throw new InvalidOperationException($"Unable to seed the Radicale conformance resource: {result.Stderr}");
+        }
+
+        using var document = JsonDocument.Parse(result.Stdout);
+        var root = document.RootElement;
+        return new RadicaleConformanceResource(
+            root.GetProperty("entityTag").GetString()!,
+            Convert.FromBase64String(root.GetProperty("content").GetString()!));
+    }
+
+    public async Task DeleteResourceAsync(
+        string resourceName,
+        string entityTag,
+        CancellationToken cancellationToken)
+    {
+        const string script = """
+            import sys
+            import urllib.parse
+            import urllib.request
+
+            name = urllib.parse.quote(sys.argv[1], safe='')
+            authorization = 'Basic ' + sys.argv[3]
+            url = 'http://127.0.0.1:5232/conformance/conformance/' + name
+            request = urllib.request.Request(
+                url,
+                headers={
+                    'Authorization': authorization,
+                    'Connection': 'close',
+                    'If-Match': sys.argv[2]
+                },
+                method='DELETE')
+            with urllib.request.urlopen(request) as response:
+                if response.status not in (200, 204):
+                    raise RuntimeError(f'DELETE returned {response.status}')
+            """;
+        var credentialsBase64 = Convert.ToBase64String(Encoding.UTF8.GetBytes($"{Username}:{Password}"));
+        var result = await _container!.ExecAsync(
+            ["/app/bin/python", "-c", script, resourceName, entityTag, credentialsBase64],
+            cancellationToken);
+        if (result.ExitCode != 0)
+        {
+            throw new InvalidOperationException($"Unable to delete the Radicale conformance resource: {result.Stderr}");
         }
     }
 
@@ -118,7 +224,7 @@ public sealed class RadicaleConformanceFixture : IAsyncLifetime
                 except urllib.error.HTTPError as error:
                     return error.code
 
-            credentials = {'Authorization': 'Basic Y29uZm9ybWFuY2U6'}
+            credentials = {'Authorization': 'Basic Y29uZm9ybWFuY2U6Y29uZm9ybWFuY2U='}
             collection = request('MKCALENDAR', base, headers=credentials)
             if collection not in (201, 405):
                 raise RuntimeError(f'MKCALENDAR returned {collection}')
@@ -171,6 +277,8 @@ public sealed record RadicaleRuntimeEvidence(
     string RuntimeTimeZone);
 
 internal sealed record RadicaleManifestEvidence(string Architecture, string Digest);
+
+public sealed record RadicaleConformanceResource(string EntityTag, byte[] Utf8);
 
 public sealed record RadicaleConformanceVariant(string Name, string TimeZone, bool StrictPreconditions)
 {

--- a/tests/DotnetAgents.CalDav.IntegrationTests/Fixtures/RadicaleFixture.cs
+++ b/tests/DotnetAgents.CalDav.IntegrationTests/Fixtures/RadicaleFixture.cs
@@ -1,6 +1,4 @@
 using System.Collections.Generic;
-using System.Net;
-using System.Net.Http.Headers;
 using System.Text;
 using DotNet.Testcontainers.Builders;
 using DotNet.Testcontainers.Configurations;
@@ -22,7 +20,6 @@ public sealed class RadicaleFixture : IAsyncLifetime
 {
     private IContainer? _container;
     private ServiceProvider? _serviceProvider;
-    private HttpClient? _adminHttpClient;
 
     private const string TestUsername = "caldavtest";
     private const string TestPassword = "caldavtest123";
@@ -86,21 +83,15 @@ public sealed class RadicaleFixture : IAsyncLifetime
         var port = _container.GetMappedPublicPort(RadicalePort);
         BaseUrl = $"http://localhost:{port}";
 
-        // 2. Set up an admin HttpClient for fixture setup (MKCOL requests).
-        _adminHttpClient = new HttpClient
-        {
-            BaseAddress = new Uri(BaseUrl)
-        };
-        var credentials = Convert.ToBase64String(Encoding.UTF8.GetBytes($"{TestUsername}:{TestPassword}"));
-        _adminHttpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", credentials);
+        // 2. Provision the fixture through Radicale's loopback interface. Product traffic below
+        // still uses the published BaseUrl and the production HTTP stack.
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await CreateUserPrincipalAsync(cancellationToken);
+        TaskListHref = await CreateTaskCollectionAsync(TaskCollectionName, "Tasks", cancellationToken);
+        ShoppingListHref = await CreateTaskCollectionAsync(ShoppingCollectionName, "Shopping", cancellationToken);
+        WorkListHref = await CreateTaskCollectionAsync(WorkCollectionName, "Work", cancellationToken);
 
-        // 3. Create user principal and task collections.
-        await CreateUserPrincipalAsync();
-        TaskListHref = await CreateTaskCollectionAsync(TaskCollectionName, "Tasks");
-        ShoppingListHref = await CreateTaskCollectionAsync(ShoppingCollectionName, "Shopping");
-        WorkListHref = await CreateTaskCollectionAsync(WorkCollectionName, "Work");
-
-        // 4. Wire production DI (AddCalDavTasks) against the live container.
+        // 3. Wire production DI (AddCalDavTasks) against the live container.
         var services = new ServiceCollection();
         services.AddLogging(builder => builder.AddConsole().SetMinimumLevel(LogLevel.Debug));
         services.AddCalDavTasks(options =>
@@ -116,8 +107,6 @@ public sealed class RadicaleFixture : IAsyncLifetime
 
     public async ValueTask DisposeAsync()
     {
-        _adminHttpClient?.Dispose();
-
         if (_serviceProvider is not null)
         {
             await _serviceProvider.DisposeAsync();
@@ -157,24 +146,17 @@ public sealed class RadicaleFixture : IAsyncLifetime
 
     // ── Collection provisioning ─────────────────────────────────────────────
 
-    private async Task CreateUserPrincipalAsync()
+    private Task CreateUserPrincipalAsync(CancellationToken cancellationToken)
     {
         // MKCOL /caldavtest/ — creates the user's principal collection.
         var principalPath = $"/{TestUsername}/";
-        var response = await _adminHttpClient!.SendAsync(
-            new HttpRequestMessage(new HttpMethod("MKCOL"), principalPath));
-
-        // 201 Created = new, 405 Method Not Allowed = already exists — both are fine.
-        if (response.StatusCode != HttpStatusCode.Created &&
-            response.StatusCode != HttpStatusCode.MethodNotAllowed)
-        {
-            var body = await response.Content.ReadAsStringAsync();
-            throw new InvalidOperationException(
-                $"Failed to create user principal at {principalPath}. Status: {response.StatusCode}, Body: {body}");
-        }
+        return ProvisionCollectionAsync(principalPath, null, cancellationToken);
     }
 
-    private async Task<string> CreateTaskCollectionAsync(string collectionName, string displayName)
+    private async Task<string> CreateTaskCollectionAsync(
+        string collectionName,
+        string displayName,
+        CancellationToken cancellationToken)
     {
         // Extended MKCOL to create a VTODO-capable calendar collection.
         var collectionPath = $"/{TestUsername}/{collectionName}/";
@@ -195,19 +177,55 @@ public sealed class RadicaleFixture : IAsyncLifetime
               </D:set>
             </D:mkcol>
             """;
-        var content = new StringContent(body, Encoding.UTF8, "application/xml");
-        var request = new HttpRequestMessage(new HttpMethod("MKCOL"), collectionPath) { Content = content };
-        var response = await _adminHttpClient!.SendAsync(request);
-
-        if (response.StatusCode != HttpStatusCode.Created &&
-            response.StatusCode != HttpStatusCode.MethodNotAllowed)
-        {
-            var responseBody = await response.Content.ReadAsStringAsync();
-            throw new InvalidOperationException(
-                $"Failed to create task collection at {collectionPath}. Status: {response.StatusCode}, Body: {responseBody}");
-        }
-
+        await ProvisionCollectionAsync(collectionPath, body, cancellationToken);
         return collectionPath;
+    }
+
+    private async Task ProvisionCollectionAsync(
+        string collectionPath,
+        string? body,
+        CancellationToken cancellationToken)
+    {
+        const string script = """
+            import base64
+            import sys
+            import urllib.error
+            import urllib.parse
+            import urllib.request
+
+            path = urllib.parse.quote(sys.argv[1], safe='/')
+            body = base64.b64decode(sys.argv[2]) if sys.argv[2] else None
+            authorization = 'Basic ' + sys.argv[3]
+            headers = {'Authorization': authorization, 'Connection': 'close'}
+            if body is not None:
+                headers['Content-Type'] = 'application/xml; charset=utf-8'
+            request = urllib.request.Request(
+                'http://127.0.0.1:5232' + path,
+                data=body,
+                headers=headers,
+                method='MKCOL')
+            try:
+                with urllib.request.urlopen(request) as response:
+                    status = response.status
+            except urllib.error.HTTPError as error:
+                status = error.code
+            if status not in (201, 405):
+                raise RuntimeError(f'MKCOL {path} returned {status}')
+            print(status)
+            """;
+        var bodyBase64 = body is null
+            ? string.Empty
+            : Convert.ToBase64String(Encoding.UTF8.GetBytes(body));
+        var credentialsBase64 = Convert.ToBase64String(
+            Encoding.UTF8.GetBytes($"{TestUsername}:{TestPassword}"));
+        var result = await _container!.ExecAsync(
+            ["/app/bin/python", "-c", script, collectionPath, bodyBase64, credentialsBase64],
+            cancellationToken);
+        if (result.ExitCode != 0)
+        {
+            throw new InvalidOperationException(
+                $"Unable to provision Radicale collection '{collectionPath}': {result.Stderr}");
+        }
     }
 }
 

--- a/tests/DotnetAgents.CalDav.IntegrationTests/RadicaleConformanceHarnessTests.cs
+++ b/tests/DotnetAgents.CalDav.IntegrationTests/RadicaleConformanceHarnessTests.cs
@@ -1,5 +1,9 @@
 using System.Text.Json;
+using DotnetAgents.CalDav.Core.Abstractions;
+using DotnetAgents.CalDav.Core.DependencyInjection;
+using DotnetAgents.CalDav.Core.Models;
 using DotnetAgents.CalDav.IntegrationTests.Fixtures;
+using Microsoft.Extensions.DependencyInjection;
 using Shouldly;
 using Xunit;
 
@@ -8,6 +12,9 @@ namespace DotnetAgents.CalDav.IntegrationTests;
 [Collection("RadicaleConformanceCollection")]
 public sealed class RadicaleConformanceHarnessTests(RadicaleConformanceFixture fixture, ITestOutputHelper output)
 {
+    internal const string ConformanceUsername = RadicaleConformanceFixture.Username;
+    internal const string ConformancePassword = RadicaleConformanceFixture.Password;
+
     [Fact]
     public void Pinned_profile_records_the_runtime_and_selected_variant()
     {
@@ -26,5 +33,134 @@ public sealed class RadicaleConformanceHarnessTests(RadicaleConformanceFixture f
         fixture.Runtime.VobjectVersion.ShouldBe("0.9.9");
         fixture.Runtime.RuntimeTimeZone.ShouldBe(fixture.Variant.TimeZone);
         fixture.Runtime.StrictPreconditions.ShouldBe(fixture.Variant.StrictPreconditions);
+    }
+
+    [Fact]
+    public async Task Pinned_profile_preserves_occurrence_boundary_dst_leap_range_and_typed_failures()
+    {
+        var calendarHref = $"{fixture.BaseUrl}/conformance/conformance/";
+        var boundaryFrom = await PutAndGetAsync(calendarHref, "boundary-from.ics", Event(
+            "boundary-from", "DTSTART:20260816T100000Z\r\nDURATION:PT1M\r\n"));
+        _ = await PutAndGetAsync(calendarHref, "boundary-to.ics", Event(
+            "boundary-to", "DTSTART:20260816T110000Z\r\nDURATION:PT1M\r\n"));
+        _ = await PutAndGetAsync(calendarHref, "dst.ics", Event(
+            "dst", "DTSTART;TZID=America/New_York:20260307T100000\r\nDURATION:PT1H\r\nRRULE:FREQ=DAILY;COUNT=3\r\n"));
+        _ = await PutAndGetAsync(calendarHref, "leap.ics", Event(
+            "leap", "DTSTART:20240229T100000Z\r\nDURATION:PT1H\r\nRRULE:FREQ=YEARLY;COUNT=3\r\n"));
+        var range = await PutAndGetAsync(calendarHref, "range.ics", RangeEvent());
+        await using var provider = CreateProvider(fixture.BaseUrl, calendarHref);
+        var service = provider.GetRequiredService<ICalendarService>();
+        var scope = CalendarEntityScope.Selected(new CalendarReference(Href: calendarHref));
+
+        var boundary = await service.QueryOccurrencesAsync(new CalendarOccurrenceQuery(
+            scope,
+            DateTimeOffset.Parse("2026-08-16T10:00:00Z"),
+            DateTimeOffset.Parse("2026-08-16T11:00:00Z")), TestContext.Current.CancellationToken);
+        var dst = await service.QueryOccurrencesAsync(new CalendarOccurrenceQuery(
+            scope,
+            DateTimeOffset.Parse("2026-03-08T14:30:00Z"),
+            DateTimeOffset.Parse("2026-03-08T14:45:00Z")), TestContext.Current.CancellationToken);
+        var leap = await service.QueryOccurrencesAsync(new CalendarOccurrenceQuery(
+            scope,
+            DateTimeOffset.Parse("2028-02-29T10:30:00Z"),
+            DateTimeOffset.Parse("2028-02-29T10:45:00Z")), TestContext.Current.CancellationToken);
+        var moved = await service.QueryOccurrencesAsync(new CalendarOccurrenceQuery(
+            scope,
+            DateTimeOffset.Parse("2026-08-17T13:30:00Z"),
+            DateTimeOffset.Parse("2026-08-17T13:45:00Z")), TestContext.Current.CancellationToken);
+
+        boundary.Items.ShouldHaveSingleItem().Snapshot.Projection.EntityUid.ShouldBe("boundary-from");
+        boundary.Items[0].Snapshot.AuthoritativeUtf8.ToArray().ShouldBe(boundaryFrom.Utf8);
+        dst.Items.ShouldHaveSingleItem().Timing.EvaluatedStartUtc!.Value.ShouldBe("2026-03-08T14:00:00Z");
+        leap.Items.ShouldHaveSingleItem().RecurrenceIdentity.Value.ShouldBe("2028-02-29T10:00:00Z");
+        var movedOccurrence = moved.Items.ShouldHaveSingleItem();
+        movedOccurrence.RecurrenceIdentity.Value.ShouldBe("2026-08-17T09:00:00Z");
+        movedOccurrence.Timing.EffectiveStart.Value.ShouldBe("2026-08-17T13:00:00Z");
+        movedOccurrence.Snapshot.AuthoritativeUtf8.ToArray().ShouldBe(range.Utf8);
+
+        var unresolved = await PutAndGetAsync(calendarHref, "unresolved.ics", Event(
+            "unresolved", "DTSTART;TZID=Private/Unknown:20260816T100000\r\nDURATION:PT1H\r\n"));
+        var unresolvedResult = await service.QueryOccurrencesAsync(new CalendarOccurrenceQuery(
+            scope,
+            DateTimeOffset.Parse("2026-08-16T00:00:00Z"),
+            DateTimeOffset.Parse("2026-08-17T00:00:00Z")), TestContext.Current.CancellationToken);
+        unresolvedResult.Code.ShouldBe(CalendarOccurrenceQueryCode.TemporalUnresolved);
+        unresolvedResult.Items.ShouldBeEmpty();
+        await DeleteAsync(unresolved, TestContext.Current.CancellationToken);
+
+        var unevaluable = await PutAndGetAsync(calendarHref, "unevaluable.ics", Event(
+            "unevaluable", "DTSTART:20260816T100000Z\r\nDURATION:PT1H\r\n"
+            + "RRULE:FREQ=DAILY;COUNT=2\r\nRRULE:FREQ=WEEKLY;COUNT=2\r\n"));
+        var unevaluableResult = await service.QueryOccurrencesAsync(new CalendarOccurrenceQuery(
+            scope,
+            DateTimeOffset.Parse("2026-08-16T00:00:00Z"),
+            DateTimeOffset.Parse("2026-08-17T00:00:00Z")), TestContext.Current.CancellationToken);
+        unevaluableResult.Code.ShouldBe(CalendarOccurrenceQueryCode.RecurrenceUnevaluable);
+        unevaluableResult.Items.ShouldBeEmpty();
+        await DeleteAsync(unevaluable, TestContext.Current.CancellationToken);
+    }
+
+    internal static ServiceProvider CreateProvider(string baseUrl, string calendarHref)
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddCalDavTasks(options =>
+        {
+            options.BaseUrl = baseUrl;
+            options.CalendarHrefs = calendarHref;
+            options.Username = ConformanceUsername;
+            options.Password = ConformancePassword;
+        });
+        return services.BuildServiceProvider();
+    }
+
+    private async Task<ObservedResource> PutAndGetAsync(
+        string calendarHref,
+        string name,
+        string content)
+    {
+        var href = $"{calendarHref}{name}";
+        var observed = await fixture.SeedResourceAsync(
+            name,
+            content,
+            TestContext.Current.CancellationToken);
+        return new ObservedResource(name, href, observed.EntityTag, observed.Utf8);
+    }
+
+    private Task DeleteAsync(
+        ObservedResource resource,
+        CancellationToken cancellationToken) =>
+        fixture.DeleteResourceAsync(resource.Name, resource.EntityTag, cancellationToken);
+
+    private static string Event(string uid, string temporalLines) =>
+        $"BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Conformance//EN\r\nBEGIN:VEVENT\r\n"
+        + $"UID:{uid}\r\nDTSTAMP:20260815T120000Z\r\n{temporalLines}END:VEVENT\r\nEND:VCALENDAR\r\n";
+
+    private static string RangeEvent() =>
+        "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Conformance//EN\r\n"
+        + "BEGIN:VEVENT\r\nUID:range\r\nDTSTAMP:20260815T120000Z\r\nDTSTART:20260814T090000Z\r\n"
+        + "DURATION:PT1H\r\nRRULE:FREQ=DAILY;COUNT=5\r\nEND:VEVENT\r\n"
+        + "BEGIN:VEVENT\r\nUID:range\r\nDTSTAMP:20260815T120000Z\r\n"
+        + "RECURRENCE-ID;RANGE=THISANDFUTURE:20260816T090000Z\r\n"
+        + "DTSTART:20260816T110000Z\r\nDURATION:PT1H\r\nEND:VEVENT\r\n"
+        + "BEGIN:VEVENT\r\nUID:range\r\nDTSTAMP:20260815T120000Z\r\n"
+        + "RECURRENCE-ID;RANGE=THISANDFUTURE:20260817T090000Z\r\n"
+        + "DTSTART:20260817T130000Z\r\nDURATION:PT2H\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n";
+
+    private sealed record ObservedResource(string Name, string Href, string EntityTag, byte[] Utf8);
+}
+
+public sealed class RadicaleConformanceHarnessConfigurationTests
+{
+    [Fact]
+    public void Provider_resolves_calendar_service_with_nonempty_conformance_credentials()
+    {
+        using var provider = RadicaleConformanceHarnessTests.CreateProvider(
+            "http://localhost:5232",
+            "http://localhost:5232/conformance/conformance/");
+
+        RadicaleConformanceFixture.Username.ShouldNotBeNullOrWhiteSpace();
+        RadicaleConformanceFixture.Password.ShouldNotBeNullOrWhiteSpace();
+        provider.GetRequiredService<ICalendarService>().ShouldNotBeNull();
     }
 }

--- a/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/CalDavHostBuilderTests.cs
+++ b/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/CalDavHostBuilderTests.cs
@@ -196,6 +196,7 @@ public class CalDavHostBuilderTests
         [
             typeof(DotnetAgents.CalDav.Mcp.Tools.CalendarTools),
             typeof(DotnetAgents.CalDav.Mcp.Tools.CalendarEntityTools),
+            typeof(DotnetAgents.CalDav.Mcp.Tools.CalendarOccurrenceTools),
             typeof(DotnetAgents.CalDav.Mcp.Tools.CalendarResourceTools),
             typeof(DotnetAgents.CalDav.Mcp.Tools.TaskListTools),
             typeof(DotnetAgents.CalDav.Mcp.Tools.ChatTaskTools)
@@ -238,6 +239,28 @@ public class CalDavHostBuilderTests
             .ShouldBe(["scope", "entityKinds"]);
         outputSchema["oneOf"]!.AsArray().Count.ShouldBe(2);
         outputSchema["$defs"]!.AsObject().ShouldContainKey("entityQuerySuccess");
+        outputSchema["$defs"]!.AsObject().ShouldContainKey("errorOutcome");
+        tool.ProtocolTool.Meta!["cache"]!["ttlMs"]!.GetValue<int>().ShouldBe(5000);
+        tool.ProtocolTool.Meta!["cache"]!["cacheScope"]!.GetValue<string>().ShouldBe("private");
+    }
+
+    [Fact]
+    public void BuildHost_AdvertisesFrozenOccurrenceQuerySchemasAndPrivateCacheHint()
+    {
+        var builder = CalDavHostBuilder.CreateBuilder();
+        builder.Services.ConfigureCalDav(ValidOptions);
+        using var host = builder.Build();
+
+        var options = host.Services.GetRequiredService<IOptions<ModelContextProtocol.Server.McpServerOptions>>().Value;
+        options.ToolCollection!.TryGetPrimitive("calendar_occurrences.query", out var tool).ShouldBeTrue();
+
+        var inputSchema = JsonNode.Parse(tool!.ProtocolTool.InputSchema.GetRawText())!.AsObject();
+        var outputSchema = JsonNode.Parse(tool.ProtocolTool.OutputSchema!.Value.GetRawText())!.AsObject();
+        inputSchema["additionalProperties"]!.GetValue<bool>().ShouldBeFalse();
+        inputSchema["required"]!.AsArray().Select(item => item!.GetValue<string>())
+            .ShouldBe(["scope", "from", "to"]);
+        outputSchema["oneOf"]!.AsArray().Count.ShouldBe(2);
+        outputSchema["$defs"]!.AsObject().ShouldContainKey("occurrenceQuerySuccess");
         outputSchema["$defs"]!.AsObject().ShouldContainKey("errorOutcome");
         tool.ProtocolTool.Meta!["cache"]!["ttlMs"]!.GetValue<int>().ShouldBe(5000);
         tool.ProtocolTool.Meta!["cache"]!["cacheScope"]!.GetValue<string>().ShouldBe("private");
@@ -294,6 +317,7 @@ public class CalDavHostBuilderTests
         [
             "calendars.list",
             "calendar_entities.query",
+            "calendar_occurrences.query",
             "calendar_resources.get",
             "list_task_lists",
             "show_tasks",
@@ -332,6 +356,7 @@ public class CalDavHostBuilderTests
         [
             "calendars.list",
             "calendar_entities.query",
+            "calendar_occurrences.query",
             "calendar_resources.get",
             "list_task_lists",
             "show_tasks",

--- a/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/CalendarOccurrenceToolsTests.cs
+++ b/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/CalendarOccurrenceToolsTests.cs
@@ -1,0 +1,641 @@
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using System.Xml;
+using DotnetAgents.CalDav.Core.Abstractions;
+using DotnetAgents.CalDav.Core.Configuration;
+using DotnetAgents.CalDav.Core.Models;
+using DotnetAgents.CalDav.Mcp.Tools;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace DotnetAgents.CalDav.Mcp.Tests.Unit;
+
+public sealed class CalendarOccurrenceToolsTests
+{
+    private static readonly DateTimeOffset Now = new(2026, 8, 15, 12, 0, 0, TimeSpan.Zero);
+    private static readonly CalendarEntityUtcArgument From = new("utcDateTime", "2026-08-15T12:00:00Z");
+    private static readonly CalendarEntityUtcArgument To = new("utcDateTime", "2026-08-16T12:00:00Z");
+
+    [Theory]
+    [InlineData(0, false)]
+    [InlineData(1, true)]
+    public async Task QueryRawAsync_EnforcesExactArgumentByteBoundary(int extraByte, bool rejected)
+    {
+        var service = Substitute.For<ICalendarService>();
+        service.QueryOccurrencesAsync(Arg.Any<CalendarOccurrenceQuery>(), Arg.Any<CancellationToken>())
+            .Returns(CalendarOccurrenceQueryResult.Success([]));
+        var sut = CreateTool(service, new MutableTimeProvider(Now));
+        var arguments = ArgumentsWithSerializedSize(CalendarOccurrenceTools.MaximumArgumentBytes + extraByte);
+
+        var result = await sut.QueryRawAsync(arguments, CancellationToken.None);
+
+        JsonSerializer.SerializeToUtf8Bytes(arguments).Length.ShouldBe(CalendarOccurrenceTools.MaximumArgumentBytes + extraByte);
+        if (rejected)
+        {
+            result.StructuredContent!.Value.GetProperty("code").GetString().ShouldBe("payload_too_large");
+            await service.DidNotReceive().QueryOccurrencesAsync(
+                Arg.Any<CalendarOccurrenceQuery>(), Arg.Any<CancellationToken>());
+        }
+        else
+        {
+            result.IsError.ShouldBe(false);
+            await service.Received(1).QueryOccurrencesAsync(
+                Arg.Any<CalendarOccurrenceQuery>(), Arg.Any<CancellationToken>());
+        }
+    }
+
+    [Fact]
+    public async Task QueryRawAsync_AcceptsExactFrozenShapeWithoutEntityKindsAndDefaultsAbsentPageSize()
+    {
+        var service = Substitute.For<ICalendarService>();
+        CalendarOccurrenceQuery? observed = null;
+        service.QueryOccurrencesAsync(Arg.Do<CalendarOccurrenceQuery>(query => observed = query), Arg.Any<CancellationToken>())
+            .Returns(CalendarOccurrenceQueryResult.Success([]));
+        var sut = CreateTool(service, new MutableTimeProvider(Now));
+        var arguments = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(
+            "{\"scope\":{\"mode\":\"selected\",\"calendar\":{\"by\":\"href\",\"href\":\"https://cal.example/a/\"}},"
+            + "\"from\":{\"kind\":\"utcDateTime\",\"value\":\"2026-08-15T12:00:00Z\"},"
+            + "\"to\":{\"kind\":\"utcDateTime\",\"value\":\"2026-08-16T12:00:00Z\"},"
+            + "\"evaluationTimeZone\":\"America/New_York\"}");
+
+        var result = await sut.QueryRawAsync(arguments, CancellationToken.None);
+
+        result.IsError.ShouldBe(false);
+        observed.ShouldNotBeNull();
+        observed.Scope.Calendar!.Href.ShouldBe("https://cal.example/a/");
+        observed.EvaluationTimeZone.ShouldBe("America/New_York");
+    }
+
+    [Fact]
+    public async Task QueryCoreAsync_RejectsOversizedRawEvidenceBeforeService()
+    {
+        var service = Substitute.For<ICalendarService>();
+        var sut = CreateTool(service, new MutableTimeProvider(Now));
+
+        var result = await sut.QueryCoreAsync(
+            new CalendarEntityScopeArgument("all"),
+            From,
+            To,
+            CancellationToken.None,
+            rawArguments: ArgumentsWithSerializedSize(CalendarOccurrenceTools.MaximumArgumentBytes + 1));
+
+        result.StructuredContent!.Value.GetProperty("code").GetString().ShouldBe("payload_too_large");
+        await service.DidNotReceive().QueryOccurrencesAsync(
+            Arg.Any<CalendarOccurrenceQuery>(), Arg.Any<CancellationToken>());
+    }
+
+    [Theory]
+    [InlineData("null")]
+    [InlineData("{}")]
+    [InlineData("{\"scope\":{\"mode\":\"all\"},\"from\":{\"kind\":\"utcDateTime\",\"value\":\"2026-08-15T12:00:00Z\"}}")]
+    [InlineData("{\"scope\":{\"mode\":\"all\"},\"from\":{\"kind\":\"utcDateTime\",\"value\":\"2026-08-15T12:00:00Z\"},\"to\":{\"kind\":\"utcDateTime\",\"value\":\"2026-08-16T12:00:00Z\"},\"entityKinds\":[\"event\"]}")]
+    [InlineData("{\"scope\":{\"mode\":\"all\"},\"from\":{\"kind\":\"utcDateTime\",\"value\":\"2026-08-15T12:00:00Z\"},\"to\":{\"kind\":\"utcDateTime\",\"value\":\"2026-08-16T12:00:00Z\"},\"pageSize\":null}")]
+    [InlineData("{\"scope\":{\"mode\":\"all\"},\"from\":{\"kind\":\"utcDateTime\",\"value\":\"2026-08-15T12:00:00Z\"},\"to\":{\"kind\":\"utcDateTime\",\"value\":\"2026-08-16T12:00:00Z\"},\"evaluationTimeZone\":null}")]
+    public async Task QueryRawAsync_RejectsMissingNullAndUnknownFrozenShape(string json)
+    {
+        var service = Substitute.For<ICalendarService>();
+        var sut = CreateTool(service, new MutableTimeProvider(Now));
+        var arguments = json == "null" ? null : JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(json);
+
+        var result = await sut.QueryRawAsync(arguments, CancellationToken.None);
+
+        result.StructuredContent!.Value.GetProperty("code").GetString().ShouldBe("invalid_input");
+        await service.DidNotReceive().QueryOccurrencesAsync(Arg.Any<CalendarOccurrenceQuery>(), Arg.Any<CancellationToken>());
+    }
+
+    [Theory]
+    [InlineData(CalendarOccurrenceQueryCode.InvalidInput, "invalid_input")]
+    [InlineData(CalendarOccurrenceQueryCode.UnsafeScope, "invalid_input")]
+    [InlineData(CalendarOccurrenceQueryCode.NotFound, "not_found")]
+    [InlineData(CalendarOccurrenceQueryCode.Ambiguous, "ambiguous")]
+    [InlineData(CalendarOccurrenceQueryCode.OutsideScope, "outside_scope")]
+    [InlineData(CalendarOccurrenceQueryCode.UnsupportedCapability, "unsupported_capability")]
+    [InlineData(CalendarOccurrenceQueryCode.ConcurrencyUnavailable, "concurrency_unavailable")]
+    [InlineData(CalendarOccurrenceQueryCode.LimitExhausted, "limit_exhausted")]
+    [InlineData(CalendarOccurrenceQueryCode.PayloadTooLarge, "payload_too_large")]
+    [InlineData(CalendarOccurrenceQueryCode.TemporalUnresolved, "temporal_unresolved")]
+    [InlineData(CalendarOccurrenceQueryCode.RecurrenceUnevaluable, "recurrence_unevaluable")]
+    [InlineData(CalendarOccurrenceQueryCode.UpstreamProtocolError, "upstream_protocol_error")]
+    public async Task QueryAsync_MapsEveryDomainFailure(CalendarOccurrenceQueryCode code, string expected)
+    {
+        var service = Substitute.For<ICalendarService>();
+        service.QueryOccurrencesAsync(Arg.Any<CalendarOccurrenceQuery>(), Arg.Any<CancellationToken>())
+            .Returns(CalendarOccurrenceQueryResult.Failure(code));
+        var sut = CreateTool(service, new MutableTimeProvider(Now));
+
+        var result = await sut.QueryCoreAsync(new CalendarEntityScopeArgument("all"), From, To, CancellationToken.None);
+
+        result.IsError.ShouldBe(true);
+        result.StructuredContent!.Value.GetProperty("code").GetString().ShouldBe(expected);
+        result.StructuredContent.Value.TryGetProperty("items", out _).ShouldBeFalse();
+    }
+
+    [Theory]
+    [InlineData(HttpStatusCode.NotFound, "upstream_protocol_error", "selectionDiscoveryCapability")]
+    [InlineData(HttpStatusCode.BadGateway, "upstream_unavailable", "execution")]
+    [InlineData(HttpStatusCode.Unauthorized, "upstream_unauthorized", "execution")]
+    [InlineData(HttpStatusCode.Forbidden, "upstream_forbidden", "execution")]
+    [InlineData(HttpStatusCode.TooManyRequests, "upstream_rate_limited", "execution")]
+    [InlineData(HttpStatusCode.MethodNotAllowed, "unsupported_capability", "selectionDiscoveryCapability")]
+    [InlineData(HttpStatusCode.NotImplemented, "unsupported_capability", "selectionDiscoveryCapability")]
+    [InlineData(HttpStatusCode.RequestEntityTooLarge, "payload_too_large", "admissionAndPayload")]
+    [InlineData(HttpStatusCode.Conflict, "conflict", "execution")]
+    [InlineData(HttpStatusCode.PreconditionFailed, "conflict", "execution")]
+    [InlineData(HttpStatusCode.RequestTimeout, "upstream_unavailable", "execution")]
+    [InlineData(HttpStatusCode.InsufficientStorage, "upstream_unavailable", "execution")]
+    [InlineData(HttpStatusCode.InternalServerError, "upstream_unavailable", "execution")]
+    [InlineData(HttpStatusCode.BadRequest, "upstream_protocol_error", "execution")]
+    [InlineData(null, "upstream_unavailable", "execution")]
+    public async Task QueryAsync_MapsHttpFailureWithoutLosingItsEarliestPhase(
+        HttpStatusCode? status,
+        string code,
+        string phase)
+    {
+        var service = Substitute.For<ICalendarService>();
+        service.QueryOccurrencesAsync(Arg.Any<CalendarOccurrenceQuery>(), Arg.Any<CancellationToken>())
+            .Returns<Task<CalendarOccurrenceQueryResult>>(_ => throw new HttpRequestException("secret", null, status));
+        var sut = CreateTool(service, new MutableTimeProvider(Now));
+
+        var result = await sut.QueryCoreAsync(new CalendarEntityScopeArgument("all"), From, To, CancellationToken.None);
+
+        result.StructuredContent!.Value.GetProperty("code").GetString().ShouldBe(code);
+        result.StructuredContent.Value.GetProperty("phase").GetString().ShouldBe(phase);
+        result.StructuredContent.Value.ToString().ShouldNotContain("secret");
+    }
+
+    [Fact]
+    public async Task QueryAsync_MapsObservedDomainLimitsWithoutPartialItems()
+    {
+        var service = Substitute.For<ICalendarService>();
+        service.QueryOccurrencesAsync(Arg.Any<CalendarOccurrenceQuery>(), Arg.Any<CancellationToken>())
+            .Returns(CalendarOccurrenceQueryResult.Failure(
+                CalendarOccurrenceQueryCode.LimitExhausted,
+                limits: new CalendarOccurrenceQueryExecutionLimits(17, 2001, 4097)));
+        var sut = CreateTool(service, new MutableTimeProvider(Now));
+
+        var result = await sut.QueryCoreAsync(
+            new CalendarEntityScopeArgument("all"), From, To, CancellationToken.None);
+
+        var limits = result.StructuredContent!.Value.GetProperty("limits");
+        limits.GetProperty("resourcesInspected").GetInt32().ShouldBe(17);
+        limits.GetProperty("occurrenceCount").GetInt32().ShouldBe(2001);
+        limits.GetProperty("byteCount").GetInt32().ShouldBe(4097);
+        result.StructuredContent.Value.TryGetProperty("items", out _).ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task QueryAsync_EmitsAuthorizedCandidatesOnlyForSelectionFailures()
+    {
+        var service = Substitute.For<ICalendarService>();
+        service.QueryOccurrencesAsync(Arg.Any<CalendarOccurrenceQuery>(), Arg.Any<CancellationToken>())
+            .Returns(CalendarOccurrenceQueryResult.Failure(
+                CalendarOccurrenceQueryCode.NotFound,
+                [new CalendarDescriptor
+                {
+                    Href = "https://cal.example/a/",
+                    DisplayName = "A",
+                    DisplayNameProvenance = DisplayNameProvenance.DavDisplayName,
+                    EventSupport = EntityKindSupport.Advertised,
+                    TodoSupport = EntityKindSupport.Advertised
+                }]));
+        var sut = CreateTool(service, new MutableTimeProvider(Now));
+
+        var result = await sut.QueryCoreAsync(
+            new CalendarEntityScopeArgument("all"), From, To, CancellationToken.None);
+
+        result.StructuredContent!.Value.GetProperty("authorizedCandidates").GetArrayLength().ShouldBe(1);
+    }
+
+    [Theory]
+    [InlineData("invalid", "utcDateTime", "utcDateTime", null, 50, 0)]
+    [InlineData("all", "date", "utcDateTime", null, 50, 0)]
+    [InlineData("all", "utcDateTime", "date", null, 50, 0)]
+    [InlineData("all", "utcDateTime", "utcDateTime", "", 50, 0)]
+    [InlineData("all", "utcDateTime", "utcDateTime", null, 0, 0)]
+    [InlineData("all", "utcDateTime", "utcDateTime", null, 201, 0)]
+    [InlineData("all", "utcDateTime", "utcDateTime", null, 50, 2049)]
+    public async Task QueryAsync_RejectsEachInvalidDomainAndPaginationBranchBeforeService(
+        string scopeMode,
+        string fromKind,
+        string toKind,
+        string? evaluationTimeZone,
+        int pageSize,
+        int cursorLength)
+    {
+        var service = Substitute.For<ICalendarService>();
+        var sut = CreateTool(service, new MutableTimeProvider(Now));
+
+        var result = await sut.QueryCoreAsync(
+            new CalendarEntityScopeArgument(scopeMode),
+            From with { Kind = fromKind },
+            To with { Kind = toKind },
+            CancellationToken.None,
+            evaluationTimeZone,
+            pageSize,
+            cursorLength == 0 ? null : new string('x', cursorLength));
+
+        result.StructuredContent!.Value.GetProperty("code").GetString().ShouldBe("invalid_input");
+        await service.DidNotReceive().QueryOccurrencesAsync(
+            Arg.Any<CalendarOccurrenceQuery>(), Arg.Any<CancellationToken>());
+    }
+
+    [Theory]
+    [MemberData(nameof(DiscoveryProtocolFailures))]
+    public async Task QueryAsync_MalformedDiscoveryRetainsSelectionDiscoveryPhase(Exception exception)
+    {
+        var service = Substitute.For<ICalendarService>();
+        service.QueryOccurrencesAsync(Arg.Any<CalendarOccurrenceQuery>(), Arg.Any<CancellationToken>())
+            .Returns<Task<CalendarOccurrenceQueryResult>>(_ => throw exception);
+        var sut = CreateTool(service, new MutableTimeProvider(Now));
+
+        var result = await sut.QueryCoreAsync(new CalendarEntityScopeArgument("all"), From, To, CancellationToken.None);
+
+        result.StructuredContent!.Value.GetProperty("code").GetString().ShouldBe("upstream_protocol_error");
+        result.StructuredContent.Value.GetProperty("phase").GetString().ShouldBe("selectionDiscoveryCapability");
+        result.StructuredContent.Value.ToString().ShouldNotContain("secret");
+    }
+
+    public static TheoryData<Exception> DiscoveryProtocolFailures => new()
+    {
+        new XmlException("secret"),
+        new CalendarDiscoveryProtocolException("secret")
+    };
+
+    [Fact]
+    public async Task QueryAsync_CandidateProtocolFailureAfterSelectionRemainsExecutionPhase()
+    {
+        var service = Substitute.For<ICalendarService>();
+        service.QueryOccurrencesAsync(Arg.Any<CalendarOccurrenceQuery>(), Arg.Any<CancellationToken>())
+            .Returns(CalendarOccurrenceQueryResult.Failure(CalendarOccurrenceQueryCode.UpstreamProtocolError));
+        var sut = CreateTool(service, new MutableTimeProvider(Now));
+
+        var result = await sut.QueryCoreAsync(new CalendarEntityScopeArgument("all"), From, To, CancellationToken.None);
+
+        result.StructuredContent!.Value.GetProperty("code").GetString().ShouldBe("upstream_protocol_error");
+        result.StructuredContent.Value.GetProperty("phase").GetString().ShouldBe("execution");
+    }
+
+    [Fact]
+    public async Task QueryAsync_EmitsExactOccurrenceShapeAndPaginatesByFrozenContinuationTuple()
+    {
+        var service = Substitute.For<ICalendarService>();
+        service.QueryOccurrencesAsync(Arg.Any<CalendarOccurrenceQuery>(), Arg.Any<CancellationToken>())
+            .Returns(CalendarOccurrenceQueryResult.Success([
+                Occurrence("2026-08-15T12:00:00Z", "https://cal.example/a/", "a", "2026-08-15T10:00:00Z"),
+                Occurrence("2026-08-15T12:00:00Z", "https://cal.example/a/", "a", "2026-08-16T10:00:00Z"),
+                Occurrence("2026-08-15T12:00:00Z", "https://cal.example/a/", "z", "2026-08-15T10:00:00Z")
+            ]));
+        var time = new MutableTimeProvider(Now);
+        var sut = CreateTool(service, time);
+
+        var first = await sut.QueryCoreAsync(
+            new CalendarEntityScopeArgument("all"), From, To, CancellationToken.None,
+            evaluationTimeZone: "America/New_York", pageSize: 2);
+        var cursor = first.StructuredContent!.Value.GetProperty("pagination").GetProperty("nextCursor").GetString();
+
+        first.IsError.ShouldBe(false);
+        first.StructuredContent.Value.GetProperty("outcome").GetString().ShouldBe("success");
+        first.StructuredContent.Value.GetProperty("items").GetArrayLength().ShouldBe(2);
+        var item = first.StructuredContent.Value.GetProperty("items")[0];
+        item.EnumerateObject().Select(property => property.Name).ShouldBe(["snapshot", "recurrenceIdentity", "timing"]);
+        item.GetProperty("recurrenceIdentity").GetProperty("value").GetProperty("kind").GetString().ShouldBe("utcDateTime");
+        cursor.ShouldNotBeNullOrEmpty();
+        cursor.Length.ShouldBeLessThanOrEqualTo(CalendarEntityCursorProtector.MaximumCursorCharacters);
+        cursor.All(character => char.IsAsciiLetterOrDigit(character) || character is '-' or '_').ShouldBeTrue();
+
+        var second = await sut.QueryCoreAsync(
+            new CalendarEntityScopeArgument("all"), From, To, CancellationToken.None,
+            evaluationTimeZone: "America/New_York", pageSize: 2, cursor: cursor);
+
+        second.StructuredContent!.Value.GetProperty("items").GetArrayLength().ShouldBe(1);
+        second.StructuredContent.Value.GetProperty("items")[0].GetProperty("snapshot")
+            .GetProperty("projection").GetProperty("uid").GetString().ShouldBe("z");
+        second.StructuredContent.Value.GetProperty("pagination").GetProperty("nextCursor").ValueKind
+            .ShouldBe(JsonValueKind.Null);
+    }
+
+    [Fact]
+    public void ContinuationUsesTheDomainTemporalCanonicalSortKey()
+    {
+        var occurrence = Occurrence(
+            "2026-08-15T12:00:00Z",
+            "https://cal.example/a/",
+            "uid",
+            "2026-08-15T10:00:00Z");
+
+        var continuation = CalendarOccurrenceContinuation.FromSnapshot(occurrence);
+
+        continuation.RecurrenceIdentity.ShouldBe(occurrence.RecurrenceIdentity.GetCanonicalSortKey());
+    }
+
+    [Fact]
+    public async Task QueryAsync_ContinuationComparesEffectiveStartBeforeCalendarHref()
+    {
+        var service = Substitute.For<ICalendarService>();
+        service.QueryOccurrencesAsync(Arg.Any<CalendarOccurrenceQuery>(), Arg.Any<CancellationToken>())
+            .Returns(CalendarOccurrenceQueryResult.Success([
+                Occurrence("2026-08-15T12:00:00Z", "https://cal.example/a/", "a", "2026-08-15T10:00:00Z"),
+                Occurrence("2026-08-15T12:00:00Z", "https://cal.example/b/", "a", "2026-08-15T10:00:00Z"),
+                Occurrence("2026-08-15T13:00:00Z", "https://cal.example/a/", "a", "2026-08-15T13:00:00Z")
+            ]));
+        var sut = CreateTool(service, new MutableTimeProvider(Now));
+        var first = await sut.QueryCoreAsync(
+            new CalendarEntityScopeArgument("all"), From, To, CancellationToken.None, pageSize: 2);
+
+        var second = await sut.QueryCoreAsync(
+            new CalendarEntityScopeArgument("all"), From, To, CancellationToken.None,
+            pageSize: 2, cursor: GetCursor(first));
+
+        second.StructuredContent!.Value.GetProperty("items").GetArrayLength().ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task QueryAsync_RejectsAuthenticatedCursorWithIncompleteContinuationTail()
+    {
+        var service = Substitute.For<ICalendarService>();
+        service.QueryOccurrencesAsync(Arg.Any<CalendarOccurrenceQuery>(), Arg.Any<CancellationToken>())
+            .Returns(CalendarOccurrenceQueryResult.Success([]));
+        var time = new MutableTimeProvider(Now);
+        var protector = CreateProtector(time);
+        var sut = new CalendarOccurrenceTools(service, protector, time);
+        var context = JsonSerializer.Serialize(new
+        {
+            ScopeMode = CalendarEntityScopeMode.All,
+            SelectorKind = "href",
+            SelectorValue = (string?)null,
+            From = DateTimeOffset.Parse(From.Value).ToString("O", System.Globalization.CultureInfo.InvariantCulture),
+            To = DateTimeOffset.Parse(To.Value).ToString("O", System.Globalization.CultureInfo.InvariantCulture),
+            EvaluationTimeZone = (string?)null,
+            PageSize = 1
+        });
+        var invalidTails = new[]
+        {
+            "null",
+            JsonSerializer.Serialize(new { CalendarHref = "", EntityUid = "uid", RecurrenceIdentity = "identity" }),
+            JsonSerializer.Serialize(new { CalendarHref = "calendar", EntityUid = "", RecurrenceIdentity = "identity" }),
+            JsonSerializer.Serialize(new { CalendarHref = "calendar", EntityUid = "uid", RecurrenceIdentity = "" })
+        };
+
+        foreach (var tail in invalidTails)
+        {
+            var cursor = protector.Protect(context, "2026-08-15T12:00:00Z", tail);
+            await AssertInvalidCursor(sut.QueryCoreAsync(
+                new CalendarEntityScopeArgument("all"), From, To, CancellationToken.None,
+                pageSize: 1, cursor: cursor));
+        }
+
+        var validTail = JsonSerializer.Serialize(
+            new { CalendarHref = "calendar", EntityUid = "uid", RecurrenceIdentity = "identity" });
+        var validCursor = protector.Protect(context, "2026-08-15T12:00:00Z", validTail);
+        var result = await sut.QueryCoreAsync(
+            new CalendarEntityScopeArgument("all"), From, To, CancellationToken.None,
+            pageSize: 1, cursor: validCursor);
+        result.IsError.ShouldBe(false);
+    }
+
+    [Fact]
+    public async Task QueryAsync_CursorIsNonceRandomTamperEvidentBoundToQueryCredentialsExpiryAndProcessKey()
+    {
+        var service = Substitute.For<ICalendarService>();
+        service.QueryOccurrencesAsync(Arg.Any<CalendarOccurrenceQuery>(), Arg.Any<CancellationToken>())
+            .Returns(CalendarOccurrenceQueryResult.Success([
+                Occurrence("2026-08-15T12:00:00Z", "https://cal.example/a/", "a", "2026-08-15T10:00:00Z"),
+                Occurrence("2026-08-15T13:00:00Z", "https://cal.example/a/", "a", "2026-08-15T13:00:00Z")
+            ]));
+        var time = new MutableTimeProvider(Now);
+        var sut = CreateTool(service, time);
+        var first = await sut.QueryCoreAsync(new CalendarEntityScopeArgument("all"), From, To, CancellationToken.None, pageSize: 1);
+        var repeated = await sut.QueryCoreAsync(new CalendarEntityScopeArgument("all"), From, To, CancellationToken.None, pageSize: 1);
+        var cursor = GetCursor(first);
+        var otherCursor = GetCursor(repeated);
+
+        cursor.ShouldNotBe(otherCursor);
+        await AssertInvalidCursor(sut.QueryCoreAsync(
+            new CalendarEntityScopeArgument("all"), From, To, CancellationToken.None, pageSize: 2, cursor: cursor));
+        await AssertInvalidCursor(sut.QueryCoreAsync(
+            new CalendarEntityScopeArgument("selected", new CalendarEntityReferenceArgument("href", Href: "https://cal.example/a/")),
+            From,
+            To,
+            CancellationToken.None,
+            pageSize: 1,
+            cursor: cursor));
+        await AssertInvalidCursor(sut.QueryCoreAsync(
+            new CalendarEntityScopeArgument("all"),
+            new CalendarEntityUtcArgument("utcDateTime", "2026-08-15T12:00:01Z"),
+            To,
+            CancellationToken.None,
+            pageSize: 1,
+            cursor: cursor));
+        await AssertInvalidCursor(sut.QueryCoreAsync(
+            new CalendarEntityScopeArgument("all"),
+            From,
+            new CalendarEntityUtcArgument("utcDateTime", "2026-08-16T11:59:59Z"),
+            CancellationToken.None,
+            pageSize: 1,
+            cursor: cursor));
+        await AssertInvalidCursor(sut.QueryCoreAsync(
+            new CalendarEntityScopeArgument("all"), From, To, CancellationToken.None,
+            evaluationTimeZone: "UTC", pageSize: 1, cursor: cursor));
+        var tampered = cursor[..^1] + (cursor[^1] == 'A' ? 'B' : 'A');
+        await AssertInvalidCursor(sut.QueryCoreAsync(
+            new CalendarEntityScopeArgument("all"), From, To, CancellationToken.None, pageSize: 1, cursor: tampered));
+        var restarted = CreateTool(service, time);
+        await AssertInvalidCursor(restarted.QueryCoreAsync(
+            new CalendarEntityScopeArgument("all"), From, To, CancellationToken.None, pageSize: 1, cursor: cursor));
+        time.Advance(TimeSpan.FromMinutes(10));
+        await AssertInvalidCursor(sut.QueryCoreAsync(
+            new CalendarEntityScopeArgument("all"), From, To, CancellationToken.None, pageSize: 1, cursor: cursor));
+    }
+
+    [Fact]
+    public async Task QueryAsync_CursorCredentialBindingRejectsSameKeyUnderDifferentCredentials()
+    {
+        var service = Substitute.For<ICalendarService>();
+        service.QueryOccurrencesAsync(Arg.Any<CalendarOccurrenceQuery>(), Arg.Any<CancellationToken>())
+            .Returns(CalendarOccurrenceQueryResult.Success([
+                Occurrence("2026-08-15T12:00:00Z", "https://cal.example/a/", "a", "2026-08-15T10:00:00Z"),
+                Occurrence("2026-08-15T13:00:00Z", "https://cal.example/a/", "a", "2026-08-15T13:00:00Z")
+            ]));
+        var time = new MutableTimeProvider(Now);
+        var key = Enumerable.Range(0, 64).Select(index => (byte)index).ToArray();
+        var source = CreateTool(service, time, key, "password-a");
+        var first = await source.QueryCoreAsync(
+            new CalendarEntityScopeArgument("all"), From, To, CancellationToken.None, pageSize: 1);
+        var otherCredential = CreateTool(service, time, key, "password-b");
+
+        await AssertInvalidCursor(otherCredential.QueryCoreAsync(
+            new CalendarEntityScopeArgument("all"), From, To, CancellationToken.None,
+            pageSize: 1, cursor: GetCursor(first)));
+    }
+
+    [Fact]
+    public async Task QueryAsync_RejectsSingleOccurrenceThatCannotFitStructuredBudget()
+    {
+        var service = Substitute.For<ICalendarService>();
+        service.QueryOccurrencesAsync(Arg.Any<CalendarOccurrenceQuery>(), Arg.Any<CancellationToken>())
+            .Returns(CalendarOccurrenceQueryResult.Success([
+                Occurrence("2026-08-15T12:00:00Z", "https://cal.example/a/", "a", "2026-08-15T10:00:00Z", new byte[3_200_000])
+            ]));
+        var sut = CreateTool(service, new MutableTimeProvider(Now));
+
+        var result = await sut.QueryCoreAsync(new CalendarEntityScopeArgument("all"), From, To, CancellationToken.None);
+
+        result.IsError.ShouldBe(true);
+        result.StructuredContent!.Value.GetProperty("code").GetString().ShouldBe("payload_too_large");
+        result.StructuredContent.Value.TryGetProperty("items", out _).ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task QueryAsync_RejectsHumanAndDiagnosticContentBeyondShared64KiBBudget()
+    {
+        var service = Substitute.For<ICalendarService>();
+        service.QueryOccurrencesAsync(Arg.Any<CalendarOccurrenceQuery>(), Arg.Any<CancellationToken>())
+            .Returns(CalendarOccurrenceQueryResult.Success(
+                [],
+                [new CalendarResourceDiagnostic("large", new string('x', 70_000), CalendarResourceDiagnosticSeverity.Warning)]));
+        var sut = CreateTool(service, new MutableTimeProvider(Now));
+
+        var result = await sut.QueryCoreAsync(new CalendarEntityScopeArgument("all"), From, To, CancellationToken.None);
+
+        result.IsError.ShouldBe(true);
+        result.StructuredContent!.Value.GetProperty("code").GetString().ShouldBe("payload_too_large");
+        result.StructuredContent.Value.TryGetProperty("items", out _).ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task QueryAsync_FinalDeadlineReturnsLimitErrorWithoutSuccessItems()
+    {
+        var service = Substitute.For<ICalendarService>();
+        service.QueryOccurrencesAsync(Arg.Any<CalendarOccurrenceQuery>(), Arg.Any<CancellationToken>())
+            .Returns(CalendarOccurrenceQueryResult.Success([]));
+        var sut = CreateTool(service, new SequencedTimeProvider(Now, Now.AddSeconds(31)));
+
+        var result = await sut.QueryCoreAsync(new CalendarEntityScopeArgument("all"), From, To, CancellationToken.None);
+
+        result.IsError.ShouldBe(true);
+        result.StructuredContent!.Value.GetProperty("code").GetString().ShouldBe("limit_exhausted");
+        result.StructuredContent.Value.TryGetProperty("items", out _).ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task QueryAsync_CallerCancellationPropagatesWithoutReturningAResult()
+    {
+        var service = Substitute.For<ICalendarService>();
+        service.QueryOccurrencesAsync(Arg.Any<CalendarOccurrenceQuery>(), Arg.Any<CancellationToken>())
+            .Returns(call => WaitForCancellation(call.ArgAt<CancellationToken>(1)));
+        var sut = CreateTool(service, new MutableTimeProvider(Now));
+        using var cancellation = new CancellationTokenSource();
+
+        var pending = sut.QueryCoreAsync(new CalendarEntityScopeArgument("all"), From, To, cancellation.Token);
+        cancellation.Cancel();
+
+        await Should.ThrowAsync<OperationCanceledException>(() => pending);
+    }
+
+    private static CalendarOccurrenceTools CreateTool(ICalendarService service, TimeProvider timeProvider) => new(
+        service,
+        CreateProtector(timeProvider),
+        timeProvider);
+
+    private static CalendarEntityCursorProtector CreateProtector(TimeProvider timeProvider) => new(
+        timeProvider,
+        Options.Create(new CalDavOptions
+        {
+            BaseUrl = "https://cal.example",
+            Username = "user",
+            Password = "password"
+        }));
+
+    private static CalendarOccurrenceTools CreateTool(
+        ICalendarService service,
+        TimeProvider timeProvider,
+        byte[] key,
+        string password) => new(
+            service,
+            new CalendarEntityCursorProtector(
+                timeProvider,
+                Options.Create(new CalDavOptions
+                {
+                    BaseUrl = "https://cal.example",
+                    Username = "user",
+                    Password = password
+                }),
+                key),
+            timeProvider);
+
+    private static CalendarOccurrenceSnapshot Occurrence(
+        string effectiveStart,
+        string calendarHref,
+        string uid,
+        string identity,
+        byte[]? bytes = null)
+    {
+        bytes ??= Encoding.UTF8.GetBytes("BEGIN:VCALENDAR\r\nEND:VCALENDAR\r\n");
+        var temporalIdentity = new CalendarTemporalValue(CalendarTemporalKind.UtcDateTime, identity);
+        var effective = new CalendarTemporalValue(CalendarTemporalKind.UtcDateTime, effectiveStart);
+        return new CalendarOccurrenceSnapshot(
+            new CalendarResourceSnapshot(
+                calendarHref,
+                $"{calendarHref}{uid}.ics",
+                "\"r1\"",
+                bytes,
+                [],
+                new CalendarResourceProjection(CalendarResourceProjectionKind.Event, uid, "summary"),
+                []),
+            temporalIdentity,
+            new CalendarOccurrenceTiming(temporalIdentity, effective, EvaluatedStartUtc: effective));
+    }
+
+    private static string GetCursor(ModelContextProtocol.Protocol.CallToolResult result) =>
+        result.StructuredContent!.Value.GetProperty("pagination").GetProperty("nextCursor").GetString()!;
+
+    private static async Task AssertInvalidCursor(Task<ModelContextProtocol.Protocol.CallToolResult> pending)
+    {
+        var result = await pending;
+        result.IsError.ShouldBe(true);
+        result.StructuredContent!.Value.GetProperty("code").GetString().ShouldBe("invalid_input");
+    }
+
+    private static async Task<CalendarOccurrenceQueryResult> WaitForCancellation(CancellationToken cancellationToken)
+    {
+        var pending = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        await pending.Task.WaitAsync(cancellationToken);
+        return CalendarOccurrenceQueryResult.Success([]);
+    }
+
+    private static Dictionary<string, JsonElement> ArgumentsWithSerializedSize(int targetBytes)
+    {
+        var arguments = new Dictionary<string, JsonElement>
+        {
+            ["scope"] = JsonSerializer.SerializeToElement(
+                new { mode = "selected", calendar = new { by = "name", name = string.Empty } }),
+            ["from"] = JsonSerializer.SerializeToElement(new { kind = "utcDateTime", value = From.Value }),
+            ["to"] = JsonSerializer.SerializeToElement(new { kind = "utcDateTime", value = To.Value })
+        };
+        var overhead = JsonSerializer.SerializeToUtf8Bytes(arguments).Length;
+        arguments["scope"] = JsonSerializer.SerializeToElement(
+            new { mode = "selected", calendar = new { by = "name", name = new string('x', targetBytes - overhead) } });
+        return arguments;
+    }
+
+    private sealed class MutableTimeProvider(DateTimeOffset utcNow) : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow() => utcNow;
+        public void Advance(TimeSpan amount) => utcNow += amount;
+    }
+
+    private sealed class SequencedTimeProvider(params DateTimeOffset[] values) : TimeProvider
+    {
+        private int _index;
+
+        public override DateTimeOffset GetUtcNow()
+        {
+            var index = Math.Min(_index, values.Length - 1);
+            _index++;
+            return values[index];
+        }
+    }
+}

--- a/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/StrictToolInputGuardTests.cs
+++ b/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/StrictToolInputGuardTests.cs
@@ -39,6 +39,11 @@ public sealed class StrictToolInputGuardTests
     [InlineData("calendar_entities.query", 262_145, false, "payload_too_large")]
     [InlineData("calendar_entities.query", 262_145, true, "payload_too_large")]
     [InlineData("calendar_entities.query", 1, true, "invalid_input")]
+    [InlineData("calendar_occurrences.query", null, false, null)]
+    [InlineData("calendar_occurrences.query", 262_144, false, null)]
+    [InlineData("calendar_occurrences.query", 262_145, false, "payload_too_large")]
+    [InlineData("calendar_occurrences.query", 262_145, true, "payload_too_large")]
+    [InlineData("calendar_occurrences.query", 1, true, "invalid_input")]
     public void Reject_AppliesQuerySpecificAdmissionBeforeDuplicateValidation(
         string toolName,
         int? argumentBytes,


### PR DESCRIPTION
## Summary

- add bounded local occurrence expansion for Events and To-dos with faithful RRULE, RDATE, EXDATE, override, RANGE, moved, and cancelled semantics
- preserve original recurrence identity and temporal families while resolving IANA and resource-local VTIMEZONE values with typed zero-partial failures
- expose the frozen `calendar_occurrences.query` MCP contract with deterministic ordering, signed cursors, admission limits, deadlines, and strict raw-input handling
- add semantic, MCP stdio, and pinned Radicale conformance evidence plus permanent compatibility and requirement catalog updates

## Validation

- Release build: 0 warnings, 0 errors
- Core unit tests: 528 passed
- MCP unit tests: 347 passed
- Raw stdio/auth focused tests: 7 passed
- Catalog/metadata/host focused tests: 29 passed
- Coverage: 94.3% lines, 85.7% branches
- Slopwatch: 0 issues

## Local integration limitation

Docker-backed Radicale could not complete locally: the normal Testcontainers path timed out waiting for Resource Reaper, and the Ryuk-disabled HTTP fixture timed out during MKCOL. Containers were removed after the attempts. The CI Radicale matrix provides baseline, strict-preconditions, and alternate-time-zone validation.

Closes #40