### PR TITLE
Delete Calendar Object Resources through MRTR

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ dotnet tool run slopwatch analyze --config .slopwatch/slopwatch.json --fail-on w
 
 - Runtime is transitional: unified Calendar tools use `ICalendarService`, while legacy task tools retain `ITaskService` until the 0.2 cleanup. Both services stay thin; WebDAV request/response logic belongs under `Core/Internal/Xml`, and iCalendar mapping belongs under `Core/Internal/Ical`.
 - `Program.cs` maps `CALDAV_*` environment variables, then delegates startup to `CalDavMcpRunner` and `CalDavHostBuilder`; keep startup testable through those types rather than adding logic to top-level statements.
-- The default host exposes `calendars.list`, `calendar_entities.query`, `calendar_occurrences.query`, `calendar_resources.get`, `events.create`, `todos.create`, and the staged legacy chat-safe tools. `CALDAV_EXPOSE_EXACT_TOOLS=true` enables exact Calendar resource access; the legacy `CALDAV_EXPOSE_ADVANCED_TOOLS=true` gate remains until its tools are removed.
+- The default host exposes `calendars.list`, `calendar_entities.query`, `calendar_occurrences.query`, `calendar_resources.get`, `events.create`, `todos.create`, `calendar_resources.delete`, and the staged legacy chat-safe tools. `CALDAV_EXPOSE_EXACT_TOOLS=true` enables exact Calendar resource access; the legacy `CALDAV_EXPOSE_ADVANCED_TOOLS=true` gate remains until its tools are removed.
 - `.opencode/opencode.jsonc` launches the published NuGet tool through `dnx`; it does not run the current checkout. Do not treat that configuration as source-level end-to-end validation.
 
 ## Invariants
@@ -43,7 +43,7 @@ dotnet tool run slopwatch analyze --config .slopwatch/slopwatch.json --fail-on w
 - Keep console providers disabled. Stdout is the JSON-RPC transport, and integration tests require a valid server run to leave both stdout and stderr clean; only startup validation failures write human-readable stderr.
 - `TaskItem` and `TaskList` are immutable records. Modify them with `with`, preserve fetched ETags on updates/deletes, and use injected `TimeProvider` for completion timestamps.
 - Chat tools resolve explicit display names first, then `CALDAV_DEFAULT_TASK_LIST`; they never infer a list from task content. Summary-based mutations must return `not_found` or `ambiguous` unless exactly one task matches.
-- Href-based tools are the advanced/raw surface. Keep their descriptions requiring an explicitly provided or confirmed absolute href; normal chat flows use list-name tools.
+- Legacy and exact href tools are the advanced/raw surface. Keep their descriptions requiring an explicitly provided or confirmed absolute href; semantic revision-bound mutations follow the frozen catalog, require an explicitly supplied revision href, and protect writes with MRTR confirmation. Normal chat flows use list-name tools.
 - Package versions are centralized in `Directory.Packages.props`; project files keep versionless `PackageReference` entries.
 - For Ical.Net, `.ics`, VTODO, or recurrence changes, load the repo-local `ical-net` skill before editing.
 

--- a/README.md
+++ b/README.md
@@ -56,12 +56,16 @@ Add this MCP server to VS Code, Claude Desktop, Cursor, or any MCP client:
 
 ### Calendar resource tools
 
+- `calendars.list` — Discover the configured Calendar Scope.
 - `calendar_resources.get` — Read an authoritative semantic-or-opaque snapshot by confirmed absolute href.
 - `calendar_entities.query` — Query bounded persisted Event and To-do snapshots across default, selected, or explicit-all Calendar Scope.
 - `calendar_occurrences.query` — Expand Event and To-do occurrences locally within a required half-open UTC window, using an explicit IANA evaluation time zone only when floating or date-only values require it.
+- `events.create` — Create one Event in a selected Calendar.
+- `todos.create` — Create one To-do in a selected Calendar.
+- `calendar_resources.delete` — Delete an entire resource from an explicitly supplied revision reference (href, UID, kind, and exact strong ETag) after MCP MRTR review and confirmation; success requires verified absence.
 - `calendar_resources.exact_get` — Opt-in exact read through a protected MCP resource link; enable with `CALDAV_EXPOSE_EXACT_TOOLS=true`.
 
-By default, the server exposes `calendars.list`, `calendar_resources.get`, `calendar_entities.query`, and `calendar_occurrences.query` alongside the legacy chat-safe tools retained during the staged migration. Set `CALDAV_EXPOSE_ADVANCED_TOOLS=true` to also expose the legacy href-based advanced tools.
+The staged default catalog is `calendars.list`, `calendar_entities.query`, `calendar_occurrences.query`, `calendar_resources.get`, `events.create`, `todos.create`, `calendar_resources.delete`, `list_task_lists`, `show_tasks`, `add_task`, `find_tasks`, `complete_task_by_summary`, and `delete_task_by_summary`. Set `CALDAV_EXPOSE_ADVANCED_TOOLS=true` to also expose the legacy href-based advanced tools.
 
 ## Supported servers
 

--- a/src/DotnetAgents.CalDav.Core/Abstractions/ICalendarClient.cs
+++ b/src/DotnetAgents.CalDav.Core/Abstractions/ICalendarClient.cs
@@ -23,4 +23,9 @@ public interface ICalendarClient
     Task<CalendarResourceCreateResult> CreateCalendarResourceAsync(
         CalendarResourceCreateRequest request,
         CancellationToken cancellationToken);
+
+    /// <summary>Conditionally deletes one complete Calendar Object Resource without retrying.</summary>
+    Task<CalendarResourceDeleteDispatchResult> DeleteCalendarResourceAsync(
+        CalendarResourceDeleteRequest request,
+        CancellationToken cancellationToken);
 }

--- a/src/DotnetAgents.CalDav.Core/Abstractions/ICalendarService.cs
+++ b/src/DotnetAgents.CalDav.Core/Abstractions/ICalendarService.cs
@@ -35,4 +35,9 @@ public interface ICalendarService
     Task<CalendarEntityCreateResult> CreateTodoAsync(
         CalendarTodoCreateRequest request,
         CancellationToken cancellationToken);
+
+    /// <summary>Deletes one reviewed resource and succeeds only after verified absence.</summary>
+    Task<CalendarResourceDeleteResult> DeleteResourceAsync(
+        CalendarResourceRevisionReference revision,
+        CancellationToken cancellationToken);
 }

--- a/src/DotnetAgents.CalDav.Core/Internal/CalDavClient.cs
+++ b/src/DotnetAgents.CalDav.Core/Internal/CalDavClient.cs
@@ -201,6 +201,13 @@ internal sealed class CalDavClient : ICalDavClient, ICalendarClient
             _httpClient,
             new Uri(_options.Value.BaseUrl, UriKind.Absolute)).CreateAsync(request, cancellationToken);
 
+    /// <inheritdoc />
+    public async Task<CalendarResourceDeleteDispatchResult> DeleteCalendarResourceAsync(
+        CalendarResourceDeleteRequest request,
+        CancellationToken cancellationToken) => await new CalendarResourceDeleteProtocol(
+            _httpClient,
+            new Uri(_options.Value.BaseUrl, UriKind.Absolute)).DeleteAsync(request, cancellationToken);
+
     private async Task<HttpResponseMessage> SendGetWithRedirectHandlingAsync(
         Uri initialUri,
         CancellationToken cancellationToken,

--- a/src/DotnetAgents.CalDav.Core/Internal/Xml/CalendarResourceDeleteProtocol.cs
+++ b/src/DotnetAgents.CalDav.Core/Internal/Xml/CalendarResourceDeleteProtocol.cs
@@ -1,0 +1,159 @@
+using System.Net;
+using System.Net.Http.Headers;
+using DotnetAgents.CalDav.Core.Models;
+
+namespace DotnetAgents.CalDav.Core.Internal.Xml;
+
+internal sealed class CalendarResourceDeleteProtocol(
+    HttpClient httpClient,
+    Uri configuredBaseUri,
+    TimeProvider? timeProvider = null)
+{
+    private const int MaximumRedirects = 3;
+
+    public async Task<CalendarResourceDeleteDispatchResult> DeleteAsync(
+        CalendarResourceDeleteRequest request,
+        CancellationToken cancellationToken)
+    {
+        if (!TryValidateRequest(request, out var resourceUri, out var entityTag))
+            return new CalendarResourceDeleteDispatchResult(CalendarResourceDeleteDispatchCode.InvalidInput);
+        cancellationToken.ThrowIfCancellationRequested();
+        try
+        {
+            return await SendAsync(resourceUri, entityTag, cancellationToken);
+        }
+        catch (Exception exception) when (exception is HttpRequestException
+            or IOException
+            or TimeoutException
+            or OperationCanceledException)
+        {
+            return new CalendarResourceDeleteDispatchResult(CalendarResourceDeleteDispatchCode.PossiblyDispatched);
+        }
+    }
+
+    private async Task<CalendarResourceDeleteDispatchResult> SendAsync(
+        Uri initialResourceUri,
+        EntityTagHeaderValue entityTag,
+        CancellationToken cancellationToken)
+    {
+        var currentUri = initialResourceUri;
+        for (var redirectCount = 0; ; redirectCount++)
+        {
+            using var message = new HttpRequestMessage(HttpMethod.Delete, currentUri);
+            message.Headers.IfMatch.Add(entityTag);
+            using var response = await httpClient.SendAsync(
+                message,
+                HttpCompletionOption.ResponseHeadersRead,
+                cancellationToken);
+            if (!IsMethodPreservingRedirect(response.StatusCode))
+                return MapResponse(response);
+            if (redirectCount >= MaximumRedirects
+                || !TryResolveRedirect(currentUri, response.Headers.Location, out var redirectUri))
+            {
+                return new CalendarResourceDeleteDispatchResult(
+                    CalendarResourceDeleteDispatchCode.UpstreamProtocolError);
+            }
+            currentUri = redirectUri;
+        }
+    }
+
+    private bool TryValidateRequest(
+        CalendarResourceDeleteRequest request,
+        out Uri resourceUri,
+        out EntityTagHeaderValue entityTag)
+    {
+        resourceUri = null!;
+        entityTag = null!;
+        if (!TryValidateAbsoluteUri(request.ResourceHref, out resourceUri)
+            || !HasSameOrigin(configuredBaseUri, resourceUri)
+            || !EntityTagHeaderValue.TryParse(request.EntityTag, out var parsedEntityTag)
+            || parsedEntityTag is null
+            || parsedEntityTag.IsWeak
+            || parsedEntityTag == EntityTagHeaderValue.Any
+            || !string.Equals(parsedEntityTag.ToString(), request.EntityTag, StringComparison.Ordinal))
+        {
+            return false;
+        }
+        entityTag = parsedEntityTag;
+        return true;
+    }
+
+    private bool TryResolveRedirect(Uri currentUri, Uri? location, out Uri redirectUri)
+    {
+        redirectUri = null!;
+        if (location is null
+            || location.OriginalString.Contains("%2e", StringComparison.OrdinalIgnoreCase)
+            || location.OriginalString.Contains("%2F", StringComparison.OrdinalIgnoreCase)
+            || location.OriginalString.Contains("%5C", StringComparison.OrdinalIgnoreCase)
+            || !Uri.TryCreate(currentUri, location, out var candidate)
+            || !IsSafeCanonicalUri(candidate, candidate.AbsoluteUri)
+            || !HasSameOrigin(configuredBaseUri, candidate))
+        {
+            return false;
+        }
+        redirectUri = candidate;
+        return true;
+    }
+
+    private static bool TryValidateAbsoluteUri(string href, out Uri uri)
+    {
+        uri = null!;
+        if (!Uri.TryCreate(href, UriKind.Absolute, out var candidate)
+            || !IsSafeCanonicalUri(candidate, href))
+        {
+            return false;
+        }
+        uri = candidate;
+        return true;
+    }
+
+    private static bool IsSafeCanonicalUri(Uri candidate, string original) =>
+        (candidate.Scheme.Equals(Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase)
+            || candidate.Scheme.Equals(Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
+        && string.IsNullOrEmpty(candidate.UserInfo)
+        && string.IsNullOrEmpty(candidate.Fragment)
+        && string.IsNullOrEmpty(candidate.Query)
+        && !candidate.AbsolutePath.Contains("%2F", StringComparison.OrdinalIgnoreCase)
+        && !candidate.AbsolutePath.Contains("%5C", StringComparison.OrdinalIgnoreCase)
+        && !original.Contains("%2e", StringComparison.OrdinalIgnoreCase)
+        && string.Equals(candidate.AbsoluteUri, original, StringComparison.Ordinal);
+
+    private static bool HasSameOrigin(Uri left, Uri right) =>
+        string.Equals(left.Scheme, right.Scheme, StringComparison.OrdinalIgnoreCase)
+        && string.Equals(left.Host, right.Host, StringComparison.OrdinalIgnoreCase)
+        && left.Port == right.Port;
+
+    private static bool IsMethodPreservingRedirect(HttpStatusCode statusCode) => statusCode is
+        HttpStatusCode.TemporaryRedirect or HttpStatusCode.PermanentRedirect;
+
+    private CalendarResourceDeleteDispatchResult MapResponse(HttpResponseMessage response) => response.StatusCode switch
+    {
+        >= HttpStatusCode.OK and < HttpStatusCode.MultipleChoices =>
+            new(CalendarResourceDeleteDispatchCode.Dispatched),
+        HttpStatusCode.NotFound => new(CalendarResourceDeleteDispatchCode.NotFound),
+        HttpStatusCode.Conflict or HttpStatusCode.PreconditionFailed =>
+            new(CalendarResourceDeleteDispatchCode.Conflict),
+        HttpStatusCode.Unauthorized => new(CalendarResourceDeleteDispatchCode.UpstreamUnauthorized),
+        HttpStatusCode.Forbidden => new(CalendarResourceDeleteDispatchCode.UpstreamForbidden),
+        HttpStatusCode.RequestEntityTooLarge => new(CalendarResourceDeleteDispatchCode.PayloadTooLarge),
+        HttpStatusCode.TooManyRequests => new(
+            CalendarResourceDeleteDispatchCode.UpstreamRateLimited,
+            ReadRetryAfterMilliseconds(response.Headers.RetryAfter)),
+        HttpStatusCode.MethodNotAllowed or HttpStatusCode.NotImplemented =>
+            new(CalendarResourceDeleteDispatchCode.UnsupportedCapability),
+        HttpStatusCode.InsufficientStorage => new(CalendarResourceDeleteDispatchCode.UpstreamUnavailable),
+        HttpStatusCode.RequestTimeout or >= HttpStatusCode.InternalServerError =>
+            new(CalendarResourceDeleteDispatchCode.PossiblyDispatched),
+        _ => new(CalendarResourceDeleteDispatchCode.UpstreamProtocolError)
+    };
+
+    private int? ReadRetryAfterMilliseconds(RetryConditionHeaderValue? retryAfter)
+    {
+        if (retryAfter is null)
+            return null;
+        var delay = retryAfter.Delta ?? retryAfter.Date - (timeProvider ?? TimeProvider.System).GetUtcNow();
+        if (delay is null)
+            return null;
+        return (int)Math.Clamp(Math.Ceiling(delay.Value.TotalMilliseconds), 0, int.MaxValue);
+    }
+}

--- a/src/DotnetAgents.CalDav.Core/Models/CalendarResourceDelete.cs
+++ b/src/DotnetAgents.CalDav.Core/Models/CalendarResourceDelete.cs
@@ -1,0 +1,75 @@
+namespace DotnetAgents.CalDav.Core.Models;
+
+/// <summary>Self-contained identity and strong revision required to delete one resource.</summary>
+public sealed record CalendarResourceRevisionReference(
+    string Href,
+    string EntityUid,
+    CalendarEntityKind EntityKind,
+    string EntityTag);
+
+/// <summary>Successful proof that one reviewed Calendar Object Resource is absent.</summary>
+public sealed record CalendarResourceDeletionReceipt(
+    string Href,
+    string EntityUid,
+    CalendarEntityKind EntityKind,
+    string ConsumedEntityTag);
+
+/// <summary>Closed deletion outcomes at the Calendar Service boundary.</summary>
+public enum CalendarResourceDeleteCode
+{
+    Success,
+    InvalidInput,
+    NotFound,
+    OutsideScope,
+    EntityKindMismatch,
+    OpaqueResource,
+    Conflict,
+    ConcurrencyUnavailable,
+    UnsupportedCapability,
+    PayloadTooLarge,
+    UpstreamUnauthorized,
+    UpstreamForbidden,
+    UpstreamRateLimited,
+    UpstreamUnavailable,
+    UpstreamProtocolError,
+    CommittedButUnverified,
+    Indeterminate
+}
+
+/// <summary>Truthful deletion result, including current authorized state when available.</summary>
+public sealed record CalendarResourceDeleteResult(
+    CalendarResourceDeleteCode Code,
+    CalendarMutationState MutationState,
+    CalendarResourceDeletionReceipt? DeletionReceipt = null,
+    CalendarResourceSnapshot? CurrentSnapshot = null,
+    int? RetryAfterMilliseconds = null,
+    bool Retryable = false)
+{
+    public static CalendarResourceDeleteResult Success(CalendarResourceDeletionReceipt receipt) =>
+        new(CalendarResourceDeleteCode.Success, CalendarMutationState.Committed, receipt);
+}
+
+/// <summary>One exact conditional DELETE request at the CalDAV transport boundary.</summary>
+public sealed record CalendarResourceDeleteRequest(string ResourceHref, string EntityTag);
+
+/// <summary>Observable outcome of the one permitted conditional DELETE dispatch.</summary>
+public enum CalendarResourceDeleteDispatchCode
+{
+    Dispatched,
+    PossiblyDispatched,
+    NotFound,
+    Conflict,
+    InvalidInput,
+    UnsupportedCapability,
+    PayloadTooLarge,
+    UpstreamUnauthorized,
+    UpstreamForbidden,
+    UpstreamRateLimited,
+    UpstreamUnavailable,
+    UpstreamProtocolError
+}
+
+/// <summary>Low-level result that preserves whether DELETE may have reached CalDAV.</summary>
+public sealed record CalendarResourceDeleteDispatchResult(
+    CalendarResourceDeleteDispatchCode Code,
+    int? RetryAfterMilliseconds = null);

--- a/src/DotnetAgents.CalDav.Core/Services/CalendarResourceDeleteEngine.cs
+++ b/src/DotnetAgents.CalDav.Core/Services/CalendarResourceDeleteEngine.cs
@@ -1,0 +1,269 @@
+using DotnetAgents.CalDav.Core.Abstractions;
+using DotnetAgents.CalDav.Core.Models;
+using System.Net.Http.Headers;
+
+namespace DotnetAgents.CalDav.Core.Services;
+
+internal sealed class CalendarResourceDeleteEngine(
+    ICalendarClient calendarClient,
+    Func<string, CancellationToken, Task<CalendarResourceRead>> readResource,
+    TimeProvider timeProvider)
+{
+    private static readonly TimeSpan ReconciliationTimeout = TimeSpan.FromSeconds(30);
+
+    public async Task<CalendarResourceDeleteResult> DeleteAsync(
+        CalendarResourceRevisionReference revision,
+        CancellationToken cancellationToken)
+    {
+        var revisionFailure = ValidateRevisionReference(revision);
+        if (revisionFailure is not null)
+            return Failure(revisionFailure.Value);
+
+        var preflight = await ReadBeforeDispatchAsync(revision.Href, cancellationToken);
+        if (preflight.Failure is not null)
+            return preflight.Failure;
+        var current = preflight.Read!;
+        if (current.Code != CalendarResourceReadCode.Success || current.Snapshot is null)
+            return FromReadFailure(current.Code);
+
+        var validation = ValidateRevision(revision, current.Snapshot);
+        if (validation is not null)
+            return validation;
+
+        var dispatch = await calendarClient.DeleteCalendarResourceAsync(
+            new CalendarResourceDeleteRequest(revision.Href, revision.EntityTag),
+            cancellationToken);
+        if (dispatch.Code == CalendarResourceDeleteDispatchCode.PossiblyDispatched)
+            return await ReconcileAsync(revision);
+        if (dispatch.Code == CalendarResourceDeleteDispatchCode.Conflict)
+            return await RefreshConflictAsync(revision.Href, cancellationToken);
+        if (dispatch.Code != CalendarResourceDeleteDispatchCode.Dispatched)
+            return FromDispatchFailure(dispatch);
+
+        return await VerifyDispatchedAsync(revision);
+    }
+
+    private async Task<(CalendarResourceRead? Read, CalendarResourceDeleteResult? Failure)> ReadBeforeDispatchAsync(
+        string href,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            return (await readResource(href, cancellationToken), null);
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            return (null, Failure(CalendarResourceDeleteCode.UpstreamUnavailable, retryable: true));
+        }
+        catch (HttpRequestException exception)
+        {
+            return (null, FromPreflightHttpFailure(exception.StatusCode));
+        }
+        catch (Exception exception) when (exception is IOException or TimeoutException)
+        {
+            return (null, Failure(CalendarResourceDeleteCode.UpstreamUnavailable, retryable: true));
+        }
+        catch (Exception exception) when (exception is System.Xml.XmlException or CalendarDiscoveryProtocolException)
+        {
+            return (null, Failure(CalendarResourceDeleteCode.UpstreamProtocolError));
+        }
+        catch (CalendarDiscoveryUnsupportedCapabilityException)
+        {
+            return (null, Failure(CalendarResourceDeleteCode.UnsupportedCapability));
+        }
+    }
+
+    private async Task<CalendarResourceDeleteResult> VerifyDispatchedAsync(
+        CalendarResourceRevisionReference revision)
+    {
+        using var verification = new CancellationTokenSource(ReconciliationTimeout, timeProvider);
+        try
+        {
+            var observed = await readResource(revision.Href, verification.Token);
+            return observed.Code == CalendarResourceReadCode.NotFound
+                ? Success(revision)
+                : CommittedButUnverified(observed.Snapshot);
+        }
+        catch (Exception)
+        {
+            return CommittedButUnverified();
+        }
+    }
+
+    private async Task<CalendarResourceDeleteResult> ReconcileAsync(CalendarResourceRevisionReference revision)
+    {
+        using var reconciliation = new CancellationTokenSource(ReconciliationTimeout, timeProvider);
+        CalendarResourceRead observed;
+        try
+        {
+            observed = await readResource(revision.Href, reconciliation.Token);
+        }
+        catch (Exception)
+        {
+            return Unknown();
+        }
+
+        if (observed.Code == CalendarResourceReadCode.NotFound)
+            return Success(revision);
+        if (observed.Code != CalendarResourceReadCode.Success || observed.Snapshot is null)
+            return Unknown();
+        if (IsSameRevision(revision, observed.Snapshot))
+        {
+            return new CalendarResourceDeleteResult(
+                CalendarResourceDeleteCode.UpstreamUnavailable,
+                CalendarMutationState.NotCommitted,
+                CurrentSnapshot: observed.Snapshot);
+        }
+        return Unknown(observed.Snapshot);
+    }
+
+    private async Task<CalendarResourceDeleteResult> RefreshConflictAsync(
+        string href,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var observed = await readResource(href, cancellationToken);
+            return Rejected(
+                CalendarResourceDeleteCode.Conflict,
+                observed.Code == CalendarResourceReadCode.Success ? observed.Snapshot : null);
+        }
+        catch (Exception)
+        {
+            return Rejected(CalendarResourceDeleteCode.Conflict);
+        }
+    }
+
+    private static bool IsSameRevision(
+        CalendarResourceRevisionReference revision,
+        CalendarResourceSnapshot snapshot) =>
+        string.Equals(snapshot.ResourceHref, revision.Href, StringComparison.Ordinal)
+        && string.Equals(snapshot.Projection.EntityUid, revision.EntityUid, StringComparison.Ordinal)
+        && string.Equals(snapshot.EntityTag, revision.EntityTag, StringComparison.Ordinal)
+        && snapshot.Projection.Kind == (revision.EntityKind == CalendarEntityKind.Event
+            ? CalendarResourceProjectionKind.Event
+            : CalendarResourceProjectionKind.Todo);
+
+    private static CalendarResourceDeleteResult Unknown(CalendarResourceSnapshot? snapshot = null) => new(
+        CalendarResourceDeleteCode.Indeterminate,
+        CalendarMutationState.Unknown,
+        CurrentSnapshot: snapshot);
+
+    private static CalendarResourceDeleteResult Success(CalendarResourceRevisionReference revision) =>
+        CalendarResourceDeleteResult.Success(new CalendarResourceDeletionReceipt(
+            revision.Href,
+            revision.EntityUid,
+            revision.EntityKind,
+            revision.EntityTag));
+
+    private static CalendarResourceDeleteResult CommittedButUnverified(
+        CalendarResourceSnapshot? snapshot = null) => new(
+        CalendarResourceDeleteCode.CommittedButUnverified,
+        CalendarMutationState.Committed,
+        CurrentSnapshot: snapshot);
+
+    private static CalendarResourceDeleteCode? ValidateRevisionReference(
+        CalendarResourceRevisionReference revision)
+    {
+        if (string.IsNullOrEmpty(revision.EntityUid)
+            || !Enum.IsDefined(revision.EntityKind)
+            || !EntityTagHeaderValue.TryParse(revision.EntityTag, out var entityTag)
+            || entityTag is null
+            || entityTag == EntityTagHeaderValue.Any
+            || !string.Equals(entityTag.ToString(), revision.EntityTag, StringComparison.Ordinal))
+        {
+            return CalendarResourceDeleteCode.InvalidInput;
+        }
+        return entityTag.IsWeak ? CalendarResourceDeleteCode.ConcurrencyUnavailable : null;
+    }
+
+    private static CalendarResourceDeleteResult? ValidateRevision(
+        CalendarResourceRevisionReference revision,
+        CalendarResourceSnapshot snapshot)
+    {
+        if (!snapshot.SemanticMutationAvailable)
+            return Failure(CalendarResourceDeleteCode.OpaqueResource, snapshot);
+        var kind = snapshot.Projection.Kind == CalendarResourceProjectionKind.Event
+            ? CalendarEntityKind.Event
+            : CalendarEntityKind.Todo;
+        if (kind != revision.EntityKind)
+            return Failure(CalendarResourceDeleteCode.EntityKindMismatch, snapshot);
+        if (!string.Equals(snapshot.Projection.EntityUid, revision.EntityUid, StringComparison.Ordinal)
+            || !string.Equals(snapshot.EntityTag, revision.EntityTag, StringComparison.Ordinal))
+        {
+            return Failure(CalendarResourceDeleteCode.Conflict, snapshot);
+        }
+        return null;
+    }
+
+    private static CalendarResourceDeleteResult FromReadFailure(CalendarResourceReadCode code) => code switch
+    {
+        CalendarResourceReadCode.InvalidInput => Failure(CalendarResourceDeleteCode.InvalidInput),
+        CalendarResourceReadCode.NotFound => Failure(CalendarResourceDeleteCode.NotFound),
+        CalendarResourceReadCode.OutsideScope => Failure(CalendarResourceDeleteCode.OutsideScope),
+        CalendarResourceReadCode.ConcurrencyUnavailable => Failure(CalendarResourceDeleteCode.ConcurrencyUnavailable),
+        CalendarResourceReadCode.PayloadTooLarge => Failure(CalendarResourceDeleteCode.PayloadTooLarge),
+        _ => Failure(CalendarResourceDeleteCode.UpstreamProtocolError)
+    };
+
+    private static CalendarResourceDeleteResult FromPreflightHttpFailure(System.Net.HttpStatusCode? statusCode) => statusCode switch
+    {
+        System.Net.HttpStatusCode.Unauthorized => Failure(CalendarResourceDeleteCode.UpstreamUnauthorized),
+        System.Net.HttpStatusCode.Forbidden => Failure(CalendarResourceDeleteCode.UpstreamForbidden),
+        System.Net.HttpStatusCode.NotFound => Failure(CalendarResourceDeleteCode.UpstreamProtocolError),
+        System.Net.HttpStatusCode.Conflict or System.Net.HttpStatusCode.PreconditionFailed =>
+            Failure(CalendarResourceDeleteCode.Conflict),
+        System.Net.HttpStatusCode.RequestEntityTooLarge => Failure(CalendarResourceDeleteCode.PayloadTooLarge),
+        System.Net.HttpStatusCode.TooManyRequests => Failure(
+            CalendarResourceDeleteCode.UpstreamRateLimited,
+            retryable: true),
+        System.Net.HttpStatusCode.MethodNotAllowed or System.Net.HttpStatusCode.NotImplemented =>
+            Failure(CalendarResourceDeleteCode.UnsupportedCapability),
+        System.Net.HttpStatusCode.InsufficientStorage => Failure(
+            CalendarResourceDeleteCode.UpstreamUnavailable,
+            retryable: false),
+        >= System.Net.HttpStatusCode.InternalServerError => Failure(
+            CalendarResourceDeleteCode.UpstreamUnavailable,
+            retryable: true),
+        _ => Failure(CalendarResourceDeleteCode.UpstreamUnavailable, retryable: true)
+    };
+
+    private static CalendarResourceDeleteResult FromDispatchFailure(
+        CalendarResourceDeleteDispatchResult dispatch) => dispatch.Code switch
+    {
+        CalendarResourceDeleteDispatchCode.NotFound => Rejected(CalendarResourceDeleteCode.NotFound),
+        CalendarResourceDeleteDispatchCode.InvalidInput => Rejected(CalendarResourceDeleteCode.InvalidInput),
+        CalendarResourceDeleteDispatchCode.UnsupportedCapability => Rejected(CalendarResourceDeleteCode.UnsupportedCapability),
+        CalendarResourceDeleteDispatchCode.PayloadTooLarge => Rejected(CalendarResourceDeleteCode.PayloadTooLarge),
+        CalendarResourceDeleteDispatchCode.UpstreamUnauthorized => Rejected(CalendarResourceDeleteCode.UpstreamUnauthorized),
+        CalendarResourceDeleteDispatchCode.UpstreamForbidden => Rejected(CalendarResourceDeleteCode.UpstreamForbidden),
+        CalendarResourceDeleteDispatchCode.UpstreamRateLimited => Rejected(
+            CalendarResourceDeleteCode.UpstreamRateLimited,
+            retryAfterMilliseconds: dispatch.RetryAfterMilliseconds,
+            retryable: true),
+        CalendarResourceDeleteDispatchCode.UpstreamProtocolError => Rejected(CalendarResourceDeleteCode.UpstreamProtocolError),
+        _ => Rejected(CalendarResourceDeleteCode.UpstreamUnavailable)
+    };
+
+    private static CalendarResourceDeleteResult Rejected(
+        CalendarResourceDeleteCode code,
+        CalendarResourceSnapshot? currentSnapshot = null,
+        int? retryAfterMilliseconds = null,
+        bool retryable = false) =>
+        new(
+            code,
+            CalendarMutationState.NotCommitted,
+            CurrentSnapshot: currentSnapshot,
+            RetryAfterMilliseconds: retryAfterMilliseconds,
+            Retryable: retryable);
+
+    private static CalendarResourceDeleteResult Failure(
+        CalendarResourceDeleteCode code,
+        CalendarResourceSnapshot? currentSnapshot = null,
+        bool retryable = false) =>
+        new(
+            code,
+            CalendarMutationState.NotAttempted,
+            CurrentSnapshot: currentSnapshot,
+            Retryable: retryable);
+}

--- a/src/DotnetAgents.CalDav.Core/Services/CalendarService.cs
+++ b/src/DotnetAgents.CalDav.Core/Services/CalendarService.cs
@@ -134,6 +134,14 @@ internal sealed class CalendarService : ICalendarService
         CalendarTodoCreateRequest request,
         CancellationToken cancellationToken) => await CreateEntityEngine().CreateTodoAsync(request, cancellationToken);
 
+    /// <inheritdoc />
+    public async Task<CalendarResourceDeleteResult> DeleteResourceAsync(
+        CalendarResourceRevisionReference revision,
+        CancellationToken cancellationToken) => await new CalendarResourceDeleteEngine(
+            _calendarClient,
+            GetResourceAsync,
+            _timeProvider).DeleteAsync(revision, cancellationToken);
+
     private CalendarEntityCreateEngine CreateEntityEngine() => new(
         _calendarClient,
         _options.Value,

--- a/src/DotnetAgents.CalDav.Mcp/Hosting/CalDavHostBuilder.cs
+++ b/src/DotnetAgents.CalDav.Mcp/Hosting/CalDavHostBuilder.cs
@@ -37,6 +37,7 @@ public sealed class CalDavHostBuilder
             .WithTools<CalendarOccurrenceTools>()
             .WithTools<CalendarResourceTools>()
             .WithTools<CalendarEntityCreateTools>()
+            .WithTools<CalendarResourceDeleteTools>()
             .WithTools<TaskListTools>()
             .WithTools<ChatTaskTools>();
 
@@ -66,6 +67,7 @@ public sealed class CalDavHostBuilder
 
         builder.Services.AddSingleton(TimeProvider.System);
         builder.Services.AddSingleton<CalendarMutationAdmission>();
+        builder.Services.AddSingleton<CalendarMutationRequestStateProtector>();
         builder.Services.AddSingleton<CalendarEntityCursorProtector>();
         builder.Services.AddTransient(serviceProvider => new CalendarEntityTools(
             serviceProvider.GetRequiredService<DotnetAgents.CalDav.Core.Abstractions.ICalendarService>(),
@@ -92,6 +94,7 @@ public sealed class CalDavHostBuilder
         ConfigureTool(options.ToolCollection, "calendar_resources.get");
         ConfigureTool(options.ToolCollection, "events.create");
         ConfigureTool(options.ToolCollection, "todos.create");
+        ConfigureTool(options.ToolCollection, "calendar_resources.delete");
         ConfigureTool(options.ToolCollection, "calendar_resources.exact_get");
     }
 

--- a/src/DotnetAgents.CalDav.Mcp/Hosting/OrderedToolCollection.cs
+++ b/src/DotnetAgents.CalDav.Mcp/Hosting/OrderedToolCollection.cs
@@ -13,6 +13,7 @@ internal sealed class OrderedToolCollection : McpServerPrimitiveCollection<McpSe
         ["calendar_resources.get"] = 3,
         ["events.create"] = 4,
         ["todos.create"] = 6,
+        ["calendar_resources.delete"] = 15,
         ["calendar_resources.exact_get"] = 16,
         ["list_task_lists"] = 17,
         ["show_tasks"] = 18,

--- a/src/DotnetAgents.CalDav.Mcp/Hosting/StrictToolInputGuard.cs
+++ b/src/DotnetAgents.CalDav.Mcp/Hosting/StrictToolInputGuard.cs
@@ -40,6 +40,7 @@ internal static class StrictToolInputGuard
             "calendar_entities.query" => RejectEntity(evidence),
             "calendar_occurrences.query" => RejectOccurrence(evidence),
             "events.create" or "todos.create" => RejectCreate(evidence),
+            "calendar_resources.delete" => RejectDelete(evidence),
             _ => null
         };
     }
@@ -52,6 +53,9 @@ internal static class StrictToolInputGuard
 
     private static CallToolResult? RejectCreate(StrictToolInputEvidence evidence) =>
         Reject(evidence, CalendarEntityCreateTools.MaximumArgumentBytes, CalendarEntityCreateTools.CreateInputGuardError);
+
+    private static CallToolResult? RejectDelete(StrictToolInputEvidence evidence) =>
+        Reject(evidence, CalendarResourceDeleteTools.MaximumArgumentBytes, CalendarResourceDeleteTools.CreateInputGuardError);
 
     private static CallToolResult? Reject(
         StrictToolInputEvidence evidence,

--- a/src/DotnetAgents.CalDav.Mcp/Tools/CalendarMutationRequestStateProtector.cs
+++ b/src/DotnetAgents.CalDav.Mcp/Tools/CalendarMutationRequestStateProtector.cs
@@ -1,0 +1,152 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using DotnetAgents.CalDav.Core.Configuration;
+using DotnetAgents.CalDav.Core.Models;
+using Microsoft.Extensions.Options;
+
+namespace DotnetAgents.CalDav.Mcp.Tools;
+
+/// <summary>Confidential, authenticated, revision-bound state for stateless mutation confirmation.</summary>
+internal sealed class CalendarMutationRequestStateProtector
+{
+    internal const int MaximumRequestStateCharacters = 2048;
+    private const string DeleteOperation = "calendar_resources.delete";
+    private static readonly TimeSpan Lifetime = TimeSpan.FromMinutes(10);
+    private readonly byte[] _encryptionKey;
+    private readonly byte[] _bindingKey;
+    private readonly string _credentialContext;
+    private readonly TimeProvider _timeProvider;
+
+    public CalendarMutationRequestStateProtector(TimeProvider timeProvider, IOptions<CalDavOptions> options)
+        : this(timeProvider, options, RandomNumberGenerator.GetBytes(64))
+    {
+    }
+
+    internal CalendarMutationRequestStateProtector(
+        TimeProvider timeProvider,
+        IOptions<CalDavOptions> options,
+        byte[] keyMaterial)
+    {
+        ArgumentNullException.ThrowIfNull(timeProvider);
+        ArgumentNullException.ThrowIfNull(options);
+        if (keyMaterial.Length != 64)
+            throw new ArgumentException("Mutation state key material must contain 64 bytes.", nameof(keyMaterial));
+
+        _timeProvider = timeProvider;
+        _encryptionKey = keyMaterial[..32];
+        _bindingKey = keyMaterial[32..];
+        var configured = options.Value;
+        _credentialContext = Bind(JsonSerializer.SerializeToUtf8Bytes(new CredentialBinding(
+            configured.BaseUrl,
+            configured.Username,
+            configured.Password)));
+    }
+
+    public string Protect(CalendarResourceRevisionReference revision)
+    {
+        var payload = JsonSerializer.SerializeToUtf8Bytes(new MutationPayload(
+            1,
+            _timeProvider.GetUtcNow().Add(Lifetime).ToUnixTimeSeconds(),
+            DeleteOperation,
+            BindRevision(revision),
+            _credentialContext));
+        var nonce = RandomNumberGenerator.GetBytes(12);
+        var cipherText = new byte[payload.Length];
+        var tag = new byte[16];
+        using (var cipher = new AesGcm(_encryptionKey, tag.Length))
+            cipher.Encrypt(nonce, payload, cipherText, tag);
+
+        var encoded = Base64UrlEncode([.. nonce, .. tag, .. cipherText]);
+        if (encoded.Length > MaximumRequestStateCharacters)
+            throw new InvalidOperationException("The protected mutation state exceeds the safe size limit.");
+        return encoded;
+    }
+
+    public bool TryUnprotect(
+        string state,
+        CalendarResourceRevisionReference revision,
+        out bool expired)
+    {
+        expired = false;
+        if (!TryDecode(state, out var protectedBytes))
+            return false;
+
+        var nonce = protectedBytes.AsSpan(0, 12);
+        var tag = protectedBytes.AsSpan(12, 16);
+        var cipherText = protectedBytes.AsSpan(28);
+        var payload = new byte[cipherText.Length];
+        try
+        {
+            using var cipher = new AesGcm(_encryptionKey, tag.Length);
+            cipher.Decrypt(nonce, cipherText, tag, payload);
+            var decoded = JsonSerializer.Deserialize<MutationPayload>(payload);
+            if (decoded is null
+                || decoded.Version != 1
+                || !string.Equals(decoded.Operation, DeleteOperation, StringComparison.Ordinal)
+                || !HasFixedTimeMatch(decoded.RevisionBinding, BindRevision(revision))
+                || !HasFixedTimeMatch(decoded.CredentialContext, _credentialContext))
+            {
+                return false;
+            }
+
+            expired = _timeProvider.GetUtcNow().ToUnixTimeSeconds() >= decoded.ExpiresAtUnixSeconds;
+            return !expired;
+        }
+        catch (Exception exception) when (exception is CryptographicException or JsonException)
+        {
+            return false;
+        }
+    }
+
+    private string BindRevision(CalendarResourceRevisionReference revision) => Bind(
+        JsonSerializer.SerializeToUtf8Bytes(new RevisionBinding(
+            revision.Href,
+            revision.EntityUid,
+            revision.EntityKind == CalendarEntityKind.Event ? "event" : "todo",
+            revision.EntityTag)));
+
+    private string Bind(ReadOnlySpan<byte> value) => Convert.ToHexStringLower(HMACSHA256.HashData(_bindingKey, value));
+
+    private static bool HasFixedTimeMatch(string left, string right) => CryptographicOperations.FixedTimeEquals(
+        Encoding.UTF8.GetBytes(left),
+        Encoding.UTF8.GetBytes(right));
+
+    private static bool TryDecode(string value, out byte[] bytes)
+    {
+        bytes = [];
+        if (value.Length is <= 0 or > MaximumRequestStateCharacters
+            || value.Any(character => !(char.IsAsciiLetterOrDigit(character) || character is '-' or '_')))
+        {
+            return false;
+        }
+
+        var padded = value.Replace('-', '+').Replace('_', '/');
+        padded += new string('=', (4 - (padded.Length % 4)) % 4);
+        try
+        {
+            bytes = Convert.FromBase64String(padded);
+            return bytes.Length > 28 && string.Equals(Base64UrlEncode(bytes), value, StringComparison.Ordinal);
+        }
+        catch (FormatException)
+        {
+            return false;
+        }
+    }
+
+    private static string Base64UrlEncode(ReadOnlySpan<byte> value) => Convert.ToBase64String(value)
+        .TrimEnd('=')
+        .Replace('+', '-')
+        .Replace('/', '_');
+
+    private sealed record MutationPayload(
+        int Version,
+        long ExpiresAtUnixSeconds,
+        string Operation,
+        string RevisionBinding,
+        string CredentialContext);
+
+    private sealed record CredentialBinding(string BaseUrl, string Username, string Password);
+
+    private sealed record RevisionBinding(string Href, string EntityUid, string EntityKind, string EntityTag);
+}

--- a/src/DotnetAgents.CalDav.Mcp/Tools/CalendarResourceDeleteArgumentParser.cs
+++ b/src/DotnetAgents.CalDav.Mcp/Tools/CalendarResourceDeleteArgumentParser.cs
@@ -1,0 +1,94 @@
+using System.Net.Http.Headers;
+using System.Text.Json;
+using DotnetAgents.CalDav.Core.Models;
+
+namespace DotnetAgents.CalDav.Mcp.Tools;
+
+internal static class CalendarResourceDeleteArgumentParser
+{
+    private static readonly HashSet<string> RootProperties = ["revision"];
+    private static readonly HashSet<string> RevisionProperties = ["href", "entityUid", "entityKind", "entityTag"];
+
+    public static bool TryParse(
+        IDictionary<string, JsonElement>? arguments,
+        out CalendarResourceRevisionReference revision)
+    {
+        revision = default!;
+        if (!TryGetRevisionObject(arguments, out var element)
+            || !TryGetRevisionFields(element, out var href, out var entityUid, out var kindText, out var entityTag)
+            || !Uri.TryCreate(href, UriKind.Absolute, out _)
+            || !TryParseKind(kindText, out var kind)
+            || !IsExactEntityTag(entityTag))
+        {
+            return false;
+        }
+
+        revision = new CalendarResourceRevisionReference(href, entityUid, kind, entityTag);
+        return true;
+    }
+
+    private static bool TryGetRevisionObject(
+        IDictionary<string, JsonElement>? arguments,
+        out JsonElement element)
+    {
+        element = default;
+        return arguments is not null
+            && HasExactProperties(arguments.Keys, RootProperties)
+            && arguments.TryGetValue("revision", out element)
+            && element.ValueKind == JsonValueKind.Object
+            && HasExactProperties(element.EnumerateObject().Select(property => property.Name), RevisionProperties);
+    }
+
+    private static bool TryGetRevisionFields(
+        JsonElement element,
+        out string href,
+        out string entityUid,
+        out string entityKind,
+        out string entityTag)
+    {
+        href = string.Empty;
+        entityUid = string.Empty;
+        entityKind = string.Empty;
+        entityTag = string.Empty;
+        return TryGetExactString(element, "href", out href)
+            && TryGetExactString(element, "entityUid", out entityUid)
+            && TryGetExactString(element, "entityKind", out entityKind)
+            && TryGetExactString(element, "entityTag", out entityTag);
+    }
+
+    private static bool TryGetExactString(JsonElement owner, string name, out string value)
+    {
+        value = string.Empty;
+        return owner.TryGetProperty(name, out var property)
+            && property.ValueKind == JsonValueKind.String
+            && property.GetString() is { Length: > 0 } text
+            && string.Equals(text, text.Trim(), StringComparison.Ordinal)
+            && (value = text) is not null;
+    }
+
+    private static bool TryParseKind(string value, out CalendarEntityKind kind)
+    {
+        kind = value switch
+        {
+            "event" => CalendarEntityKind.Event,
+            "todo" => CalendarEntityKind.Todo,
+            _ => default
+        };
+        return value is "event" or "todo";
+    }
+
+    public static bool IsWeakEntityTag(string value) =>
+        EntityTagHeaderValue.TryParse(value, out var parsed) && parsed?.IsWeak == true;
+
+    private static bool IsExactEntityTag(string value) =>
+        EntityTagHeaderValue.TryParse(value, out var parsed)
+        && parsed is not null
+        && parsed != EntityTagHeaderValue.Any
+        && string.Equals(parsed.ToString(), value, StringComparison.Ordinal);
+
+    private static bool HasExactProperties(IEnumerable<string> actual, HashSet<string> expected)
+    {
+        var properties = actual.ToArray();
+        return properties.Length == expected.Count && properties.All(expected.Contains);
+    }
+}

--- a/src/DotnetAgents.CalDav.Mcp/Tools/CalendarResourceDeleteTools.cs
+++ b/src/DotnetAgents.CalDav.Mcp/Tools/CalendarResourceDeleteTools.cs
@@ -1,0 +1,674 @@
+using System.ComponentModel;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using DotnetAgents.CalDav.Core.Abstractions;
+using DotnetAgents.CalDav.Core.Models;
+using Microsoft.Extensions.DependencyInjection;
+using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
+
+namespace DotnetAgents.CalDav.Mcp.Tools;
+
+/// <summary>Deletes one reviewed Calendar Object Resource through revision-bound MRTR confirmation.</summary>
+[McpServerToolType]
+public sealed class CalendarResourceDeleteTools
+{
+    internal const int MaximumArgumentBytes = CalendarQueryToolSupport.MaximumArgumentBytes;
+    private const string ConfirmationKey = "confirm_delete";
+    private const string ConfirmationTitle = "Confirm deletion";
+    private const string ConfirmationDescription = "Delete exactly the reviewed resource revision.";
+    private static readonly TimeSpan BeforeDispatchDeadline = TimeSpan.FromSeconds(30);
+    private readonly ICalendarService _calendarService;
+    private readonly CalendarMutationRequestStateProtector _stateProtector;
+    private readonly TimeProvider _timeProvider;
+    private readonly CalendarMutationAdmission _admission;
+
+    public CalendarResourceDeleteTools(IServiceProvider services)
+        : this(
+            services.GetRequiredService<ICalendarService>(),
+            services.GetRequiredService<CalendarMutationRequestStateProtector>(),
+            services.GetRequiredService<TimeProvider>(),
+            services.GetRequiredService<CalendarMutationAdmission>())
+    {
+    }
+
+    internal CalendarResourceDeleteTools(
+        ICalendarService calendarService,
+        CalendarMutationRequestStateProtector stateProtector,
+        TimeProvider timeProvider,
+        CalendarMutationAdmission admission)
+    {
+        _calendarService = calendarService;
+        _stateProtector = stateProtector;
+        _timeProvider = timeProvider;
+        _admission = admission;
+    }
+
+    [McpServerTool(
+        Name = "calendar_resources.delete",
+        ReadOnly = false,
+        Destructive = true,
+        Idempotent = false,
+        OpenWorld = true,
+        UseStructuredContent = true,
+        OutputSchemaType = typeof(CalendarResourceDeleteSuccessResult)),
+     Description("Confirm and delete one revision-bound Calendar Object Resource.")]
+    public Task<CallToolResult> DeleteAsync(
+        RequestContext<CallToolRequestParams> requestContext,
+        McpServer server,
+        CancellationToken cancellationToken) => DeleteRawAsync(
+            requestContext.Params?.Arguments,
+            requestContext.Params?.RequestState,
+            requestContext.Params?.InputResponses,
+            server.IsMrtrSupported,
+            cancellationToken);
+
+    internal async Task<CallToolResult> DeleteRawAsync(
+        IDictionary<string, JsonElement>? arguments,
+        string? requestState,
+        IDictionary<string, InputResponse>? inputResponses,
+        bool mrtrSupported,
+        CancellationToken cancellationToken)
+    {
+        if (CalendarQueryToolSupport.MeasureArguments(
+                arguments,
+                arguments ?? new Dictionary<string, JsonElement>()) > MaximumArgumentBytes)
+        {
+            return Error(
+                "payload_too_large",
+                "limitsAndAdmission",
+                "The Calendar Object Resource delete arguments exceed the safe payload limit.",
+                false,
+                "admissionAndPayload",
+                "not_attempted");
+        }
+
+        using var lease = await _admission.AcquireAsync(cancellationToken).ConfigureAwait(false);
+        if (lease is null)
+            return BusyError();
+        if (!CalendarResourceDeleteArgumentParser.TryParse(arguments, out var revision))
+            return InputError();
+        if (CalendarResourceDeleteArgumentParser.IsWeakEntityTag(revision.EntityTag))
+            return Error(Failure(CalendarResourceDeleteCode.ConcurrencyUnavailable));
+
+        return await ExecuteWithDeadlineAsync(
+            revision,
+            requestState,
+            inputResponses,
+            mrtrSupported,
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task<CallToolResult> ExecuteWithDeadlineAsync(
+        CalendarResourceRevisionReference revision,
+        string? requestState,
+        IDictionary<string, InputResponse>? inputResponses,
+        bool mrtrSupported,
+        CancellationToken cancellationToken)
+    {
+        using var deadline = new CancellationTokenSource(BeforeDispatchDeadline, _timeProvider);
+        using var linked = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, deadline.Token);
+        try
+        {
+            return await ExecuteRoundAsync(
+                revision,
+                requestState,
+                inputResponses,
+                mrtrSupported,
+                linked.Token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (deadline.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+        {
+            return DeadlineError();
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            return PreviewUnavailableError();
+        }
+        catch (HttpRequestException exception)
+        {
+            return PreviewHttpError(exception.StatusCode);
+        }
+        catch (CalendarDiscoveryUnsupportedCapabilityException)
+        {
+            return Error(
+                "unsupported_capability",
+                "capabilityAndProjection",
+                "The server does not support the required Calendar discovery capability.",
+                false,
+                "selectionDiscoveryCapability",
+                "not_attempted");
+        }
+        catch (CalendarDiscoveryLimitException exception)
+        {
+            return Error(
+                "limit_exhausted",
+                "limitsAndAdmission",
+                "The Calendar mutation exceeded its Calendar discovery limit.",
+                false,
+                "selectionDiscoveryCapability",
+                "not_attempted",
+                limits: new CalendarEntityCreateLimits(CalendarCount: exception.CalendarCount));
+        }
+        catch (Exception exception) when (exception is not (InputRequiredException or OperationCanceledException))
+        {
+            return PreviewProtocolError();
+        }
+    }
+
+    private async Task<CallToolResult> ExecuteRoundAsync(
+        CalendarResourceRevisionReference revision,
+        string? requestState,
+        IDictionary<string, InputResponse>? inputResponses,
+        bool mrtrSupported,
+        CancellationToken cancellationToken)
+    {
+        var hasContinuation = requestState is not null || inputResponses is not null;
+        if (hasContinuation && !mrtrSupported)
+            return UnsupportedMrtrError();
+        if (hasContinuation)
+            return await ContinueAsync(revision, requestState, inputResponses, cancellationToken).ConfigureAwait(false);
+
+        var proposedMessage = CreateConfirmationMessage(
+            revision.Href,
+            revision.EntityUid,
+            revision.EntityKind,
+            revision.EntityTag);
+        if (!IsConfirmationPreviewWithinBudget(proposedMessage))
+            return ConfirmationPreviewPayloadError();
+
+        var preview = await ReviewAsync(revision, cancellationToken).ConfigureAwait(false);
+        if (preview.Failure is not null)
+            return Error(preview.Failure);
+        if (!mrtrSupported)
+            return UnsupportedMrtrError();
+
+        cancellationToken.ThrowIfCancellationRequested();
+        var state = _stateProtector.Protect(revision);
+        var reviewed = preview.Snapshot!;
+        var confirmationMessage = CreateConfirmationMessage(
+            reviewed.ResourceHref,
+            reviewed.Projection.EntityUid!,
+            reviewed.Projection.Kind == CalendarResourceProjectionKind.Event
+                ? CalendarEntityKind.Event
+                : CalendarEntityKind.Todo,
+            reviewed.EntityTag);
+        if (!IsConfirmationPreviewWithinBudget(confirmationMessage))
+            return ConfirmationPreviewPayloadError();
+        throw new InputRequiredException(
+            new Dictionary<string, InputRequest>
+            {
+                [ConfirmationKey] = InputRequest.ForElicitation(new ElicitRequestParams
+                {
+                    Mode = "form",
+                    Message = confirmationMessage,
+                    RequestedSchema = new ElicitRequestParams.RequestSchema
+                    {
+                        Properties = new Dictionary<string, ElicitRequestParams.PrimitiveSchemaDefinition>
+                        {
+                            ["confirm"] = new ElicitRequestParams.BooleanSchema
+                            {
+                                Title = ConfirmationTitle,
+                                Description = ConfirmationDescription,
+                                Default = false
+                            }
+                        },
+                        Required = ["confirm"]
+                    }
+                })
+            },
+            state);
+    }
+
+    private async Task<CallToolResult> ContinueAsync(
+        CalendarResourceRevisionReference revision,
+        string? requestState,
+        IDictionary<string, InputResponse>? inputResponses,
+        CancellationToken cancellationToken)
+    {
+        var confirmation = ReadContinuation(revision, requestState, inputResponses);
+        if (confirmation == ConfirmationDecision.Mismatch)
+        {
+            return ConfirmationMismatch();
+        }
+        if (confirmation == ConfirmationDecision.Expired)
+            return ConfirmationExpired();
+        if (confirmation == ConfirmationDecision.Declined)
+            return ConfirmationDeclined();
+
+        var current = await ReviewAsync(revision, cancellationToken).ConfigureAwait(false);
+        if (current.Failure is not null)
+            return Error(current.Failure);
+
+        CalendarResourceDeleteResult result;
+        try
+        {
+            result = await _calendarService.DeleteResourceAsync(revision, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception exception) when (exception is not OperationCanceledException)
+        {
+            return Error(new CalendarResourceDeleteResult(
+                CalendarResourceDeleteCode.Indeterminate,
+                CalendarMutationState.Unknown));
+        }
+        var mapped = result.Code == CalendarResourceDeleteCode.Success && result.DeletionReceipt is not null
+            ? Success(result.DeletionReceipt)
+            : Error(result);
+        return CalendarQueryToolSupport.EnsureBoundedResult(mapped, (_, _) => Error(
+            "payload_too_large",
+            "limitsAndAdmission",
+            "The Calendar mutation result exceeds the safe payload limit.",
+            false,
+            "admissionAndPayload",
+            MutationState(result.MutationState)));
+    }
+
+    private ConfirmationDecision ReadContinuation(
+        CalendarResourceRevisionReference revision,
+        string? requestState,
+        IDictionary<string, InputResponse>? inputResponses)
+    {
+        if (!TryGetConfirmationResponse(requestState, inputResponses, out var response))
+            return ConfirmationDecision.Mismatch;
+        if (!_stateProtector.TryUnprotect(requestState!, revision, out var expired))
+            return expired ? ConfirmationDecision.Expired : ConfirmationDecision.Mismatch;
+        return !TryReadConfirmation(response, out var confirmed)
+            ? ConfirmationDecision.Mismatch
+            : confirmed ? ConfirmationDecision.Confirmed : ConfirmationDecision.Declined;
+    }
+
+    private static bool TryGetConfirmationResponse(
+        string? requestState,
+        IDictionary<string, InputResponse>? inputResponses,
+        out InputResponse response)
+    {
+        response = default!;
+        if (string.IsNullOrEmpty(requestState)
+            || inputResponses is null
+            || inputResponses.Count != 1
+            || !inputResponses.TryGetValue(ConfirmationKey, out var candidate)
+            || candidate is null)
+        {
+            return false;
+        }
+        response = candidate;
+        return true;
+    }
+
+    private static bool TryReadConfirmation(InputResponse response, out bool confirmed)
+    {
+        confirmed = false;
+        var elicitation = response.Deserialize(InputResponse.ElicitResultJsonTypeInfo);
+        if (elicitation is null)
+            return false;
+        if (elicitation.Action is "decline" or "cancel")
+            return true;
+        if (!string.Equals(elicitation.Action, "accept", StringComparison.Ordinal)
+            || elicitation.Content is null
+            || elicitation.Content.Count != 1
+            || !elicitation.Content.TryGetValue("confirm", out var element)
+            || element.ValueKind is not JsonValueKind.True and not JsonValueKind.False)
+        {
+            return false;
+        }
+        confirmed = element.GetBoolean();
+        return true;
+    }
+
+    internal static CallToolResult CreateInputGuardError(bool payloadTooLarge) => payloadTooLarge
+        ? Error(
+            "payload_too_large",
+            "limitsAndAdmission",
+            "The Calendar Object Resource delete arguments exceed the safe payload limit.",
+            false,
+            "admissionAndPayload",
+            "not_attempted")
+        : InputError();
+
+    private async Task<ReviewOutcome> ReviewAsync(
+        CalendarResourceRevisionReference revision,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var read = await _calendarService.GetResourceAsync(revision.Href, cancellationToken).ConfigureAwait(false);
+            if (read.Code != CalendarResourceReadCode.Success || read.Snapshot is null)
+                return new ReviewOutcome(null, FromReadFailure(read.Code));
+            if (!read.Snapshot.SemanticMutationAvailable)
+                return new ReviewOutcome(null, Failure(CalendarResourceDeleteCode.OpaqueResource, read.Snapshot));
+            var kind = read.Snapshot.Projection.Kind == CalendarResourceProjectionKind.Event
+                ? CalendarEntityKind.Event
+                : CalendarEntityKind.Todo;
+            if (kind != revision.EntityKind)
+                return new ReviewOutcome(null, Failure(CalendarResourceDeleteCode.EntityKindMismatch, read.Snapshot));
+            return string.Equals(read.Snapshot.Projection.EntityUid, revision.EntityUid, StringComparison.Ordinal)
+                && string.Equals(read.Snapshot.EntityTag, revision.EntityTag, StringComparison.Ordinal)
+                ? new ReviewOutcome(read.Snapshot, null)
+                : new ReviewOutcome(null, Failure(CalendarResourceDeleteCode.Conflict, read.Snapshot));
+        }
+        catch (Exception exception) when (exception is IOException or TimeoutException)
+        {
+            return new ReviewOutcome(
+                null,
+                Failure(CalendarResourceDeleteCode.UpstreamUnavailable, retryable: true));
+        }
+    }
+
+    private static string CreateConfirmationMessage(
+        string href,
+        string entityUid,
+        CalendarEntityKind entityKind,
+        string entityTag)
+    {
+        var kind = entityKind == CalendarEntityKind.Event ? "event" : "todo";
+        return $"Confirm calendar_resources.delete for href {href}, UID {entityUid}, kind {kind}, and expected ETag {entityTag}.";
+    }
+
+    private static bool IsConfirmationPreviewWithinBudget(string message) =>
+        JsonSerializer.SerializeToUtf8Bytes(new ConfirmationPreviewBudget(
+            message,
+            ConfirmationTitle,
+            ConfirmationDescription)).Length <= CalendarQueryToolSupport.MaximumHumanReadableBytes;
+
+    private static CalendarResourceDeleteResult FromReadFailure(CalendarResourceReadCode code) => code switch
+    {
+        CalendarResourceReadCode.InvalidInput => Failure(CalendarResourceDeleteCode.InvalidInput),
+        CalendarResourceReadCode.NotFound => Failure(CalendarResourceDeleteCode.NotFound),
+        CalendarResourceReadCode.OutsideScope => Failure(CalendarResourceDeleteCode.OutsideScope),
+        CalendarResourceReadCode.ConcurrencyUnavailable => Failure(CalendarResourceDeleteCode.ConcurrencyUnavailable),
+        CalendarResourceReadCode.PayloadTooLarge => Failure(CalendarResourceDeleteCode.PayloadTooLarge),
+        _ => Failure(CalendarResourceDeleteCode.UpstreamProtocolError)
+    };
+
+    private static CalendarResourceDeleteResult Failure(
+        CalendarResourceDeleteCode code,
+        CalendarResourceSnapshot? snapshot = null,
+        bool retryable = false) =>
+        new(
+            code,
+            CalendarMutationState.NotAttempted,
+            CurrentSnapshot: snapshot,
+            Retryable: retryable);
+
+    private static CallToolResult Error(CalendarResourceDeleteResult result)
+    {
+        var (code, category, message, defaultPhase) = Describe(result.Code);
+        return Error(
+            code,
+            category,
+            message,
+            result.Retryable,
+            ResolvePhase(result, defaultPhase),
+            MutationState(result.MutationState),
+            result.CurrentSnapshot is null ? null : CalendarSnapshotResult.FromSnapshot(result.CurrentSnapshot),
+            retryAfterMs: result.RetryAfterMilliseconds);
+    }
+
+    private static CallToolResult Success(CalendarResourceDeletionReceipt receipt) => new()
+    {
+        IsError = false,
+        StructuredContent = JsonSerializer.SerializeToElement(new CalendarResourceDeleteSuccessResult(
+            "success",
+            "committed",
+            new CalendarResourceDeletionReceiptResult(
+                receipt.Href,
+                receipt.EntityUid,
+                receipt.EntityKind == CalendarEntityKind.Event ? "event" : "todo",
+                receipt.ConsumedEntityTag),
+            [])),
+        Content = [new TextContentBlock { Text = "Calendar Object Resource deletion completed." }]
+    };
+
+    private static CallToolResult ConfirmationDeclined() => new()
+    {
+        IsError = false,
+        StructuredContent = JsonSerializer.SerializeToElement(new CalendarResourceDeleteNonMutationResult(
+            "confirmation_declined",
+            "not_attempted",
+            [])),
+        Content = [new TextContentBlock { Text = "Calendar Object Resource deletion was declined." }]
+    };
+
+    private static CallToolResult ConfirmationMismatch() => Error(
+        "confirmation_mismatch",
+        "confirmation",
+        "The mutation confirmation does not match the reviewed request.",
+        false,
+        "mrtr",
+        "not_attempted");
+
+    private static CallToolResult ConfirmationExpired() => Error(
+        "confirmation_expired",
+        "confirmation",
+        "The mutation confirmation has expired.",
+        false,
+        "mrtr",
+        "not_attempted");
+
+    private static (string Code, string Category, string Message, string Phase) Describe(
+        CalendarResourceDeleteCode code) => code switch
+    {
+        CalendarResourceDeleteCode.InvalidInput =>
+            ("invalid_input", "input", "The Calendar Object Resource delete input is invalid.", "schemaLexicalDiscriminator"),
+        CalendarResourceDeleteCode.NotFound =>
+            ("not_found", "selection", "The Calendar Object Resource was not found.", "targetRevision"),
+        CalendarResourceDeleteCode.OutsideScope =>
+            ("outside_scope", "selection", "The Calendar Object Resource is outside the configured Calendar Scope.", "originScopeAuthorization"),
+        CalendarResourceDeleteCode.EntityKindMismatch =>
+            ("entity_kind_mismatch", "state", "The Calendar Object Resource Entity Kind has changed.", "targetRevision"),
+        CalendarResourceDeleteCode.OpaqueResource =>
+            ("opaque_resource", "capabilityAndProjection", "The Calendar Object Resource cannot be projected safely.", "targetRevision"),
+        CalendarResourceDeleteCode.Conflict =>
+            ("conflict", "state", "The Calendar Object Resource revision has changed.", "targetRevision"),
+        CalendarResourceDeleteCode.ConcurrencyUnavailable =>
+            ("concurrency_unavailable", "state", "The Calendar Object Resource has no strong Entity Tag.", "targetRevision"),
+        CalendarResourceDeleteCode.UnsupportedCapability =>
+            ("unsupported_capability", "capabilityAndProjection", "The server does not support conditional Calendar Object Resource deletion.", "selectionDiscoveryCapability"),
+        CalendarResourceDeleteCode.PayloadTooLarge =>
+            ("payload_too_large", "limitsAndAdmission", "The Calendar Object Resource exceeds the safe payload limit.", "admissionAndPayload"),
+        CalendarResourceDeleteCode.UpstreamUnauthorized =>
+            ("upstream_unauthorized", "upstream", "The Calendar mutation was not authorized.", "execution"),
+        CalendarResourceDeleteCode.UpstreamForbidden =>
+            ("upstream_forbidden", "upstream", "The Calendar mutation was forbidden.", "execution"),
+        CalendarResourceDeleteCode.UpstreamRateLimited =>
+            ("upstream_rate_limited", "upstream", "The Calendar mutation is rate limited.", "execution"),
+        CalendarResourceDeleteCode.UpstreamUnavailable =>
+            ("upstream_unavailable", "upstream", "The Calendar Object Resource is temporarily unavailable.", "targetRevision"),
+        CalendarResourceDeleteCode.UpstreamProtocolError =>
+            ("upstream_protocol_error", "upstream", "The Calendar mutation returned an invalid response.", "execution"),
+        CalendarResourceDeleteCode.CommittedButUnverified =>
+            ("committed_but_unverified", "postWriteTruth", "The committed deletion could not be verified.", "postWriteVerificationOrReconciliation"),
+        CalendarResourceDeleteCode.Indeterminate =>
+            ("indeterminate", "postWriteTruth", "The Calendar mutation outcome is indeterminate.", "postWriteVerificationOrReconciliation"),
+        _ =>
+            ("upstream_protocol_error", "upstream", "The Calendar Object Resource returned an invalid response.", "targetRevision")
+    };
+
+    private static string ResolvePhase(CalendarResourceDeleteResult result, string defaultPhase)
+    {
+        if (result.MutationState is CalendarMutationState.Committed or CalendarMutationState.Unknown)
+            return "postWriteVerificationOrReconciliation";
+        if (result.MutationState == CalendarMutationState.NotCommitted)
+        {
+            return result.Code == CalendarResourceDeleteCode.UpstreamUnavailable
+                && result.CurrentSnapshot is not null
+                ? "postWriteVerificationOrReconciliation"
+                : "execution";
+        }
+        if (result.Code == CalendarResourceDeleteCode.InvalidInput)
+            return "originScopeAuthorization";
+        return defaultPhase;
+    }
+
+    private static CallToolResult UnsupportedMrtrError() => Error(
+        "unsupported_capability",
+        "capabilityAndProjection",
+        "Calendar Object Resource deletion requires MRTR confirmation support.",
+        false,
+        "mrtr",
+        "not_attempted");
+
+    private static CallToolResult ConfirmationPreviewPayloadError() => Error(
+        "payload_too_large",
+        "limitsAndAdmission",
+        "The Calendar Object Resource deletion confirmation exceeds the safe human-readable limit.",
+        false,
+        "admissionAndPayload",
+        "not_attempted");
+
+    private static CallToolResult InputError() => Error(
+        "invalid_input",
+        "input",
+        "The Calendar Object Resource delete input is invalid.",
+        false,
+        "schemaLexicalDiscriminator",
+        "not_attempted");
+
+    private static CallToolResult BusyError() => Error(
+        "busy",
+        "limitsAndAdmission",
+        "The Calendar mutation admission queue is busy.",
+        true,
+        "admissionAndPayload",
+        "not_attempted",
+        retryAfterMs: CalendarMutationAdmission.RetryAfterMilliseconds);
+
+    private static CallToolResult DeadlineError() => Error(
+        "limit_exhausted",
+        "limitsAndAdmission",
+        "The Calendar mutation exhausted its elapsed_time execution budget.",
+        false,
+        "execution",
+        "not_attempted");
+
+    private static CallToolResult PreviewUnavailableError() => Error(
+        "upstream_unavailable",
+        "upstream",
+        "The Calendar Object Resource is temporarily unavailable.",
+        true,
+        "targetRevision",
+        "not_attempted");
+
+    private static CallToolResult PreviewProtocolError() => Error(
+        "upstream_protocol_error",
+        "upstream",
+        "The Calendar Object Resource returned an invalid response.",
+        false,
+        "targetRevision",
+        "not_attempted");
+
+    private static CallToolResult PreviewHttpError(System.Net.HttpStatusCode? statusCode) => statusCode switch
+    {
+        System.Net.HttpStatusCode.Unauthorized => Error(
+            "upstream_unauthorized", "upstream", "Calendar discovery was not authorized.", false,
+            "selectionDiscoveryCapability", "not_attempted"),
+        System.Net.HttpStatusCode.Forbidden => Error(
+            "upstream_forbidden", "upstream", "Calendar discovery was forbidden.", false,
+            "selectionDiscoveryCapability", "not_attempted"),
+        System.Net.HttpStatusCode.NotFound => Error(
+            "upstream_protocol_error", "upstream", "Calendar discovery returned an invalid response.", false,
+            "selectionDiscoveryCapability", "not_attempted"),
+        System.Net.HttpStatusCode.Conflict or System.Net.HttpStatusCode.PreconditionFailed => Error(
+            "conflict", "state", "Calendar discovery reported a conflicting state.", false,
+            "selectionDiscoveryCapability", "not_attempted"),
+        System.Net.HttpStatusCode.RequestEntityTooLarge => Error(
+            "payload_too_large", "limitsAndAdmission", "Calendar discovery exceeded the safe payload limit.", false,
+            "selectionDiscoveryCapability", "not_attempted"),
+        System.Net.HttpStatusCode.TooManyRequests => Error(
+            "upstream_rate_limited", "upstream", "Calendar discovery is rate limited.", true,
+            "selectionDiscoveryCapability", "not_attempted"),
+        System.Net.HttpStatusCode.MethodNotAllowed or System.Net.HttpStatusCode.NotImplemented => Error(
+            "unsupported_capability", "capabilityAndProjection", "Calendar discovery is not supported.", false,
+            "selectionDiscoveryCapability", "not_attempted"),
+        System.Net.HttpStatusCode.InsufficientStorage => Error(
+            "upstream_unavailable", "upstream", "Calendar discovery is temporarily unavailable.", false,
+            "selectionDiscoveryCapability", "not_attempted"),
+        >= System.Net.HttpStatusCode.InternalServerError => Error(
+            "upstream_unavailable", "upstream", "Calendar discovery is temporarily unavailable.", true,
+            "selectionDiscoveryCapability", "not_attempted"),
+        _ => Error(
+            "upstream_unavailable", "upstream", "Calendar discovery is temporarily unavailable.", true,
+            "selectionDiscoveryCapability", "not_attempted")
+    };
+
+    private static CallToolResult Error(
+        string code,
+        string category,
+        string message,
+        bool retryable,
+        string phase,
+        string mutationState,
+        CalendarSnapshotResult? currentSnapshot = null,
+        int? retryAfterMs = null,
+        CalendarEntityCreateLimits? limits = null) => new()
+        {
+            IsError = true,
+            StructuredContent = JsonSerializer.SerializeToElement(new CalendarResourceDeleteErrorResult(
+                code,
+                category,
+                message,
+                retryable,
+                phase,
+                mutationState,
+                currentSnapshot,
+                retryAfterMs,
+                limits)),
+            Content = [new TextContentBlock { Text = "Calendar Object Resource deletion failed." }]
+        };
+
+    private static string MutationState(CalendarMutationState state) => state switch
+    {
+        CalendarMutationState.NotAttempted => "not_attempted",
+        CalendarMutationState.NotCommitted => "not_committed",
+        CalendarMutationState.Committed => "committed",
+        _ => "unknown"
+    };
+
+    private enum ConfirmationDecision
+    {
+        Mismatch,
+        Expired,
+        Declined,
+        Confirmed
+    }
+
+    private sealed record ReviewOutcome(
+        CalendarResourceSnapshot? Snapshot,
+        CalendarResourceDeleteResult? Failure);
+
+    private sealed record ConfirmationPreviewBudget(
+        string Message,
+        string Title,
+        string Description);
+}
+
+public sealed record CalendarResourceDeleteSuccessResult(
+    [property: JsonPropertyName("outcome")] string Outcome,
+    [property: JsonPropertyName("mutationState")] string MutationState,
+    [property: JsonPropertyName("deletionReceipt")] CalendarResourceDeletionReceiptResult DeletionReceipt,
+    [property: JsonPropertyName("diagnostics")] IReadOnlyList<CalendarDiagnosticResult> Diagnostics);
+
+public sealed record CalendarResourceDeletionReceiptResult(
+    [property: JsonPropertyName("href")] string Href,
+    [property: JsonPropertyName("entityUid")] string EntityUid,
+    [property: JsonPropertyName("entityKind")] string EntityKind,
+    [property: JsonPropertyName("consumedEntityTag")] string ConsumedEntityTag);
+
+public sealed record CalendarResourceDeleteNonMutationResult(
+    [property: JsonPropertyName("outcome")] string Outcome,
+    [property: JsonPropertyName("mutationState")] string MutationState,
+    [property: JsonPropertyName("diagnostics")] IReadOnlyList<CalendarDiagnosticResult> Diagnostics);
+
+public sealed record CalendarResourceDeleteErrorResult(
+    [property: JsonPropertyName("code")] string Code,
+    [property: JsonPropertyName("category")] string Category,
+    [property: JsonPropertyName("message")] string Message,
+    [property: JsonPropertyName("retryable")] bool Retryable,
+    [property: JsonPropertyName("phase")] string Phase,
+    [property: JsonPropertyName("mutationState")] string MutationState,
+    [property: JsonPropertyName("currentSnapshot"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        CalendarSnapshotResult? CurrentSnapshot = null,
+    [property: JsonPropertyName("retryAfterMs"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        int? RetryAfterMs = null,
+    [property: JsonPropertyName("limits"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        CalendarEntityCreateLimits? Limits = null);

--- a/tests/DotnetAgents.CalDav.Core.Tests.Unit/Internal/Xml/CalendarResourceDeleteProtocolTests.cs
+++ b/tests/DotnetAgents.CalDav.Core.Tests.Unit/Internal/Xml/CalendarResourceDeleteProtocolTests.cs
@@ -1,0 +1,202 @@
+using System.Net;
+using DotnetAgents.CalDav.Core.Internal.Xml;
+using DotnetAgents.CalDav.Core.Models;
+using Shouldly;
+using Xunit;
+
+namespace DotnetAgents.CalDav.Core.Tests.Unit.Internal.Xml;
+
+public sealed class CalendarResourceDeleteProtocolTests
+{
+    [Theory]
+    [InlineData("relative.ics", "\"r1\"")]
+    [InlineData("https://other.example/tasks/a.ics", "\"r1\"")]
+    [InlineData("https://example.com/tasks/a.ics?secret=true", "\"r1\"")]
+    [InlineData("https://example.com/tasks/a.ics", "")]
+    [InlineData("https://example.com/tasks/a.ics", "r1")]
+    [InlineData("https://example.com/tasks/a.ics", "W/\"r1\"")]
+    [InlineData("https://example.com/tasks/a.ics", "*")]
+    public async Task DeleteAsync_RejectsUnsafeHrefAndNonExactStrongTagBeforeDispatch(
+        string href,
+        string entityTag)
+    {
+        var sendCount = 0;
+        using var httpClient = new HttpClient(new Handler(_ =>
+        {
+            sendCount++;
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NoContent));
+        }));
+        var sut = new CalendarResourceDeleteProtocol(httpClient, new Uri("https://example.com"));
+
+        var result = await sut.DeleteAsync(
+            new CalendarResourceDeleteRequest(href, entityTag),
+            TestContext.Current.CancellationToken);
+
+        result.Code.ShouldBe(CalendarResourceDeleteDispatchCode.InvalidInput);
+        sendCount.ShouldBe(0);
+    }
+
+    [Theory]
+    [InlineData(HttpStatusCode.NotFound, CalendarResourceDeleteDispatchCode.NotFound)]
+    [InlineData(HttpStatusCode.Conflict, CalendarResourceDeleteDispatchCode.Conflict)]
+    [InlineData(HttpStatusCode.PreconditionFailed, CalendarResourceDeleteDispatchCode.Conflict)]
+    [InlineData(HttpStatusCode.Unauthorized, CalendarResourceDeleteDispatchCode.UpstreamUnauthorized)]
+    [InlineData(HttpStatusCode.Forbidden, CalendarResourceDeleteDispatchCode.UpstreamForbidden)]
+    [InlineData(HttpStatusCode.RequestEntityTooLarge, CalendarResourceDeleteDispatchCode.PayloadTooLarge)]
+    [InlineData(HttpStatusCode.TooManyRequests, CalendarResourceDeleteDispatchCode.UpstreamRateLimited)]
+    [InlineData(HttpStatusCode.MethodNotAllowed, CalendarResourceDeleteDispatchCode.UnsupportedCapability)]
+    [InlineData(HttpStatusCode.NotImplemented, CalendarResourceDeleteDispatchCode.UnsupportedCapability)]
+    [InlineData(HttpStatusCode.InsufficientStorage, CalendarResourceDeleteDispatchCode.UpstreamUnavailable)]
+    [InlineData(HttpStatusCode.RequestTimeout, CalendarResourceDeleteDispatchCode.PossiblyDispatched)]
+    [InlineData(HttpStatusCode.ServiceUnavailable, CalendarResourceDeleteDispatchCode.PossiblyDispatched)]
+    [InlineData(HttpStatusCode.BadRequest, CalendarResourceDeleteDispatchCode.UpstreamProtocolError)]
+    public async Task DeleteAsync_MapsDefinitiveHttpOutcome(
+        HttpStatusCode statusCode,
+        CalendarResourceDeleteDispatchCode expectedCode)
+    {
+        using var httpClient = new HttpClient(new Handler(_ =>
+            Task.FromResult(new HttpResponseMessage(statusCode))));
+        var sut = new CalendarResourceDeleteProtocol(httpClient, new Uri("https://example.com"));
+
+        var result = await sut.DeleteAsync(
+            new CalendarResourceDeleteRequest("https://example.com/tasks/a.ics", "\"r1\""),
+            TestContext.Current.CancellationToken);
+
+        result.Code.ShouldBe(expectedCode);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_ClassifiesTransportFailureAfterSingleAttemptAsPossiblyDispatched()
+    {
+        var sendCount = 0;
+        using var httpClient = new HttpClient(new Handler(_ =>
+        {
+            sendCount++;
+            throw new HttpRequestException("private transport detail");
+        }));
+        var sut = new CalendarResourceDeleteProtocol(httpClient, new Uri("https://example.com"));
+
+        var result = await sut.DeleteAsync(
+            new CalendarResourceDeleteRequest("https://example.com/tasks/a.ics", "\"r1\""),
+            TestContext.Current.CancellationToken);
+
+        result.Code.ShouldBe(CalendarResourceDeleteDispatchCode.PossiblyDispatched);
+        sendCount.ShouldBe(1);
+    }
+
+    [Theory]
+    [InlineData(3, 3_000)]
+    [InlineData(3_000_000, int.MaxValue)]
+    public async Task DeleteAsync_RateLimitPreservesBoundedDeltaRetryAfter(
+        int delaySeconds,
+        int expectedMilliseconds)
+    {
+        using var httpClient = new HttpClient(new Handler(_ =>
+        {
+            var response = new HttpResponseMessage(HttpStatusCode.TooManyRequests);
+            response.Headers.RetryAfter = new System.Net.Http.Headers.RetryConditionHeaderValue(
+                TimeSpan.FromSeconds(delaySeconds));
+            return Task.FromResult(response);
+        }));
+        var sut = new CalendarResourceDeleteProtocol(httpClient, new Uri("https://example.com"));
+
+        var result = await sut.DeleteAsync(
+            new CalendarResourceDeleteRequest("https://example.com/tasks/a.ics", "\"r1\""),
+            TestContext.Current.CancellationToken);
+
+        result.Code.ShouldBe(CalendarResourceDeleteDispatchCode.UpstreamRateLimited);
+        result.RetryAfterMilliseconds.ShouldBe(expectedMilliseconds);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_SendsOneExactStrongConditionalDeleteAcrossSafeRedirect()
+    {
+        var requests = new List<(string Href, string Method, string IfMatch, bool HasContent)>();
+        using var httpClient = new HttpClient(new Handler(request =>
+        {
+            requests.Add((
+                request.RequestUri!.AbsoluteUri,
+                request.Method.Method,
+                request.Headers.IfMatch.Single().ToString(),
+                request.Content is not null));
+            return Task.FromResult(requests.Count == 1
+                ? new HttpResponseMessage(HttpStatusCode.TemporaryRedirect)
+                {
+                    Headers = { Location = new Uri("https://example.com/calendars/user/tasks/canonical.ics") }
+                }
+                : new HttpResponseMessage(HttpStatusCode.NoContent));
+        }));
+        var sut = new CalendarResourceDeleteProtocol(httpClient, new Uri("https://example.com"));
+
+        var result = await sut.DeleteAsync(
+            new CalendarResourceDeleteRequest(
+                "https://example.com/calendars/user/tasks/reviewed.ics",
+                "\"r1\""),
+            TestContext.Current.CancellationToken);
+
+        result.Code.ShouldBe(CalendarResourceDeleteDispatchCode.Dispatched);
+        requests.ShouldBe([
+            ("https://example.com/calendars/user/tasks/reviewed.ics", "DELETE", "\"r1\"", false),
+            ("https://example.com/calendars/user/tasks/canonical.ics", "DELETE", "\"r1\"", false)
+        ]);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_RejectsCrossOriginRedirectBeforeSecondDispatch()
+    {
+        var sendCount = 0;
+        using var httpClient = new HttpClient(new Handler(_ =>
+        {
+            sendCount++;
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.TemporaryRedirect)
+            {
+                Headers = { Location = new Uri("https://other.example/tasks/a.ics") }
+            });
+        }));
+        var sut = new CalendarResourceDeleteProtocol(httpClient, new Uri("https://example.com"));
+
+        var result = await sut.DeleteAsync(
+            new CalendarResourceDeleteRequest("https://example.com/tasks/a.ics", "\"r1\""),
+            TestContext.Current.CancellationToken);
+
+        result.Code.ShouldBe(CalendarResourceDeleteDispatchCode.UpstreamProtocolError);
+        sendCount.ShouldBe(1);
+    }
+
+    [Theory]
+    [InlineData(3, CalendarResourceDeleteDispatchCode.Dispatched, 4)]
+    [InlineData(4, CalendarResourceDeleteDispatchCode.UpstreamProtocolError, 4)]
+    public async Task DeleteAsync_EnforcesExactThreeRedirectCeiling(
+        int redirectResponses,
+        CalendarResourceDeleteDispatchCode expectedCode,
+        int expectedSendCount)
+    {
+        var sendCount = 0;
+        using var httpClient = new HttpClient(new Handler(_ =>
+        {
+            sendCount++;
+            return Task.FromResult(sendCount <= redirectResponses
+                ? new HttpResponseMessage(HttpStatusCode.PermanentRedirect)
+                {
+                    Headers = { Location = new Uri($"https://example.com/tasks/{sendCount}.ics") }
+                }
+                : new HttpResponseMessage(HttpStatusCode.NoContent));
+        }));
+        var sut = new CalendarResourceDeleteProtocol(httpClient, new Uri("https://example.com"));
+
+        var result = await sut.DeleteAsync(
+            new CalendarResourceDeleteRequest("https://example.com/tasks/a.ics", "\"r1\""),
+            TestContext.Current.CancellationToken);
+
+        result.Code.ShouldBe(expectedCode);
+        sendCount.ShouldBe(expectedSendCount);
+    }
+
+    private sealed class Handler(
+        Func<HttpRequestMessage, Task<HttpResponseMessage>> send) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken) => send(request);
+    }
+}

--- a/tests/DotnetAgents.CalDav.Core.Tests.Unit/Services/CalendarResourceDeleteServiceTests.cs
+++ b/tests/DotnetAgents.CalDav.Core.Tests.Unit/Services/CalendarResourceDeleteServiceTests.cs
@@ -1,0 +1,495 @@
+using System.Text;
+using DotnetAgents.CalDav.Core.Abstractions;
+using DotnetAgents.CalDav.Core.Configuration;
+using DotnetAgents.CalDav.Core.Models;
+using DotnetAgents.CalDav.Core.Services;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace DotnetAgents.CalDav.Core.Tests.Unit.Services;
+
+public sealed class CalendarResourceDeleteServiceTests
+{
+    [Theory]
+    [InlineData("", CalendarResourceDeleteCode.InvalidInput)]
+    [InlineData("r1", CalendarResourceDeleteCode.InvalidInput)]
+    [InlineData("W/\"r1\"", CalendarResourceDeleteCode.ConcurrencyUnavailable)]
+    [InlineData("*", CalendarResourceDeleteCode.InvalidInput)]
+    public async Task DeleteResourceAsync_RejectsInvalidOrWeakRevisionBeforeAnyNetwork(
+        string entityTag,
+        CalendarResourceDeleteCode expectedCode)
+    {
+        var client = Substitute.For<ICalendarClient>();
+        var sut = CreateService(client);
+
+        var result = await sut.DeleteResourceAsync(
+            new CalendarResourceRevisionReference(
+                "https://cal.example/tasks/reviewed.ics",
+                "reviewed-delete",
+                CalendarEntityKind.Todo,
+                entityTag),
+            CancellationToken.None);
+
+        result.Code.ShouldBe(expectedCode);
+        result.MutationState.ShouldBe(CalendarMutationState.NotAttempted);
+        await client.DidNotReceive().GetCalendarsAsync(Arg.Any<CancellationToken>());
+        await client.DidNotReceive().GetCalendarResourceAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await client.DidNotReceive().DeleteCalendarResourceAsync(
+            Arg.Any<CalendarResourceDeleteRequest>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Theory]
+    [InlineData("https://other.example/tasks/reviewed.ics")]
+    [InlineData("HTTPS://cal.example/tasks/reviewed.ics")]
+    [InlineData("https://user@cal.example/tasks/reviewed.ics")]
+    [InlineData("https://cal.example/tasks/reviewed.ics?view=full")]
+    [InlineData("https://cal.example/tasks/reviewed.ics#component")]
+    [InlineData("https://cal.example/tasks%2Freviewed.ics")]
+    [InlineData("https://cal.example/tasks%5Creviewed.ics")]
+    public async Task DeleteResourceAsync_RejectsUnsafeAbsoluteHrefBeforeDelete(string href)
+    {
+        var client = Substitute.For<ICalendarClient>();
+        var sut = CreateService(client);
+
+        var result = await sut.DeleteResourceAsync(
+            new CalendarResourceRevisionReference(
+                href,
+                "reviewed-delete",
+                CalendarEntityKind.Todo,
+                "\"r1\""),
+            CancellationToken.None);
+
+        result.Code.ShouldBe(CalendarResourceDeleteCode.InvalidInput);
+        result.MutationState.ShouldBe(CalendarMutationState.NotAttempted);
+        await client.DidNotReceive().GetCalendarsAsync(Arg.Any<CancellationToken>());
+        await client.DidNotReceive().GetCalendarResourceAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await client.DidNotReceive().DeleteCalendarResourceAsync(
+            Arg.Any<CalendarResourceDeleteRequest>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Theory]
+    [InlineData("uid", CalendarResourceDeleteCode.Conflict)]
+    [InlineData("kind", CalendarResourceDeleteCode.EntityKindMismatch)]
+    [InlineData("tag", CalendarResourceDeleteCode.Conflict)]
+    public async Task DeleteResourceAsync_RefetchesAndRejectsChangedRevisionOrOwnershipBeforeDelete(
+        string changedField,
+        CalendarResourceDeleteCode expectedCode)
+    {
+        const string calendarHref = "https://cal.example/tasks/";
+        const string resourceHref = "https://cal.example/tasks/reviewed.ics";
+        var client = Substitute.For<ICalendarClient>();
+        client.GetCalendarsAsync(Arg.Any<CancellationToken>()).Returns([TodoCalendar(calendarHref)]);
+        client.GetCalendarResourceAsync(resourceHref, Arg.Any<CancellationToken>()).Returns(
+            Resource(resourceHref, "\"current\"", "current-uid"));
+        var sut = CreateService(client);
+        var revision = new CalendarResourceRevisionReference(
+            resourceHref,
+            changedField == "uid" ? "reviewed-uid" : "current-uid",
+            changedField == "kind" ? CalendarEntityKind.Event : CalendarEntityKind.Todo,
+            changedField == "tag" ? "\"reviewed\"" : "\"current\"");
+
+        var result = await sut.DeleteResourceAsync(revision, CancellationToken.None);
+
+        result.Code.ShouldBe(expectedCode);
+        result.MutationState.ShouldBe(CalendarMutationState.NotAttempted);
+        result.CurrentSnapshot.ShouldNotBeNull();
+        result.CurrentSnapshot.EntityTag.ShouldBe("\"current\"");
+        await client.DidNotReceive().DeleteCalendarResourceAsync(
+            Arg.Any<CalendarResourceDeleteRequest>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Theory]
+    [InlineData("absent", CalendarResourceDeleteCode.Success, CalendarMutationState.Committed)]
+    [InlineData("unchanged", CalendarResourceDeleteCode.UpstreamUnavailable, CalendarMutationState.NotCommitted)]
+    [InlineData("changed", CalendarResourceDeleteCode.Indeterminate, CalendarMutationState.Unknown)]
+    [InlineData("unavailable", CalendarResourceDeleteCode.Indeterminate, CalendarMutationState.Unknown)]
+    public async Task DeleteResourceAsync_ReconcilesPossiblyDispatchedDeleteWithoutRetry(
+        string observation,
+        CalendarResourceDeleteCode expectedCode,
+        CalendarMutationState expectedState)
+    {
+        const string calendarHref = "https://cal.example/tasks/";
+        const string resourceHref = "https://cal.example/tasks/reviewed.ics";
+        const string entityTag = "\"r1\"";
+        var client = Substitute.For<ICalendarClient>();
+        client.GetCalendarsAsync(Arg.Any<CancellationToken>()).Returns([TodoCalendar(calendarHref)]);
+        var observed = observation switch
+        {
+            "absent" => new CalendarResourceRead(CalendarResourceReadCode.NotFound),
+            "unchanged" => Resource(resourceHref, entityTag, "reviewed-delete"),
+            "changed" => Resource(resourceHref, "\"r2\"", "reviewed-delete"),
+            _ => new CalendarResourceRead(CalendarResourceReadCode.UpstreamProtocolError)
+        };
+        client.GetCalendarResourceAsync(resourceHref, Arg.Any<CancellationToken>()).Returns(
+            Resource(resourceHref, entityTag, "reviewed-delete"),
+            observed);
+        client.DeleteCalendarResourceAsync(Arg.Any<CalendarResourceDeleteRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new CalendarResourceDeleteDispatchResult(CalendarResourceDeleteDispatchCode.PossiblyDispatched));
+        var sut = CreateService(client);
+
+        var result = await sut.DeleteResourceAsync(
+            new CalendarResourceRevisionReference(
+                resourceHref,
+                "reviewed-delete",
+                CalendarEntityKind.Todo,
+                entityTag),
+            CancellationToken.None);
+
+        result.Code.ShouldBe(expectedCode);
+        result.MutationState.ShouldBe(expectedState);
+        (result.DeletionReceipt is not null).ShouldBe(observation == "absent");
+        await client.Received(1).DeleteCalendarResourceAsync(
+            Arg.Any<CalendarResourceDeleteRequest>(),
+            Arg.Any<CancellationToken>());
+        await client.Received(2).GetCalendarResourceAsync(resourceHref, Arg.Any<CancellationToken>());
+    }
+
+    [Theory]
+    [InlineData(CalendarResourceDeleteDispatchCode.NotFound, CalendarResourceDeleteCode.NotFound)]
+    [InlineData(CalendarResourceDeleteDispatchCode.Conflict, CalendarResourceDeleteCode.Conflict)]
+    [InlineData(CalendarResourceDeleteDispatchCode.UnsupportedCapability, CalendarResourceDeleteCode.UnsupportedCapability)]
+    [InlineData(CalendarResourceDeleteDispatchCode.PayloadTooLarge, CalendarResourceDeleteCode.PayloadTooLarge)]
+    [InlineData(CalendarResourceDeleteDispatchCode.UpstreamUnauthorized, CalendarResourceDeleteCode.UpstreamUnauthorized)]
+    [InlineData(CalendarResourceDeleteDispatchCode.UpstreamForbidden, CalendarResourceDeleteCode.UpstreamForbidden)]
+    [InlineData(CalendarResourceDeleteDispatchCode.UpstreamRateLimited, CalendarResourceDeleteCode.UpstreamRateLimited)]
+    [InlineData(CalendarResourceDeleteDispatchCode.UpstreamUnavailable, CalendarResourceDeleteCode.UpstreamUnavailable)]
+    [InlineData(CalendarResourceDeleteDispatchCode.UpstreamProtocolError, CalendarResourceDeleteCode.UpstreamProtocolError)]
+    public async Task DeleteResourceAsync_MapsDefinitiveDeleteRejectionAsNotCommitted(
+        CalendarResourceDeleteDispatchCode dispatchCode,
+        CalendarResourceDeleteCode expectedCode)
+    {
+        const string calendarHref = "https://cal.example/tasks/";
+        const string resourceHref = "https://cal.example/tasks/reviewed.ics";
+        var client = Substitute.For<ICalendarClient>();
+        client.GetCalendarsAsync(Arg.Any<CancellationToken>()).Returns([TodoCalendar(calendarHref)]);
+        client.GetCalendarResourceAsync(resourceHref, Arg.Any<CancellationToken>()).Returns(
+            Resource(resourceHref, "\"r1\"", "reviewed-delete"));
+        client.DeleteCalendarResourceAsync(Arg.Any<CalendarResourceDeleteRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new CalendarResourceDeleteDispatchResult(dispatchCode));
+        var sut = CreateService(client);
+
+        var result = await sut.DeleteResourceAsync(
+            new CalendarResourceRevisionReference(
+                resourceHref,
+                "reviewed-delete",
+                CalendarEntityKind.Todo,
+                "\"r1\""),
+            CancellationToken.None);
+
+        result.Code.ShouldBe(expectedCode);
+        result.MutationState.ShouldBe(CalendarMutationState.NotCommitted);
+        await client.Received(1).DeleteCalendarResourceAsync(
+            Arg.Any<CalendarResourceDeleteRequest>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task DeleteResourceAsync_PreservesRateLimitRetryAfterAsNotCommitted()
+    {
+        const string calendarHref = "https://cal.example/tasks/";
+        const string resourceHref = "https://cal.example/tasks/reviewed.ics";
+        var client = Substitute.For<ICalendarClient>();
+        client.GetCalendarsAsync(Arg.Any<CancellationToken>()).Returns([TodoCalendar(calendarHref)]);
+        client.GetCalendarResourceAsync(resourceHref, Arg.Any<CancellationToken>()).Returns(
+            Resource(resourceHref, "\"r1\"", "reviewed-delete"));
+        client.DeleteCalendarResourceAsync(Arg.Any<CalendarResourceDeleteRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new CalendarResourceDeleteDispatchResult(
+                CalendarResourceDeleteDispatchCode.UpstreamRateLimited,
+                RetryAfterMilliseconds: 3_000));
+        var sut = CreateService(client);
+
+        var result = await sut.DeleteResourceAsync(
+            new CalendarResourceRevisionReference(
+                resourceHref,
+                "reviewed-delete",
+                CalendarEntityKind.Todo,
+                "\"r1\""),
+            CancellationToken.None);
+
+        result.Code.ShouldBe(CalendarResourceDeleteCode.UpstreamRateLimited);
+        result.MutationState.ShouldBe(CalendarMutationState.NotCommitted);
+        result.RetryAfterMilliseconds.ShouldBe(3_000);
+    }
+
+    [Fact]
+    public async Task DeleteResourceAsync_ConflictRefetchesCurrentAuthorizedSnapshot()
+    {
+        const string calendarHref = "https://cal.example/tasks/";
+        const string resourceHref = "https://cal.example/tasks/reviewed.ics";
+        var client = Substitute.For<ICalendarClient>();
+        client.GetCalendarsAsync(Arg.Any<CancellationToken>()).Returns([TodoCalendar(calendarHref)]);
+        client.GetCalendarResourceAsync(resourceHref, Arg.Any<CancellationToken>()).Returns(
+            Resource(resourceHref, "\"r1\"", "reviewed-delete"),
+            Resource(resourceHref, "\"r2\"", "reviewed-delete"));
+        client.DeleteCalendarResourceAsync(Arg.Any<CalendarResourceDeleteRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new CalendarResourceDeleteDispatchResult(CalendarResourceDeleteDispatchCode.Conflict));
+        var sut = CreateService(client);
+
+        var result = await sut.DeleteResourceAsync(
+            new CalendarResourceRevisionReference(
+                resourceHref,
+                "reviewed-delete",
+                CalendarEntityKind.Todo,
+                "\"r1\""),
+            CancellationToken.None);
+
+        result.Code.ShouldBe(CalendarResourceDeleteCode.Conflict);
+        result.MutationState.ShouldBe(CalendarMutationState.NotCommitted);
+        result.CurrentSnapshot.ShouldNotBeNull().EntityTag.ShouldBe("\"r2\"");
+        await client.Received(2).GetCalendarResourceAsync(resourceHref, Arg.Any<CancellationToken>());
+        await client.Received(1).DeleteCalendarResourceAsync(
+            Arg.Any<CalendarResourceDeleteRequest>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task DeleteResourceAsync_UsesReviewedStrongRevisionAndReturnsReceiptOnlyAfterVerifiedAbsence()
+    {
+        const string calendarHref = "https://cal.example/tasks/";
+        const string resourceHref = "https://cal.example/tasks/reviewed.ics";
+        const string entityTag = "\"r1\"";
+        var client = Substitute.For<ICalendarClient>();
+        client.GetCalendarsAsync(Arg.Any<CancellationToken>()).Returns([TodoCalendar(calendarHref)]);
+        client.GetCalendarResourceAsync(resourceHref, Arg.Any<CancellationToken>()).Returns(
+            Resource(resourceHref, entityTag, "reviewed-delete"),
+            new CalendarResourceRead(CalendarResourceReadCode.NotFound));
+        client.DeleteCalendarResourceAsync(Arg.Any<CalendarResourceDeleteRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new CalendarResourceDeleteDispatchResult(CalendarResourceDeleteDispatchCode.Dispatched));
+        var sut = CreateService(client);
+        var revision = new CalendarResourceRevisionReference(
+            resourceHref,
+            "reviewed-delete",
+            CalendarEntityKind.Todo,
+            entityTag);
+
+        var result = await sut.DeleteResourceAsync(revision, CancellationToken.None);
+
+        result.Code.ShouldBe(CalendarResourceDeleteCode.Success);
+        result.MutationState.ShouldBe(CalendarMutationState.Committed);
+        result.DeletionReceipt.ShouldBe(new CalendarResourceDeletionReceipt(
+            resourceHref,
+            "reviewed-delete",
+            CalendarEntityKind.Todo,
+            entityTag));
+        await client.Received(1).DeleteCalendarResourceAsync(
+            new CalendarResourceDeleteRequest(resourceHref, entityTag),
+            Arg.Any<CancellationToken>());
+        await client.Received(2).GetCalendarResourceAsync(resourceHref, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task DeleteResourceAsync_DefiniteDispatchVerificationOutlivesCallerCancellation()
+    {
+        const string calendarHref = "https://cal.example/tasks/";
+        const string resourceHref = "https://cal.example/tasks/reviewed.ics";
+        using var caller = new CancellationTokenSource();
+        var readTokens = new List<CancellationToken>();
+        var client = Substitute.For<ICalendarClient>();
+        client.GetCalendarsAsync(Arg.Any<CancellationToken>()).Returns([TodoCalendar(calendarHref)]);
+        var readIndex = 0;
+        client.GetCalendarResourceAsync(resourceHref, Arg.Any<CancellationToken>()).Returns(call =>
+        {
+            readTokens.Add(call.Arg<CancellationToken>());
+            return readIndex++ == 0
+                ? Resource(resourceHref, "\"r1\"", "reviewed-delete")
+                : new CalendarResourceRead(CalendarResourceReadCode.NotFound);
+        });
+        client.DeleteCalendarResourceAsync(Arg.Any<CalendarResourceDeleteRequest>(), Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                caller.Cancel();
+                return new CalendarResourceDeleteDispatchResult(CalendarResourceDeleteDispatchCode.Dispatched);
+            });
+        var sut = CreateService(client);
+
+        var result = await sut.DeleteResourceAsync(
+            new CalendarResourceRevisionReference(
+                resourceHref,
+                "reviewed-delete",
+                CalendarEntityKind.Todo,
+                "\"r1\""),
+            caller.Token);
+
+        result.Code.ShouldBe(CalendarResourceDeleteCode.Success);
+        readTokens.Count.ShouldBe(2);
+        readTokens[0].CanBeCanceled.ShouldBeTrue();
+        readTokens[1].IsCancellationRequested.ShouldBeFalse();
+    }
+
+    [Theory]
+    [InlineData("io")]
+    [InlineData("xml")]
+    [InlineData("protocol")]
+    [InlineData("unsupported")]
+    [InlineData("unexpected")]
+    public async Task DeleteResourceAsync_DefiniteDispatchVerificationFailureIsCommittedButUnverified(
+        string failure)
+    {
+        const string calendarHref = "https://cal.example/tasks/";
+        const string resourceHref = "https://cal.example/tasks/reviewed.ics";
+        var client = Substitute.For<ICalendarClient>();
+        client.GetCalendarsAsync(Arg.Any<CancellationToken>()).Returns([TodoCalendar(calendarHref)]);
+        var readIndex = 0;
+        client.GetCalendarResourceAsync(resourceHref, Arg.Any<CancellationToken>()).Returns(_ =>
+            readIndex++ == 0
+                ? Task.FromResult(Resource(resourceHref, "\"r1\"", "reviewed-delete"))
+                : Task.FromException<CalendarResourceRead>(failure switch
+                {
+                    "io" => new IOException("secret transport failure"),
+                    "xml" => new System.Xml.XmlException("secret xml failure"),
+                    "protocol" => new CalendarDiscoveryProtocolException("secret protocol failure"),
+                    "unsupported" => new CalendarDiscoveryUnsupportedCapabilityException("secret capability failure"),
+                    _ => new InvalidOperationException("secret unexpected failure")
+                }));
+        client.DeleteCalendarResourceAsync(Arg.Any<CalendarResourceDeleteRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new CalendarResourceDeleteDispatchResult(CalendarResourceDeleteDispatchCode.Dispatched));
+        var sut = CreateService(client);
+
+        var result = await sut.DeleteResourceAsync(
+            new CalendarResourceRevisionReference(
+                resourceHref,
+                "reviewed-delete",
+                CalendarEntityKind.Todo,
+                "\"r1\""),
+            CancellationToken.None);
+
+        result.Code.ShouldBe(CalendarResourceDeleteCode.CommittedButUnverified);
+        result.MutationState.ShouldBe(CalendarMutationState.Committed);
+        result.DeletionReceipt.ShouldBeNull();
+    }
+
+    [Theory]
+    [InlineData("io", CalendarResourceDeleteCode.UpstreamUnavailable)]
+    [InlineData("cancel", CalendarResourceDeleteCode.UpstreamUnavailable)]
+    [InlineData("protocol", CalendarResourceDeleteCode.UpstreamProtocolError)]
+    [InlineData("unsupported", CalendarResourceDeleteCode.UnsupportedCapability)]
+    public async Task DeleteResourceAsync_PreflightFailureIsNotAttemptedAndNeverDeletes(
+        string failure,
+        CalendarResourceDeleteCode expectedCode)
+    {
+        var client = Substitute.For<ICalendarClient>();
+        client.GetCalendarsAsync(Arg.Any<CancellationToken>()).Returns<IReadOnlyList<CalendarDescriptor>>(_ =>
+            throw failure switch
+            {
+                "io" => new IOException("secret io"),
+                "cancel" => new OperationCanceledException("secret cancel"),
+                "protocol" => new CalendarDiscoveryProtocolException("secret protocol"),
+                _ => new CalendarDiscoveryUnsupportedCapabilityException("secret unsupported")
+            });
+        var sut = CreateService(client);
+
+        var result = await sut.DeleteResourceAsync(
+            new CalendarResourceRevisionReference(
+                "https://cal.example/tasks/reviewed.ics",
+                "reviewed-delete",
+                CalendarEntityKind.Todo,
+                "\"r1\""),
+            CancellationToken.None);
+
+        result.Code.ShouldBe(expectedCode);
+        result.MutationState.ShouldBe(CalendarMutationState.NotAttempted);
+        await client.DidNotReceive().DeleteCalendarResourceAsync(
+            Arg.Any<CalendarResourceDeleteRequest>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Theory]
+    [InlineData(401, CalendarResourceDeleteCode.UpstreamUnauthorized, false)]
+    [InlineData(403, CalendarResourceDeleteCode.UpstreamForbidden, false)]
+    [InlineData(404, CalendarResourceDeleteCode.UpstreamProtocolError, false)]
+    [InlineData(409, CalendarResourceDeleteCode.Conflict, false)]
+    [InlineData(412, CalendarResourceDeleteCode.Conflict, false)]
+    [InlineData(413, CalendarResourceDeleteCode.PayloadTooLarge, false)]
+    [InlineData(429, CalendarResourceDeleteCode.UpstreamRateLimited, true)]
+    [InlineData(405, CalendarResourceDeleteCode.UnsupportedCapability, false)]
+    [InlineData(501, CalendarResourceDeleteCode.UnsupportedCapability, false)]
+    [InlineData(507, CalendarResourceDeleteCode.UpstreamUnavailable, false)]
+    [InlineData(503, CalendarResourceDeleteCode.UpstreamUnavailable, true)]
+    public async Task DeleteResourceAsync_MapsPreflightHttpStatusWithoutDelete(
+        int statusCode,
+        CalendarResourceDeleteCode expectedCode,
+        bool expectedRetryable)
+    {
+        var client = Substitute.For<ICalendarClient>();
+        client.GetCalendarsAsync(Arg.Any<CancellationToken>()).Returns<IReadOnlyList<CalendarDescriptor>>(_ =>
+            throw new HttpRequestException(
+                "secret upstream response",
+                inner: null,
+                (System.Net.HttpStatusCode)statusCode));
+        var sut = CreateService(client);
+
+        var result = await sut.DeleteResourceAsync(
+            new CalendarResourceRevisionReference(
+                "https://cal.example/tasks/reviewed.ics",
+                "reviewed-delete",
+                CalendarEntityKind.Todo,
+                "\"r1\""),
+            CancellationToken.None);
+
+        result.Code.ShouldBe(expectedCode);
+        result.MutationState.ShouldBe(CalendarMutationState.NotAttempted);
+        result.Retryable.ShouldBe(expectedRetryable);
+        await client.DidNotReceive().DeleteCalendarResourceAsync(
+            Arg.Any<CalendarResourceDeleteRequest>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task DeleteResourceAsync_FetchedWeakRevisionReturnsConcurrencyUnavailableWithoutDelete()
+    {
+        const string calendarHref = "https://cal.example/tasks/";
+        const string resourceHref = "https://cal.example/tasks/reviewed.ics";
+        var client = Substitute.For<ICalendarClient>();
+        client.GetCalendarsAsync(Arg.Any<CancellationToken>()).Returns([TodoCalendar(calendarHref)]);
+        client.GetCalendarResourceAsync(resourceHref, Arg.Any<CancellationToken>()).Returns(
+            new CalendarResourceRead(CalendarResourceReadCode.ConcurrencyUnavailable));
+        var sut = CreateService(client);
+
+        var result = await sut.DeleteResourceAsync(
+            new CalendarResourceRevisionReference(
+                resourceHref,
+                "reviewed-delete",
+                CalendarEntityKind.Todo,
+                "\"r1\""),
+            CancellationToken.None);
+
+        result.Code.ShouldBe(CalendarResourceDeleteCode.ConcurrencyUnavailable);
+        result.MutationState.ShouldBe(CalendarMutationState.NotAttempted);
+        await client.DidNotReceive().DeleteCalendarResourceAsync(
+            Arg.Any<CalendarResourceDeleteRequest>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    private static CalendarService CreateService(ICalendarClient client) => new(
+        client,
+        Options.Create(new CalDavOptions
+        {
+            BaseUrl = "https://cal.example",
+            Username = "user",
+            Password = "secret",
+            CalendarHrefs = "https://cal.example/tasks/"
+        }),
+        Substitute.For<ILogger<CalendarService>>());
+
+    private static CalendarDescriptor TodoCalendar(string href) => new()
+    {
+        Href = href,
+        DisplayName = "Tasks",
+        DisplayNameProvenance = DisplayNameProvenance.DavDisplayName,
+        EventSupport = EntityKindSupport.NotAdvertised,
+        TodoSupport = EntityKindSupport.Advertised
+    };
+
+    private static CalendarResourceRead Resource(string href, string entityTag, string uid)
+    {
+        var content = Encoding.UTF8.GetBytes(
+            $"BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Tests//EN\r\nBEGIN:VTODO\r\nUID:{uid}\r\nDTSTAMP:20260815T120000Z\r\nEND:VTODO\r\nEND:VCALENDAR\r\n");
+        return CalendarResourceRead.Success(href, entityTag, content);
+    }
+}

--- a/tests/DotnetAgents.CalDav.Core.Tests.Unit/Services/CalendarServiceTests.cs
+++ b/tests/DotnetAgents.CalDav.Core.Tests.Unit/Services/CalendarServiceTests.cs
@@ -3668,6 +3668,10 @@ public sealed class CalendarServiceTests
         public Task<CalendarResourceCreateResult> CreateCalendarResourceAsync(
             CalendarResourceCreateRequest request,
             CancellationToken cancellationToken) => transport.CreateCalendarResourceAsync(request, cancellationToken);
+
+        public Task<CalendarResourceDeleteDispatchResult> DeleteCalendarResourceAsync(
+            CalendarResourceDeleteRequest request,
+            CancellationToken cancellationToken) => transport.DeleteCalendarResourceAsync(request, cancellationToken);
     }
 
     private sealed class DelegatingQueryCalendarClient(
@@ -3695,6 +3699,10 @@ public sealed class CalendarServiceTests
         public Task<CalendarResourceCreateResult> CreateCalendarResourceAsync(
             CalendarResourceCreateRequest request,
             CancellationToken cancellationToken) => transport.CreateCalendarResourceAsync(request, cancellationToken);
+
+        public Task<CalendarResourceDeleteDispatchResult> DeleteCalendarResourceAsync(
+            CalendarResourceDeleteRequest request,
+            CancellationToken cancellationToken) => transport.DeleteCalendarResourceAsync(request, cancellationToken);
     }
 
     private sealed class RedirectHttpMessageHandler(Func<HttpRequestMessage, HttpResponseMessage> handler) : HttpMessageHandler

--- a/tests/DotnetAgents.CalDav.IntegrationTests/CalendarMcpRawStdioTests.cs
+++ b/tests/DotnetAgents.CalDav.IntegrationTests/CalendarMcpRawStdioTests.cs
@@ -1,9 +1,13 @@
+using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Net;
 using System.Net.Sockets;
 using System.Text;
 using System.Text.Json;
 using DotnetAgents.CalDav.Mcp.Tools;
+using ModelContextProtocol;
+using ModelContextProtocol.Client;
+using ModelContextProtocol.Protocol;
 using Shouldly;
 using Xunit;
 
@@ -12,6 +16,179 @@ namespace DotnetAgents.CalDav.IntegrationTests;
 /// <summary>Exercises raw JSON evidence that the SDK's dictionary client cannot represent.</summary>
 public sealed class CalendarMcpRawStdioTests
 {
+    [Fact]
+    public async Task CalendarResourceDelete_NativeSdkCompletesMrtrOverStdioWithoutDocker()
+    {
+        await using var server = new DeleteServer();
+        var stderr = new ConcurrentQueue<string>();
+        var elicitationCount = 0;
+        var transport = new StdioClientTransport(new StdioClientTransportOptions
+        {
+            Command = "dotnet",
+            Arguments = [GetServerAssemblyPath()],
+            WorkingDirectory = AppContext.BaseDirectory,
+            InheritEnvironmentVariables = true,
+            EnvironmentVariables = new Dictionary<string, string?>
+            {
+                ["CALDAV_URL"] = server.BaseUrl,
+                ["CALDAV_USERNAME"] = "test",
+                ["CALDAV_PASSWORD"] = "test",
+                ["CALDAV_CALENDAR_HREFS"] = server.CalendarHref
+            },
+            StandardErrorLines = stderr.Enqueue
+        });
+        var options = new McpClientOptions
+        {
+            ProtocolVersion = "2026-07-28",
+            DiscoverProbeTimeout = TimeSpan.FromSeconds(10),
+            Handlers = new McpClientHandlers
+            {
+                ElicitationHandler = (request, _) =>
+                {
+                    Interlocked.Increment(ref elicitationCount);
+                    var schema = request.ShouldNotBeNull().RequestedSchema.ShouldNotBeNull();
+                    schema.Properties.ShouldNotBeNull().ShouldContainKey("confirm");
+                    return ValueTask.FromResult(new ElicitResult
+                    {
+                        Action = "accept",
+                        Content = new Dictionary<string, JsonElement>
+                        {
+                            ["confirm"] = JsonSerializer.SerializeToElement(true)
+                        }
+                    });
+                }
+            }
+        };
+        using var timeout = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        timeout.CancelAfter(TimeSpan.FromSeconds(20));
+        await using var client = await McpClient.CreateAsync(transport, options, cancellationToken: timeout.Token);
+
+        var result = await client.CallToolAsync(
+            "calendar_resources.delete",
+            new Dictionary<string, object?>
+            {
+                ["revision"] = new Dictionary<string, object?>
+                {
+                    ["href"] = server.ResourceHref,
+                    ["entityUid"] = "stdio-delete-1",
+                    ["entityKind"] = "todo",
+                    ["entityTag"] = "\"r1\""
+                }
+            },
+            cancellationToken: timeout.Token);
+
+        result.IsError.ShouldBe(false, result.StructuredContent?.ToString());
+        var structured = result.StructuredContent!.Value;
+        structured.GetProperty("outcome").GetString().ShouldBe("success");
+        structured.GetProperty("mutationState").GetString().ShouldBe("committed");
+        structured.GetProperty("deletionReceipt").GetProperty("consumedEntityTag").GetString().ShouldBe("\"r1\"");
+        elicitationCount.ShouldBe(1);
+        server.DeleteCount.ShouldBe(1);
+        server.ObservedIfMatch.ShouldBe("\"r1\"");
+        server.IsDeleted.ShouldBeTrue();
+        JsonSerializer.Serialize(result).ShouldNotContain("Private reviewed delete");
+        stderr.ShouldBeEmpty();
+    }
+
+    [Theory]
+    [InlineData("decline")]
+    [InlineData("cancel")]
+    public async Task CalendarResourceDelete_NativeSdkDeclineOrCancelMakesNoDelete(string action)
+    {
+        await using var server = new DeleteServer();
+        var stderr = new ConcurrentQueue<string>();
+        var transport = CreateDeleteTransport(server, stderr);
+        var options = new McpClientOptions
+        {
+            ProtocolVersion = "2026-07-28",
+            DiscoverProbeTimeout = TimeSpan.FromSeconds(10),
+            Handlers = new McpClientHandlers
+            {
+                ElicitationHandler = (_, _) => ValueTask.FromResult(new ElicitResult { Action = action })
+            }
+        };
+        using var timeout = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        timeout.CancelAfter(TimeSpan.FromSeconds(20));
+        await using var client = await McpClient.CreateAsync(transport, options, cancellationToken: timeout.Token);
+
+        var result = await CallDeleteAsync(client, server.ResourceHref, timeout.Token);
+
+        result.IsError.ShouldBe(false);
+        result.StructuredContent!.Value.GetProperty("outcome").GetString().ShouldBe("confirmation_declined");
+        result.StructuredContent.Value.GetProperty("mutationState").GetString().ShouldBe("not_attempted");
+        server.DeleteCount.ShouldBe(0);
+        server.IsDeleted.ShouldBeFalse();
+        stderr.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task CalendarResourceDelete_LegacySdkIsRejectedAtProtocolHandshakeBeforeDelete()
+    {
+        await using var server = new DeleteServer();
+        var stderr = new ConcurrentQueue<string>();
+        var transport = CreateDeleteTransport(server, stderr);
+        var options = new McpClientOptions
+        {
+            ProtocolVersion = "2025-06-18",
+            DiscoverProbeTimeout = TimeSpan.FromSeconds(10)
+        };
+        using var timeout = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        timeout.CancelAfter(TimeSpan.FromSeconds(20));
+        await Should.ThrowAsync<UnsupportedProtocolVersionException>(async () =>
+        {
+            await using var client = await McpClient.CreateAsync(transport, options, cancellationToken: timeout.Token);
+        });
+        server.DeleteCount.ShouldBe(0);
+    }
+
+    [Theory]
+    [InlineData("changed_args")]
+    [InlineData("tampered_state")]
+    public async Task CalendarResourceDelete_RawMrtrRejectsChangedArgumentsOrTamperedState(string mismatch)
+    {
+        await using var server = new DeleteServer();
+
+        var result = await InvokeRawDeleteMrtrMismatchAsync(server, mismatch);
+
+        AssertTypedError(result, "confirmation_mismatch", "mrtr");
+        result.GetProperty("structuredContent").GetProperty("mutationState").GetString().ShouldBe("not_attempted");
+        server.DeleteCount.ShouldBe(0);
+        server.IsDeleted.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task CalendarResourceDelete_RootDuplicateRevisionReturnsTypedInvalidInputBeforeNetwork()
+    {
+        const string request = """
+            {"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"calendar_resources.delete","arguments":{"revision":{"href":"https://cal.example/tasks/a.ics","entityUid":"private-1","entityKind":"todo","entityTag":"\"r1\""},"revision":{"href":"https://cal.example/tasks/b.ics","entityUid":"private-2","entityKind":"todo","entityTag":"\"r2\""}}}}
+            """;
+
+        var result = await InvokeRawAsync(request);
+
+        AssertTypedError(result, "invalid_input", "schemaLexicalDiscriminator");
+        result.ToString().ShouldNotContain("private-1");
+        result.ToString().ShouldNotContain("private-2");
+    }
+
+    [Theory]
+    [InlineData(262_144, "invalid_input", "schemaLexicalDiscriminator")]
+    [InlineData(262_145, "payload_too_large", "admissionAndPayload")]
+    public async Task CalendarResourceDelete_EnforcesExact256KiBArgumentBoundary(
+        int argumentBytes,
+        string expectedCode,
+        string expectedPhase)
+    {
+        var arguments = DeleteArgumentsAtSize(argumentBytes);
+        Encoding.UTF8.GetByteCount(arguments).ShouldBe(argumentBytes);
+        var request = "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/call\",\"params\":{\"name\":\"calendar_resources.delete\",\"arguments\":"
+            + arguments
+            + "}}";
+
+        var result = await InvokeRawAsync(request);
+
+        AssertTypedError(result, expectedCode, expectedPhase);
+    }
+
     [Theory]
     [InlineData("events.create", "event", "private-event-marker")]
     [InlineData("todos.create", "todo", "private-todo-marker")]
@@ -199,6 +376,136 @@ public sealed class CalendarMcpRawStdioTests
         }
     }
 
+    private static async Task<JsonElement> InvokeRawDeleteMrtrMismatchAsync(
+        DeleteServer server,
+        string mismatch)
+    {
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(20));
+        using var process = StartServer(server.BaseUrl, server.CalendarHref);
+        var arguments = DeleteArguments(server.ResourceHref, "stdio-delete-1");
+        try
+        {
+            await process.StandardInput.WriteLineAsync(
+                "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/call\",\"params\":{\"_meta\":{\"io.modelcontextprotocol/protocolVersion\":\"2026-07-28\",\"io.modelcontextprotocol/clientInfo\":{\"name\":\"raw-test\",\"version\":\"1\"},\"io.modelcontextprotocol/clientCapabilities\":{}},\"name\":\"calendar_resources.delete\",\"arguments\":"
+                + arguments
+                + "}}");
+            await process.StandardInput.FlushAsync(timeout.Token);
+            var first = await ReadResponseAsync(process, 2, timeout.Token);
+            first.TryGetProperty("result", out var inputRequired).ShouldBeTrue(first.ToString());
+            inputRequired.TryGetProperty("inputRequests", out var inputRequests)
+                .ShouldBeTrue(inputRequired.ToString());
+            inputRequests.TryGetProperty("confirm_delete", out _).ShouldBeTrue();
+            var state = inputRequired.GetProperty("requestState").GetString();
+            state.ShouldNotBeNullOrWhiteSpace();
+            if (mismatch == "tampered_state")
+                state = $"{state![..^1]}{(state[^1] == 'A' ? 'B' : 'A')}";
+            else
+                arguments = DeleteArguments(server.ResourceHref, "changed-uid");
+            var retry = JsonSerializer.Serialize(new
+            {
+                jsonrpc = "2.0",
+                id = 3,
+                method = "tools/call",
+                @params = new
+                {
+                    _meta = new Dictionary<string, object?>
+                    {
+                        ["io.modelcontextprotocol/protocolVersion"] = "2026-07-28",
+                        ["io.modelcontextprotocol/clientInfo"] = new { name = "raw-test", version = "1" },
+                        ["io.modelcontextprotocol/clientCapabilities"] = new { }
+                    },
+                    name = "calendar_resources.delete",
+                    arguments = JsonSerializer.Deserialize<JsonElement>(arguments),
+                    requestState = state,
+                    inputResponses = new Dictionary<string, object?>
+                    {
+                        ["confirm_delete"] = new
+                        {
+                            action = "accept",
+                            content = new { confirm = true }
+                        }
+                    }
+                }
+            });
+            await process.StandardInput.WriteLineAsync(retry);
+            await process.StandardInput.FlushAsync(timeout.Token);
+            var response = await ReadResponseAsync(process, 3, timeout.Token);
+            process.StandardInput.Close();
+            await process.WaitForExitAsync(timeout.Token);
+            (await process.StandardError.ReadToEndAsync(timeout.Token)).ShouldBeEmpty();
+            return response.GetProperty("result").Clone();
+        }
+        finally
+        {
+            if (!process.HasExited)
+                process.Kill(entireProcessTree: true);
+        }
+    }
+
+    private static StdioClientTransport CreateDeleteTransport(
+        DeleteServer server,
+        ConcurrentQueue<string> stderr) => new(new StdioClientTransportOptions
+        {
+            Command = "dotnet",
+            Arguments = [GetServerAssemblyPath()],
+            WorkingDirectory = AppContext.BaseDirectory,
+            InheritEnvironmentVariables = true,
+            EnvironmentVariables = new Dictionary<string, string?>
+            {
+                ["CALDAV_URL"] = server.BaseUrl,
+                ["CALDAV_USERNAME"] = "test",
+                ["CALDAV_PASSWORD"] = "test",
+                ["CALDAV_CALENDAR_HREFS"] = server.CalendarHref
+            },
+            StandardErrorLines = stderr.Enqueue
+        });
+
+    private static Task<CallToolResult> CallDeleteAsync(
+        McpClient client,
+        string resourceHref,
+        CancellationToken cancellationToken) => client.CallToolAsync(
+            "calendar_resources.delete",
+            new Dictionary<string, object?>
+            {
+                ["revision"] = new Dictionary<string, object?>
+                {
+                    ["href"] = resourceHref,
+                    ["entityUid"] = "stdio-delete-1",
+                    ["entityKind"] = "todo",
+                    ["entityTag"] = "\"r1\""
+                }
+            },
+            cancellationToken: cancellationToken).AsTask();
+
+    private static string DeleteArguments(string resourceHref, string uid) => JsonSerializer.Serialize(new
+    {
+        revision = new
+        {
+            href = resourceHref,
+            entityUid = uid,
+            entityKind = "todo",
+            entityTag = "\"r1\""
+        }
+    });
+
+    private static string DeleteArgumentsAtSize(int argumentBytes)
+    {
+        var value = new Dictionary<string, object?>
+        {
+            ["revision"] = new
+            {
+                href = "https://cal.example/tasks/a.ics",
+                entityUid = "todo-1",
+                entityKind = "todo",
+                entityTag = "\"r1\""
+            },
+            ["padding"] = string.Empty
+        };
+        var fixedBytes = JsonSerializer.SerializeToUtf8Bytes(value).Length;
+        value["padding"] = new string('x', argumentBytes - fixedBytes);
+        return JsonSerializer.Serialize(value);
+    }
+
     private static Process StartServer(string baseUrl, string calendarHref)
     {
         var startInfo = new ProcessStartInfo("dotnet", GetServerAssemblyPath())
@@ -370,6 +677,139 @@ public sealed class CalendarMcpRawStdioTests
             var bytes = Encoding.UTF8.GetBytes(xml);
             response.StatusCode = (int)HttpStatusCode.MultiStatus;
             response.ContentType = "application/xml; charset=utf-8";
+            response.ContentLength64 = bytes.Length;
+            await response.OutputStream.WriteAsync(bytes, TestContext.Current.CancellationToken);
+            response.Close();
+        }
+
+        private static int ReservePort()
+        {
+            var listener = new TcpListener(IPAddress.Loopback, 0);
+            listener.Start();
+            var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+            listener.Stop();
+            return port;
+        }
+    }
+
+    private sealed class DeleteServer : IAsyncDisposable
+    {
+        private const string ResourcePath = "/calendars/test/entities/stdio-delete-1.ics";
+        private const string Content = "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Integration//EN\r\nBEGIN:VTODO\r\nUID:stdio-delete-1\r\nDTSTAMP:20260815T120000Z\r\nSUMMARY:Private reviewed delete\r\nEND:VTODO\r\nEND:VCALENDAR\r\n";
+        private readonly HttpListener _listener = new();
+        private readonly CancellationTokenSource _stopping = new();
+        private readonly Task _serve;
+        private int _deleteCount;
+        private int _deleted;
+        private string? _observedIfMatch;
+
+        public DeleteServer()
+        {
+            var port = ReservePort();
+            BaseUrl = $"http://127.0.0.1:{port}/";
+            CalendarHref = BaseUrl + "calendars/test/entities/";
+            ResourceHref = BaseUrl + ResourcePath.TrimStart('/');
+            _listener.Prefixes.Add(BaseUrl);
+            _listener.Start();
+            _serve = ServeAsync();
+        }
+
+        public string BaseUrl { get; }
+
+        public string CalendarHref { get; }
+
+        public string ResourceHref { get; }
+
+        public int DeleteCount => Volatile.Read(ref _deleteCount);
+
+        public bool IsDeleted => Volatile.Read(ref _deleted) != 0;
+
+        public string? ObservedIfMatch => _observedIfMatch;
+
+        public async ValueTask DisposeAsync()
+        {
+            await _stopping.CancelAsync();
+            _listener.Stop();
+            try
+            {
+                await _serve;
+            }
+            finally
+            {
+                _listener.Close();
+                _stopping.Dispose();
+            }
+        }
+
+        private async Task ServeAsync()
+        {
+            try
+            {
+                while (!_stopping.IsCancellationRequested)
+                {
+                    var context = await _listener.GetContextAsync();
+                    await RespondAsync(context);
+                }
+            }
+            catch (Exception exception) when (_stopping.IsCancellationRequested
+                && exception is HttpListenerException or ObjectDisposedException)
+            {
+                return;
+            }
+        }
+
+        private async Task RespondAsync(HttpListenerContext context)
+        {
+            switch (context.Request.HttpMethod)
+            {
+                case "PROPFIND":
+                    await WriteDiscoveryAsync(context.Response, context.Request.Url!.AbsolutePath);
+                    return;
+                case "GET":
+                    await GetAsync(context.Response);
+                    return;
+                case "DELETE":
+                    _observedIfMatch = context.Request.Headers["If-Match"];
+                    Interlocked.Increment(ref _deleteCount);
+                    Interlocked.Exchange(ref _deleted, 1);
+                    context.Response.StatusCode = (int)HttpStatusCode.NoContent;
+                    context.Response.Close();
+                    return;
+                default:
+                    context.Response.StatusCode = (int)HttpStatusCode.MethodNotAllowed;
+                    context.Response.Close();
+                    return;
+            }
+        }
+
+        private static async Task WriteDiscoveryAsync(HttpListenerResponse response, string path)
+        {
+            var body = path == "/"
+                ? "<d:response><d:href>/</d:href><d:propstat><d:prop><c:calendar-home-set><d:href>/calendars/test/</d:href></c:calendar-home-set></d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat></d:response>"
+                : "<d:response><d:href>/calendars/test/entities/</d:href><d:propstat><d:prop><d:resourcetype><c:calendar/></d:resourcetype><d:displayname>Entities</d:displayname><c:supported-calendar-component-set><c:comp name=\"VEVENT\"/><c:comp name=\"VTODO\"/></c:supported-calendar-component-set></d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat></d:response>";
+            var xml = "<?xml version=\"1.0\" encoding=\"utf-8\"?><d:multistatus xmlns:d=\"DAV:\" xmlns:c=\"urn:ietf:params:xml:ns:caldav\">"
+                + body
+                + "</d:multistatus>";
+            var bytes = Encoding.UTF8.GetBytes(xml);
+            response.StatusCode = (int)HttpStatusCode.MultiStatus;
+            response.ContentType = "application/xml; charset=utf-8";
+            response.ContentLength64 = bytes.Length;
+            await response.OutputStream.WriteAsync(bytes, TestContext.Current.CancellationToken);
+            response.Close();
+        }
+
+        private async Task GetAsync(HttpListenerResponse response)
+        {
+            if (IsDeleted)
+            {
+                response.StatusCode = (int)HttpStatusCode.NotFound;
+                response.Close();
+                return;
+            }
+            var bytes = Encoding.UTF8.GetBytes(Content);
+            response.StatusCode = (int)HttpStatusCode.OK;
+            response.ContentType = "text/calendar; charset=utf-8";
+            response.AddHeader("ETag", "\"r1\"");
             response.ContentLength64 = bytes.Length;
             await response.OutputStream.WriteAsync(bytes, TestContext.Current.CancellationToken);
             response.Close();

--- a/tests/DotnetAgents.CalDav.IntegrationTests/CalendarMcpStdioIntegrationTests.cs
+++ b/tests/DotnetAgents.CalDav.IntegrationTests/CalendarMcpStdioIntegrationTests.cs
@@ -2,6 +2,7 @@ using System.Collections.Concurrent;
 using System.Net;
 using System.Net.Http.Headers;
 using System.Text;
+using System.Text.Json;
 using DotnetAgents.CalDav.IntegrationTests.Fixtures;
 using ModelContextProtocol.Client;
 using ModelContextProtocol.Protocol;
@@ -55,6 +56,7 @@ public sealed class CalendarMcpStdioIntegrationTests
             "calendar_resources.get",
             "events.create",
             "todos.create",
+            "calendar_resources.delete",
             "list_task_lists",
             "show_tasks",
             "add_task",
@@ -398,6 +400,42 @@ public sealed class CalendarMcpStdioIntegrationTests
     }
 
     [Fact]
+    public async Task CalendarResourceDelete_ConfirmedMrtrDeletesOneReviewedResourceOverStdio()
+    {
+        const string content = "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Integration//EN\r\nBEGIN:VTODO\r\nUID:stdio-delete-1\r\nDTSTAMP:20260815T120000Z\r\nSUMMARY:Reviewed delete\r\nEND:VTODO\r\nEND:VCALENDAR\r\n";
+        var href = await PutResourceAsync("stdio-delete-1.ics", content);
+        var observed = await GetResourceAsync(href);
+        var stderr = new ConcurrentQueue<string>();
+        await using var client = await CreateClientAsync(stderr, exposeExact: false, confirmMutations: true);
+
+        var result = await client.CallToolAsync(
+            "calendar_resources.delete",
+            new Dictionary<string, object?>
+            {
+                ["revision"] = new Dictionary<string, object?>
+                {
+                    ["href"] = href,
+                    ["entityUid"] = "stdio-delete-1",
+                    ["entityKind"] = "todo",
+                    ["entityTag"] = observed.EntityTag
+                }
+            },
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        result.IsError.ShouldBe(false, result.StructuredContent?.ToString());
+        var structured = result.StructuredContent!.Value;
+        structured.GetProperty("outcome").GetString().ShouldBe("success");
+        structured.GetProperty("mutationState").GetString().ShouldBe("committed");
+        var receipt = structured.GetProperty("deletionReceipt");
+        receipt.GetProperty("href").GetString().ShouldBe(href);
+        receipt.GetProperty("entityUid").GetString().ShouldBe("stdio-delete-1");
+        receipt.GetProperty("entityKind").GetString().ShouldBe("todo");
+        receipt.GetProperty("consumedEntityTag").GetString().ShouldBe(observed.EntityTag);
+        (await GetStatusAsync(href)).ShouldBe(HttpStatusCode.NotFound);
+        stderr.ShouldBeEmpty();
+    }
+
+    [Fact]
     public async Task CalendarEntityQuery_InvalidRawShapesReturnTypedErrorsWithoutNetwork()
     {
         var stderr = new ConcurrentQueue<string>();
@@ -497,6 +535,7 @@ public sealed class CalendarMcpStdioIntegrationTests
             "calendar_resources.get",
             "events.create",
             "todos.create",
+            "calendar_resources.delete",
             "calendar_resources.exact_get",
             "list_task_lists",
             "show_tasks",
@@ -519,7 +558,8 @@ public sealed class CalendarMcpStdioIntegrationTests
         ConcurrentQueue<string> stderr,
         bool exposeExact,
         string? baseUrl = null,
-        string? calendarHrefs = null)
+        string? calendarHrefs = null,
+        bool confirmMutations = false)
     {
         var environment = CreateEnvironment();
         if (baseUrl is not null)
@@ -539,9 +579,28 @@ public sealed class CalendarMcpStdioIntegrationTests
             EnvironmentVariables = environment,
             StandardErrorLines = stderr.Enqueue
         });
+        var options = new McpClientOptions
+        {
+            ProtocolVersion = "2026-07-28",
+            DiscoverProbeTimeout = TimeSpan.FromSeconds(10)
+        };
+        if (confirmMutations)
+        {
+            options.Handlers = new McpClientHandlers
+            {
+                ElicitationHandler = (_, _) => ValueTask.FromResult(new ElicitResult
+                {
+                    Action = "accept",
+                    Content = new Dictionary<string, JsonElement>
+                    {
+                        ["confirm"] = JsonSerializer.SerializeToElement(true)
+                    }
+                })
+            };
+        }
         return await McpClient.CreateAsync(
             transport,
-            new McpClientOptions { ProtocolVersion = "2026-07-28", DiscoverProbeTimeout = TimeSpan.FromSeconds(10) },
+            options,
             cancellationToken: TestContext.Current.CancellationToken);
     }
 
@@ -596,6 +655,13 @@ public sealed class CalendarMcpStdioIntegrationTests
         return new ObservedResource(
             response.Headers.ETag.ToString(),
             await response.Content.ReadAsByteArrayAsync(TestContext.Current.CancellationToken));
+    }
+
+    private async Task<HttpStatusCode> GetStatusAsync(string href)
+    {
+        using var client = CreateAuthenticatedClient();
+        using var response = await client.GetAsync(href, TestContext.Current.CancellationToken);
+        return response.StatusCode;
     }
 
     private HttpClient CreateAuthenticatedClient()

--- a/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/CalDavHostBuilderTests.cs
+++ b/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/CalDavHostBuilderTests.cs
@@ -199,6 +199,7 @@ public class CalDavHostBuilderTests
             typeof(DotnetAgents.CalDav.Mcp.Tools.CalendarOccurrenceTools),
             typeof(DotnetAgents.CalDav.Mcp.Tools.CalendarResourceTools),
             typeof(DotnetAgents.CalDav.Mcp.Tools.CalendarEntityCreateTools),
+            typeof(DotnetAgents.CalDav.Mcp.Tools.CalendarResourceDeleteTools),
             typeof(DotnetAgents.CalDav.Mcp.Tools.TaskListTools),
             typeof(DotnetAgents.CalDav.Mcp.Tools.ChatTaskTools)
         ]);
@@ -343,6 +344,34 @@ public class CalDavHostBuilderTests
     }
 
     [Fact]
+    public void BuildHost_AdvertisesFrozenRevisionBoundDeleteContract()
+    {
+        var builder = CalDavHostBuilder.CreateBuilder();
+        builder.Services.ConfigureCalDav(ValidOptions);
+        using var host = builder.Build();
+
+        var options = host.Services.GetRequiredService<IOptions<ModelContextProtocol.Server.McpServerOptions>>().Value;
+        options.ToolCollection!.TryGetPrimitive("calendar_resources.delete", out var tool).ShouldBeTrue();
+
+        var inputSchema = JsonNode.Parse(tool!.ProtocolTool.InputSchema.GetRawText())!.AsObject();
+        var outputSchema = JsonNode.Parse(tool.ProtocolTool.OutputSchema!.Value.GetRawText())!.AsObject();
+        inputSchema["additionalProperties"]!.GetValue<bool>().ShouldBeFalse();
+        inputSchema["required"]!.AsArray().Select(item => item!.GetValue<string>()).ShouldBe(["revision"]);
+        inputSchema["$defs"]!["revisionReference"]!["required"]!.AsArray()
+            .Select(item => item!.GetValue<string>())
+            .ShouldBe(["href", "entityUid", "entityKind", "entityTag"]);
+        outputSchema["oneOf"]!.AsArray().Count.ShouldBe(3);
+        outputSchema["$defs"]!.AsObject().ShouldContainKey("deleteMutationSuccess");
+        outputSchema["$defs"]!.AsObject().ShouldContainKey("mutationErrorOutcome");
+        tool.ProtocolTool.Meta!["cache"]!["ttlMs"]!.GetValue<int>().ShouldBe(0);
+        tool.ProtocolTool.Meta!["cache"]!["cacheScope"]!.GetValue<string>().ShouldBe("private");
+        tool.ProtocolTool.Annotations!.ReadOnlyHint.ShouldBe(false);
+        tool.ProtocolTool.Annotations.DestructiveHint.ShouldBe(true);
+        tool.ProtocolTool.Annotations.IdempotentHint.ShouldBe(false);
+        tool.ProtocolTool.Annotations.OpenWorldHint.ShouldBe(true);
+    }
+
+    [Fact]
     public void BuildHost_DefaultMode_ListsToolsInCanonicalWireOrder()
     {
         var builder = CalDavHostBuilder.CreateBuilder();
@@ -362,6 +391,7 @@ public class CalDavHostBuilderTests
             "calendar_resources.get",
             "events.create",
             "todos.create",
+            "calendar_resources.delete",
             "list_task_lists",
             "show_tasks",
             "add_task",
@@ -403,6 +433,7 @@ public class CalDavHostBuilderTests
             "calendar_resources.get",
             "events.create",
             "todos.create",
+            "calendar_resources.delete",
             "list_task_lists",
             "show_tasks",
             "add_task",

--- a/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/CalendarResourceDeleteToolsTests.cs
+++ b/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/CalendarResourceDeleteToolsTests.cs
@@ -1,0 +1,1062 @@
+using System.Text;
+using System.Text.Json;
+using System.Xml;
+using DotnetAgents.CalDav.Core.Abstractions;
+using DotnetAgents.CalDav.Core.Configuration;
+using DotnetAgents.CalDav.Core.Models;
+using DotnetAgents.CalDav.Mcp.Tools;
+using Microsoft.Extensions.Options;
+using ModelContextProtocol.Protocol;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace DotnetAgents.CalDav.Mcp.Tests.Unit;
+
+public sealed class CalendarResourceDeleteToolsTests
+{
+    [Fact]
+    public async Task DeleteRawAsync_FirstRoundReturnsOpaqueRevisionBoundConfirmationWithoutDeleting()
+    {
+        var service = Substitute.For<ICalendarService>();
+        var snapshot = TodoSnapshot();
+        service.GetResourceAsync(snapshot.ResourceHref, Arg.Any<CancellationToken>()).Returns(
+            CalendarResourceRead.Success(snapshot.ResourceHref, snapshot.EntityTag, snapshot.AuthoritativeUtf8) with
+            {
+                Snapshot = snapshot
+            });
+        var timeProvider = new FixedTimeProvider(DateTimeOffset.Parse("2026-08-16T12:00:00Z"));
+        var protector = new CalendarMutationRequestStateProtector(
+            timeProvider,
+            Options.Create(CreateOptions()),
+            Enumerable.Range(0, 64).Select(value => (byte)value).ToArray());
+        var sut = new CalendarResourceDeleteTools(
+            service,
+            protector,
+            timeProvider,
+            new CalendarMutationAdmission(timeProvider));
+
+        var exception = await Should.ThrowAsync<InputRequiredException>(() => sut.DeleteRawAsync(
+            ValidArguments(),
+            requestState: null,
+            inputResponses: null,
+            mrtrSupported: true,
+            CancellationToken.None));
+
+        exception.Result.RequestState.ShouldNotBeNullOrWhiteSpace();
+        exception.Result.RequestState!.Length.ShouldBeLessThanOrEqualTo(
+            CalendarMutationRequestStateProtector.MaximumRequestStateCharacters);
+        exception.Result.RequestState.ShouldNotContain(snapshot.ResourceHref);
+        exception.Result.RequestState.ShouldNotContain(snapshot.Projection.EntityUid!);
+        exception.Result.RequestState.ShouldNotContain(snapshot.EntityTag);
+        var request = exception.Result.InputRequests.ShouldNotBeNull()["confirm_delete"];
+        var elicitation = request.ElicitationParams.ShouldNotBeNull();
+        elicitation.Message.ShouldBe(
+            "Confirm calendar_resources.delete for href https://cal.example/tasks/a.ics, UID todo-1, kind todo, and expected ETag \"r1\".");
+        elicitation.Message.ShouldNotContain("Private");
+        elicitation.Message.ShouldNotContain("user");
+        elicitation.Message.ShouldNotContain("secret");
+        elicitation.Message.ShouldNotContain(exception.Result.RequestState);
+        var schema = elicitation.RequestedSchema.ShouldNotBeNull();
+        schema.Properties["confirm"].ShouldBeOfType<ElicitRequestParams.BooleanSchema>().Default.ShouldBe(false);
+        await service.Received(1).GetResourceAsync(snapshot.ResourceHref, Arg.Any<CancellationToken>());
+        await service.DidNotReceive().DeleteResourceAsync(
+            Arg.Any<CalendarResourceRevisionReference>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Theory]
+    [InlineData(CalendarQueryToolSupport.MaximumHumanReadableBytes, true)]
+    [InlineData(CalendarQueryToolSupport.MaximumHumanReadableBytes + 1, false)]
+    public async Task DeleteRawAsync_EnforcesExactHumanPreviewBoundaryWithoutTruncatingIdentity(
+        int previewBytes,
+        bool expectsConfirmation)
+    {
+        const string href = "https://cal.example/tasks/a.ics";
+        const string prefix = "Confirm calendar_resources.delete for href https://cal.example/tasks/a.ics, UID ";
+        const string suffix = ", kind todo, and expected ETag \"r1\".";
+        const string title = "Confirm deletion";
+        const string description = "Delete exactly the reviewed resource revision.";
+        var fixedPreviewBytes = JsonSerializer.SerializeToUtf8Bytes(new
+        {
+            Message = prefix + suffix,
+            Title = title,
+            Description = description
+        }).Length;
+        var uid = new string('u', previewBytes - fixedPreviewBytes);
+        var expectedMessage = prefix + uid + suffix;
+        var snapshot = TodoSnapshot() with
+        {
+            Projection = new CalendarResourceProjection(CalendarResourceProjectionKind.Todo, uid, "Private")
+        };
+        var service = Substitute.For<ICalendarService>();
+        service.GetResourceAsync(href, Arg.Any<CancellationToken>()).Returns(
+            CalendarResourceRead.Success(href, snapshot.EntityTag, snapshot.AuthoritativeUtf8) with
+            {
+                Snapshot = snapshot
+            });
+        var timeProvider = new FixedTimeProvider(DateTimeOffset.Parse("2026-08-16T12:00:00Z"));
+        var sut = CreateTool(service, timeProvider);
+        var arguments = ArgumentsWithIdentity(href, uid);
+
+        if (expectsConfirmation)
+        {
+            var exception = await Should.ThrowAsync<InputRequiredException>(() => sut.DeleteRawAsync(
+                arguments,
+                requestState: null,
+                inputResponses: null,
+                mrtrSupported: true,
+                CancellationToken.None));
+
+            var message = exception.Result.InputRequests.ShouldNotBeNull()["confirm_delete"]
+                .ElicitationParams.ShouldNotBeNull().Message;
+            exception.Result.RequestState.ShouldNotBeNull().Length.ShouldBeLessThanOrEqualTo(
+                CalendarMutationRequestStateProtector.MaximumRequestStateCharacters);
+            message.ShouldBe(expectedMessage);
+            JsonSerializer.SerializeToUtf8Bytes(new
+            {
+                Message = message,
+                Title = title,
+                Description = description
+            }).Length.ShouldBe(previewBytes);
+        }
+        else
+        {
+            var result = await sut.DeleteRawAsync(
+                arguments,
+                requestState: null,
+                inputResponses: null,
+                mrtrSupported: true,
+                CancellationToken.None);
+
+            result.IsError.ShouldBe(true);
+            var structured = result.StructuredContent!.Value;
+            structured.GetProperty("code").GetString().ShouldBe("payload_too_large");
+            structured.GetProperty("phase").GetString().ShouldBe("admissionAndPayload");
+            structured.GetProperty("mutationState").GetString().ShouldBe("not_attempted");
+            JsonSerializer.Serialize(result).ShouldNotContain(uid);
+        }
+
+        await service.Received(expectsConfirmation ? 1 : 0)
+            .GetResourceAsync(href, Arg.Any<CancellationToken>());
+        await service.DidNotReceive().DeleteResourceAsync(
+            Arg.Any<CalendarResourceRevisionReference>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task DeleteRawAsync_AcceptedContinuationRefetchesThenReturnsVerifiedDeletionReceipt()
+    {
+        var service = Substitute.For<ICalendarService>();
+        var snapshot = TodoSnapshot();
+        service.GetResourceAsync(snapshot.ResourceHref, Arg.Any<CancellationToken>()).Returns(
+            CalendarResourceRead.Success(snapshot.ResourceHref, snapshot.EntityTag, snapshot.AuthoritativeUtf8) with
+            {
+                Snapshot = snapshot
+            });
+        service.DeleteResourceAsync(Arg.Any<CalendarResourceRevisionReference>(), Arg.Any<CancellationToken>())
+            .Returns(CalendarResourceDeleteResult.Success(new CalendarResourceDeletionReceipt(
+                snapshot.ResourceHref,
+                snapshot.Projection.EntityUid!,
+                CalendarEntityKind.Todo,
+                snapshot.EntityTag)));
+        var timeProvider = new FixedTimeProvider(DateTimeOffset.Parse("2026-08-16T12:00:00Z"));
+        var sut = CreateTool(service, timeProvider);
+        var firstRound = await Should.ThrowAsync<InputRequiredException>(() => sut.DeleteRawAsync(
+            ValidArguments(),
+            requestState: null,
+            inputResponses: null,
+            mrtrSupported: true,
+            CancellationToken.None));
+
+        var result = await sut.DeleteRawAsync(
+            ValidArguments(),
+            firstRound.Result.RequestState,
+            AcceptedConfirmation(),
+            mrtrSupported: true,
+            CancellationToken.None);
+
+        result.IsError.ShouldBe(false);
+        var structured = result.StructuredContent!.Value;
+        structured.GetProperty("outcome").GetString().ShouldBe("success");
+        structured.GetProperty("mutationState").GetString().ShouldBe("committed");
+        var receipt = structured.GetProperty("deletionReceipt");
+        receipt.GetProperty("href").GetString().ShouldBe(snapshot.ResourceHref);
+        receipt.GetProperty("entityUid").GetString().ShouldBe("todo-1");
+        receipt.GetProperty("entityKind").GetString().ShouldBe("todo");
+        receipt.GetProperty("consumedEntityTag").GetString().ShouldBe("\"r1\"");
+        await service.Received(2).GetResourceAsync(snapshot.ResourceHref, Arg.Any<CancellationToken>());
+        await service.Received(1).DeleteResourceAsync(
+            new CalendarResourceRevisionReference(
+                snapshot.ResourceHref,
+                "todo-1",
+                CalendarEntityKind.Todo,
+                "\"r1\""),
+            Arg.Any<CancellationToken>());
+        result.Content.OfType<TextContentBlock>().Single().Text.ShouldNotContain("todo-1");
+    }
+
+    [Theory]
+    [InlineData("decline", null)]
+    [InlineData("cancel", null)]
+    [InlineData("accept", false)]
+    public async Task DeleteRawAsync_NegativeConfirmationIsSuccessfulNonMutation(
+        string action,
+        bool? confirmation)
+    {
+        var service = ReviewedService();
+        var timeProvider = new FixedTimeProvider(DateTimeOffset.Parse("2026-08-16T12:00:00Z"));
+        var sut = CreateTool(service, timeProvider);
+        var firstRound = await BeginAsync(sut);
+        var content = confirmation is null
+            ? null
+            : new Dictionary<string, JsonElement>
+            {
+                ["confirm"] = JsonSerializer.SerializeToElement(confirmation.Value)
+            };
+
+        var result = await sut.DeleteRawAsync(
+            ValidArguments(),
+            firstRound.Result.RequestState,
+            new Dictionary<string, InputResponse>
+            {
+                ["confirm_delete"] = InputResponse.FromElicitResult(new ElicitResult
+                {
+                    Action = action,
+                    Content = content
+                })
+            },
+            mrtrSupported: true,
+            CancellationToken.None);
+
+        result.IsError.ShouldBe(false);
+        result.StructuredContent!.Value.GetProperty("outcome").GetString().ShouldBe("confirmation_declined");
+        result.StructuredContent.Value.GetProperty("mutationState").GetString().ShouldBe("not_attempted");
+        await service.DidNotReceive().DeleteResourceAsync(
+            Arg.Any<CalendarResourceRevisionReference>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task DeleteRawAsync_TamperedStateReturnsFrozenConfirmationMismatch()
+    {
+        var service = ReviewedService();
+        var timeProvider = new FixedTimeProvider(DateTimeOffset.Parse("2026-08-16T12:00:00Z"));
+        var sut = CreateTool(service, timeProvider);
+        var firstRound = await BeginAsync(sut);
+        var state = firstRound.Result.RequestState!;
+        var tampered = $"{state[..^1]}{(state[^1] == 'A' ? 'B' : 'A')}";
+
+        var result = await sut.DeleteRawAsync(
+            ValidArguments(),
+            tampered,
+            AcceptedConfirmation(),
+            mrtrSupported: true,
+            CancellationToken.None);
+
+        result.IsError.ShouldBe(true);
+        var structured = result.StructuredContent!.Value;
+        structured.GetProperty("code").GetString().ShouldBe("confirmation_mismatch");
+        structured.GetProperty("category").GetString().ShouldBe("confirmation");
+        structured.GetProperty("phase").GetString().ShouldBe("mrtr");
+        structured.GetProperty("mutationState").GetString().ShouldBe("not_attempted");
+        await service.DidNotReceive().DeleteResourceAsync(
+            Arg.Any<CalendarResourceRevisionReference>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task DeleteRawAsync_ExpiredStateReturnsFrozenConfirmationExpired()
+    {
+        var service = ReviewedService();
+        var timeProvider = new FixedTimeProvider(DateTimeOffset.Parse("2026-08-16T12:00:00Z"));
+        var sut = CreateTool(service, timeProvider);
+        var firstRound = await BeginAsync(sut);
+        timeProvider.Advance(TimeSpan.FromMinutes(10));
+
+        var result = await sut.DeleteRawAsync(
+            ValidArguments(),
+            firstRound.Result.RequestState,
+            AcceptedConfirmation(),
+            mrtrSupported: true,
+            CancellationToken.None);
+
+        result.IsError.ShouldBe(true);
+        var structured = result.StructuredContent!.Value;
+        structured.GetProperty("code").GetString().ShouldBe("confirmation_expired");
+        structured.GetProperty("category").GetString().ShouldBe("confirmation");
+        structured.GetProperty("phase").GetString().ShouldBe("mrtr");
+        structured.GetProperty("mutationState").GetString().ShouldBe("not_attempted");
+        await service.DidNotReceive().DeleteResourceAsync(
+            Arg.Any<CalendarResourceRevisionReference>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task DeleteRawAsync_ChangedReviewedRevisionRejectsStateBeforeRefetchOrDelete()
+    {
+        var service = ReviewedService();
+        var timeProvider = new FixedTimeProvider(DateTimeOffset.Parse("2026-08-16T12:00:00Z"));
+        var sut = CreateTool(service, timeProvider);
+        var firstRound = await BeginAsync(sut);
+        var changed = ValidArguments();
+        changed["revision"] = JsonSerializer.SerializeToElement(new
+        {
+            href = "https://cal.example/tasks/a.ics",
+            entityUid = "todo-2",
+            entityKind = "todo",
+            entityTag = "\"r1\""
+        });
+
+        var result = await sut.DeleteRawAsync(
+            changed,
+            firstRound.Result.RequestState,
+            AcceptedConfirmation(),
+            mrtrSupported: true,
+            CancellationToken.None);
+
+        result.StructuredContent!.Value.GetProperty("code").GetString().ShouldBe("confirmation_mismatch");
+        await service.Received(1).GetResourceAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await service.DidNotReceive().DeleteResourceAsync(
+            Arg.Any<CalendarResourceRevisionReference>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task DeleteRawAsync_RevisionChangedAfterConfirmationReturnsConflictWithCurrentSnapshot()
+    {
+        var first = TodoSnapshot();
+        var changed = first with { EntityTag = "\"r2\"" };
+        var service = Substitute.For<ICalendarService>();
+        service.GetResourceAsync(first.ResourceHref, Arg.Any<CancellationToken>()).Returns(
+            CalendarResourceRead.Success(first.ResourceHref, first.EntityTag, first.AuthoritativeUtf8) with { Snapshot = first },
+            CalendarResourceRead.Success(changed.ResourceHref, changed.EntityTag, changed.AuthoritativeUtf8) with { Snapshot = changed });
+        var timeProvider = new FixedTimeProvider(DateTimeOffset.Parse("2026-08-16T12:00:00Z"));
+        var sut = CreateTool(service, timeProvider);
+        var firstRound = await BeginAsync(sut);
+
+        var result = await sut.DeleteRawAsync(
+            ValidArguments(),
+            firstRound.Result.RequestState,
+            AcceptedConfirmation(),
+            mrtrSupported: true,
+            CancellationToken.None);
+
+        result.IsError.ShouldBe(true);
+        var structured = result.StructuredContent!.Value;
+        structured.GetProperty("code").GetString().ShouldBe("conflict");
+        structured.GetProperty("phase").GetString().ShouldBe("targetRevision");
+        structured.GetProperty("mutationState").GetString().ShouldBe("not_attempted");
+        structured.GetProperty("currentSnapshot").GetProperty("resourceRevision")
+            .GetProperty("entityTag").GetString().ShouldBe("\"r2\"");
+        await service.DidNotReceive().DeleteResourceAsync(
+            Arg.Any<CalendarResourceRevisionReference>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Theory]
+    [InlineData(CalendarResourceDeleteCode.NotFound, CalendarMutationState.NotCommitted, "not_found", "selection", "execution", false)]
+    [InlineData(CalendarResourceDeleteCode.EntityKindMismatch, CalendarMutationState.NotAttempted, "entity_kind_mismatch", "state", "targetRevision", false)]
+    [InlineData(CalendarResourceDeleteCode.UnsupportedCapability, CalendarMutationState.NotCommitted, "unsupported_capability", "capabilityAndProjection", "execution", false)]
+    [InlineData(CalendarResourceDeleteCode.PayloadTooLarge, CalendarMutationState.NotCommitted, "payload_too_large", "limitsAndAdmission", "execution", false)]
+    [InlineData(CalendarResourceDeleteCode.UpstreamUnauthorized, CalendarMutationState.NotCommitted, "upstream_unauthorized", "upstream", "execution", false)]
+    [InlineData(CalendarResourceDeleteCode.UpstreamForbidden, CalendarMutationState.NotCommitted, "upstream_forbidden", "upstream", "execution", false)]
+    [InlineData(CalendarResourceDeleteCode.UpstreamRateLimited, CalendarMutationState.NotCommitted, "upstream_rate_limited", "upstream", "execution", true)]
+    [InlineData(CalendarResourceDeleteCode.UpstreamUnavailable, CalendarMutationState.NotCommitted, "upstream_unavailable", "upstream", "execution", false)]
+    [InlineData(CalendarResourceDeleteCode.UpstreamProtocolError, CalendarMutationState.NotCommitted, "upstream_protocol_error", "upstream", "execution", false)]
+    [InlineData(CalendarResourceDeleteCode.CommittedButUnverified, CalendarMutationState.Committed, "committed_but_unverified", "postWriteTruth", "postWriteVerificationOrReconciliation", false)]
+    [InlineData(CalendarResourceDeleteCode.Indeterminate, CalendarMutationState.Unknown, "indeterminate", "postWriteTruth", "postWriteVerificationOrReconciliation", false)]
+    public async Task DeleteRawAsync_MapsFrozenDeletionFailureOutcome(
+        CalendarResourceDeleteCode code,
+        CalendarMutationState mutationState,
+        string expectedCode,
+        string expectedCategory,
+        string expectedPhase,
+        bool expectedRetryable)
+    {
+        var service = ReviewedService();
+        service.DeleteResourceAsync(Arg.Any<CalendarResourceRevisionReference>(), Arg.Any<CancellationToken>())
+            .Returns(new CalendarResourceDeleteResult(code, mutationState, Retryable: expectedRetryable));
+        var timeProvider = new FixedTimeProvider(DateTimeOffset.Parse("2026-08-16T12:00:00Z"));
+        var sut = CreateTool(service, timeProvider);
+        var firstRound = await BeginAsync(sut);
+
+        var result = await sut.DeleteRawAsync(
+            ValidArguments(),
+            firstRound.Result.RequestState,
+            AcceptedConfirmation(),
+            mrtrSupported: true,
+            CancellationToken.None);
+
+        result.IsError.ShouldBe(true);
+        var structured = result.StructuredContent!.Value;
+        structured.GetProperty("code").GetString().ShouldBe(expectedCode);
+        structured.GetProperty("category").GetString().ShouldBe(expectedCategory);
+        structured.GetProperty("phase").GetString().ShouldBe(expectedPhase);
+        structured.GetProperty("mutationState").GetString().ShouldBe(MutationStateText(mutationState));
+        structured.GetProperty("retryable").GetBoolean().ShouldBe(expectedRetryable);
+    }
+
+    [Fact]
+    public async Task DeleteRawAsync_DefiniteRateLimitIsRetryableAndPreservesRetryAfter()
+    {
+        var service = ReviewedService();
+        service.DeleteResourceAsync(Arg.Any<CalendarResourceRevisionReference>(), Arg.Any<CancellationToken>())
+            .Returns(new CalendarResourceDeleteResult(
+                CalendarResourceDeleteCode.UpstreamRateLimited,
+                CalendarMutationState.NotCommitted,
+                RetryAfterMilliseconds: 3_000,
+                Retryable: true));
+        var timeProvider = new FixedTimeProvider(DateTimeOffset.Parse("2026-08-16T12:00:00Z"));
+        var sut = CreateTool(service, timeProvider);
+        var firstRound = await BeginAsync(sut);
+
+        var result = await sut.DeleteRawAsync(
+            ValidArguments(),
+            firstRound.Result.RequestState,
+            AcceptedConfirmation(),
+            mrtrSupported: true,
+            CancellationToken.None);
+
+        result.IsError.ShouldBe(true);
+        var structured = result.StructuredContent!.Value;
+        structured.GetProperty("code").GetString().ShouldBe("upstream_rate_limited");
+        structured.GetProperty("mutationState").GetString().ShouldBe("not_committed");
+        structured.GetProperty("retryable").GetBoolean().ShouldBeTrue();
+        structured.GetProperty("retryAfterMs").GetInt32().ShouldBe(3_000);
+    }
+
+    [Theory]
+    [InlineData("{}")]
+    [InlineData("{\"revision\":{\"href\":\"https://cal.example/tasks/a.ics\",\"entityUid\":\"todo-1\",\"entityKind\":\"todo\",\"entityTag\":\"\\\"r1\\\"\"},\"extra\":true}")]
+    [InlineData("{\"revision\":{\"href\":\"https://cal.example/tasks/a.ics\",\"entityUid\":\"todo-1\",\"entityKind\":\"todo\",\"entityTag\":\"\\\"r1\\\"\",\"extra\":true}}")]
+    [InlineData("{\"revision\":{\"href\":\"relative/a.ics\",\"entityUid\":\"todo-1\",\"entityKind\":\"todo\",\"entityTag\":\"\\\"r1\\\"\"}}")]
+    [InlineData("{\"revision\":{\"href\":\"https://cal.example/tasks/a.ics\",\"entityUid\":\" todo-1\",\"entityKind\":\"todo\",\"entityTag\":\"\\\"r1\\\"\"}}")]
+    [InlineData("{\"revision\":{\"href\":\"https://cal.example/tasks/a.ics\",\"entityUid\":\"todo-1\",\"entityKind\":\"task\",\"entityTag\":\"\\\"r1\\\"\"}}")]
+    [InlineData("{\"revision\":{\"href\":\"https://cal.example/tasks/a.ics\",\"entityUid\":\"todo-1\",\"entityKind\":\"todo\",\"entityTag\":\"*\"}}")]
+    public async Task DeleteRawAsync_RejectsNonFrozenOrLexicallyInvalidInputBeforeReading(string json)
+    {
+        var service = Substitute.For<ICalendarService>();
+        var timeProvider = new FixedTimeProvider(DateTimeOffset.Parse("2026-08-16T12:00:00Z"));
+        var sut = CreateTool(service, timeProvider);
+
+        var result = await sut.DeleteRawAsync(
+            JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(json),
+            requestState: null,
+            inputResponses: null,
+            mrtrSupported: true,
+            CancellationToken.None);
+
+        result.IsError.ShouldBe(true);
+        var structured = result.StructuredContent!.Value;
+        structured.GetProperty("code").GetString().ShouldBe("invalid_input");
+        structured.GetProperty("phase").GetString().ShouldBe("schemaLexicalDiscriminator");
+        await service.DidNotReceive().GetResourceAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task DeleteRawAsync_WeakRevisionReturnsConcurrencyUnavailableBeforeReading()
+    {
+        var service = Substitute.For<ICalendarService>();
+        var timeProvider = new FixedTimeProvider(DateTimeOffset.Parse("2026-08-16T12:00:00Z"));
+        var sut = CreateTool(service, timeProvider);
+        var arguments = ValidArguments();
+        arguments["revision"] = JsonSerializer.SerializeToElement(new
+        {
+            href = "https://cal.example/tasks/a.ics",
+            entityUid = "todo-1",
+            entityKind = "todo",
+            entityTag = "W/\"r1\""
+        });
+
+        var result = await sut.DeleteRawAsync(
+            arguments,
+            requestState: null,
+            inputResponses: null,
+            mrtrSupported: true,
+            CancellationToken.None);
+
+        result.IsError.ShouldBe(true);
+        var structured = result.StructuredContent!.Value;
+        structured.GetProperty("code").GetString().ShouldBe("concurrency_unavailable");
+        structured.GetProperty("phase").GetString().ShouldBe("targetRevision");
+        structured.GetProperty("mutationState").GetString().ShouldBe("not_attempted");
+        await service.DidNotReceive().GetResourceAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await service.DidNotReceive().DeleteResourceAsync(
+            Arg.Any<CalendarResourceRevisionReference>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task DeleteRawAsync_DirectTargetNotFoundReturnsTargetRevisionFailureWithoutDelete()
+    {
+        var service = Substitute.For<ICalendarService>();
+        service.GetResourceAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new CalendarResourceRead(CalendarResourceReadCode.NotFound));
+        var timeProvider = new FixedTimeProvider(DateTimeOffset.Parse("2026-08-16T12:00:00Z"));
+        var sut = CreateTool(service, timeProvider);
+
+        var result = await sut.DeleteRawAsync(
+            ValidArguments(),
+            requestState: null,
+            inputResponses: null,
+            mrtrSupported: true,
+            CancellationToken.None);
+
+        result.IsError.ShouldBe(true);
+        var structured = result.StructuredContent!.Value;
+        structured.GetProperty("code").GetString().ShouldBe("not_found");
+        structured.GetProperty("phase").GetString().ShouldBe("targetRevision");
+        structured.GetProperty("mutationState").GetString().ShouldBe("not_attempted");
+        await service.DidNotReceive().DeleteResourceAsync(
+            Arg.Any<CalendarResourceRevisionReference>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task DeleteRawAsync_WithoutMrtrSupportReturnsTypedCapabilityErrorAfterReadOnlyPreview()
+    {
+        var service = ReviewedService();
+        var timeProvider = new FixedTimeProvider(DateTimeOffset.Parse("2026-08-16T12:00:00Z"));
+        var sut = CreateTool(service, timeProvider);
+
+        var result = await sut.DeleteRawAsync(
+            ValidArguments(),
+            requestState: null,
+            inputResponses: null,
+            mrtrSupported: false,
+            CancellationToken.None);
+
+        result.IsError.ShouldBe(true);
+        var structured = result.StructuredContent!.Value;
+        structured.GetProperty("code").GetString().ShouldBe("unsupported_capability");
+        structured.GetProperty("phase").GetString().ShouldBe("mrtr");
+        structured.GetProperty("mutationState").GetString().ShouldBe("not_attempted");
+        await service.Received(1).GetResourceAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await service.DidNotReceive().DeleteResourceAsync(
+            Arg.Any<CalendarResourceRevisionReference>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task DeleteRawAsync_ContinuationWithoutMrtrSupportFailsBeforeStateOrServiceAccess()
+    {
+        var service = Substitute.For<ICalendarService>();
+        var timeProvider = new FixedTimeProvider(DateTimeOffset.Parse("2026-08-16T12:00:00Z"));
+        var sut = CreateTool(service, timeProvider);
+        const string opaqueRequestState = "opaque-state-that-must-not-be-unprotected";
+
+        var result = await sut.DeleteRawAsync(
+            ValidArguments(),
+            opaqueRequestState,
+            AcceptedConfirmation(),
+            mrtrSupported: false,
+            CancellationToken.None);
+
+        result.IsError.ShouldBe(true);
+        var structured = result.StructuredContent!.Value;
+        structured.GetProperty("code").GetString().ShouldBe("unsupported_capability");
+        structured.GetProperty("phase").GetString().ShouldBe("mrtr");
+        structured.GetProperty("mutationState").GetString().ShouldBe("not_attempted");
+        JsonSerializer.Serialize(result).ShouldNotContain(opaqueRequestState);
+        await service.DidNotReceive().GetResourceAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await service.DidNotReceive().DeleteResourceAsync(
+            Arg.Any<CalendarResourceRevisionReference>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Theory]
+    [InlineData("https://other.example/tasks/a.ics")]
+    [InlineData("HTTPS://cal.example/tasks/a.ics")]
+    [InlineData("https://user@cal.example/tasks/a.ics")]
+    [InlineData("https://cal.example/tasks/a.ics?view=full")]
+    [InlineData("https://cal.example/tasks/a.ics#component")]
+    [InlineData("https://cal.example/tasks%2Fa.ics")]
+    [InlineData("https://cal.example/tasks%5Ca.ics")]
+    public async Task DeleteRawAsync_ServicePreflightHrefRejectionUsesOriginScopePhaseWithoutDelete(string href)
+    {
+        var service = Substitute.For<ICalendarService>();
+        service.GetResourceAsync(href, Arg.Any<CancellationToken>())
+            .Returns(new CalendarResourceRead(CalendarResourceReadCode.InvalidInput));
+        var timeProvider = new FixedTimeProvider(DateTimeOffset.Parse("2026-08-16T12:00:00Z"));
+        var sut = CreateTool(service, timeProvider);
+        var arguments = ArgumentsWithHref(href);
+
+        var result = await sut.DeleteRawAsync(
+            arguments,
+            requestState: null,
+            inputResponses: null,
+            mrtrSupported: true,
+            CancellationToken.None);
+
+        result.IsError.ShouldBe(true);
+        var structured = result.StructuredContent!.Value;
+        structured.GetProperty("code").GetString().ShouldBe("invalid_input");
+        structured.GetProperty("phase").GetString().ShouldBe("originScopeAuthorization");
+        structured.GetProperty("mutationState").GetString().ShouldBe("not_attempted");
+        await service.Received(1).GetResourceAsync(href, Arg.Any<CancellationToken>());
+        await service.DidNotReceive().DeleteResourceAsync(
+            Arg.Any<CalendarResourceRevisionReference>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public void MutationRequestState_IsNonceRandomCredentialBoundAndInvalidatedByKeyRotation()
+    {
+        var timeProvider = new FixedTimeProvider(DateTimeOffset.Parse("2026-08-16T12:00:00Z"));
+        var key = Enumerable.Range(0, 64).Select(value => (byte)value).ToArray();
+        var original = new CalendarMutationRequestStateProtector(
+            timeProvider,
+            Options.Create(CreateOptions()),
+            key);
+        var changedCredentials = CreateOptions();
+        changedCredentials.Password = "different";
+        var redistributed = new CalendarMutationRequestStateProtector(
+            timeProvider,
+            Options.Create(changedCredentials),
+            key);
+        var rotated = new CalendarMutationRequestStateProtector(
+            timeProvider,
+            Options.Create(CreateOptions()),
+            key.Select(value => (byte)(value + 1)).ToArray());
+        var revision = new CalendarResourceRevisionReference(
+            "https://cal.example/tasks/a.ics",
+            "todo-1",
+            CalendarEntityKind.Todo,
+            "\"r1\"");
+
+        var first = original.Protect(revision);
+        var second = original.Protect(revision);
+
+        first.ShouldNotBe(second);
+        original.TryUnprotect(first, revision, out var expired).ShouldBeTrue();
+        expired.ShouldBeFalse();
+        redistributed.TryUnprotect(first, revision, out _).ShouldBeFalse();
+        rotated.TryUnprotect(first, revision, out _).ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task DeleteRawAsync_RejectsOversizeRequestStateBeforeRefetchOrDelete()
+    {
+        var service = Substitute.For<ICalendarService>();
+        var timeProvider = new FixedTimeProvider(DateTimeOffset.Parse("2026-08-16T12:00:00Z"));
+        var sut = CreateTool(service, timeProvider);
+
+        var result = await sut.DeleteRawAsync(
+            ValidArguments(),
+            new string('A', CalendarMutationRequestStateProtector.MaximumRequestStateCharacters + 1),
+            AcceptedConfirmation(),
+            mrtrSupported: true,
+            CancellationToken.None);
+
+        result.IsError.ShouldBe(true);
+        result.StructuredContent!.Value.GetProperty("code").GetString().ShouldBe("confirmation_mismatch");
+        await service.DidNotReceive().GetResourceAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await service.DidNotReceive().DeleteResourceAsync(
+            Arg.Any<CalendarResourceRevisionReference>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task DeleteRawAsync_ReplayAfterSuccessRevalidatesAndDoesNotDeleteAgain()
+    {
+        var snapshot = TodoSnapshot();
+        var service = Substitute.For<ICalendarService>();
+        service.GetResourceAsync(snapshot.ResourceHref, Arg.Any<CancellationToken>()).Returns(
+            CalendarResourceRead.Success(snapshot.ResourceHref, snapshot.EntityTag, snapshot.AuthoritativeUtf8) with { Snapshot = snapshot },
+            CalendarResourceRead.Success(snapshot.ResourceHref, snapshot.EntityTag, snapshot.AuthoritativeUtf8) with { Snapshot = snapshot },
+            new CalendarResourceRead(CalendarResourceReadCode.NotFound));
+        service.DeleteResourceAsync(Arg.Any<CalendarResourceRevisionReference>(), Arg.Any<CancellationToken>())
+            .Returns(CalendarResourceDeleteResult.Success(new CalendarResourceDeletionReceipt(
+                snapshot.ResourceHref,
+                snapshot.Projection.EntityUid!,
+                CalendarEntityKind.Todo,
+                snapshot.EntityTag)));
+        var timeProvider = new FixedTimeProvider(DateTimeOffset.Parse("2026-08-16T12:00:00Z"));
+        var sut = CreateTool(service, timeProvider);
+        var firstRound = await BeginAsync(sut);
+
+        var first = await sut.DeleteRawAsync(
+            ValidArguments(),
+            firstRound.Result.RequestState,
+            AcceptedConfirmation(),
+            mrtrSupported: true,
+            CancellationToken.None);
+        var replay = await sut.DeleteRawAsync(
+            ValidArguments(),
+            firstRound.Result.RequestState,
+            AcceptedConfirmation(),
+            mrtrSupported: true,
+            CancellationToken.None);
+
+        first.IsError.ShouldBe(false);
+        replay.IsError.ShouldBe(true);
+        replay.StructuredContent!.Value.GetProperty("code").GetString().ShouldBe("not_found");
+        await service.Received(1).DeleteResourceAsync(
+            Arg.Any<CalendarResourceRevisionReference>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task DeleteRawAsync_PreviewDeadlineReturnsLimitExhaustedWithoutWrite()
+    {
+        var service = Substitute.For<ICalendarService>();
+        service.GetResourceAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(call =>
+            new TaskCompletionSource<CalendarResourceRead>(TaskCreationOptions.RunContinuationsAsynchronously)
+                .Task.WaitAsync(call.Arg<CancellationToken>()));
+        var timeProvider = new FixedTimeProvider(DateTimeOffset.Parse("2026-08-16T12:00:00Z"));
+        var sut = CreateTool(service, timeProvider);
+        var pending = sut.DeleteRawAsync(
+            ValidArguments(),
+            requestState: null,
+            inputResponses: null,
+            mrtrSupported: true,
+            CancellationToken.None);
+
+        timeProvider.Advance(TimeSpan.FromSeconds(30));
+        var result = await pending;
+
+        result.IsError.ShouldBe(true);
+        var structured = result.StructuredContent!.Value;
+        structured.GetProperty("code").GetString().ShouldBe("limit_exhausted");
+        structured.GetProperty("category").GetString().ShouldBe("limitsAndAdmission");
+        structured.GetProperty("phase").GetString().ShouldBe("execution");
+        structured.GetProperty("mutationState").GetString().ShouldBe("not_attempted");
+        await service.DidNotReceive().DeleteResourceAsync(
+            Arg.Any<CalendarResourceRevisionReference>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task DeleteRawAsync_AdmissionTimeoutReturnsFrozenBusyBeforeSchemaOrRead()
+    {
+        var service = Substitute.For<ICalendarService>();
+        var timeProvider = new FixedTimeProvider(DateTimeOffset.Parse("2026-08-16T12:00:00Z"));
+        var admission = new CalendarMutationAdmission(timeProvider);
+        using var active = (await admission.AcquireAsync(CancellationToken.None))!;
+        var sut = CreateTool(service, timeProvider, admission);
+        var pending = sut.DeleteRawAsync(
+            new Dictionary<string, JsonElement>(),
+            requestState: null,
+            inputResponses: null,
+            mrtrSupported: true,
+            CancellationToken.None);
+
+        timeProvider.Advance(TimeSpan.FromSeconds(2));
+        var result = await pending;
+
+        result.IsError.ShouldBe(true);
+        var structured = result.StructuredContent!.Value;
+        structured.GetProperty("code").GetString().ShouldBe("busy");
+        structured.GetProperty("phase").GetString().ShouldBe("admissionAndPayload");
+        structured.GetProperty("retryAfterMs").GetInt32().ShouldBe(2_000);
+        await service.DidNotReceive().GetResourceAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Theory]
+    [InlineData("io")]
+    [InlineData("unexpected")]
+    public async Task DeleteRawAsync_SanitizesExceptionalMutationHandoffAsIndeterminate(string failure)
+    {
+        var service = ReviewedService();
+        service.DeleteResourceAsync(Arg.Any<CalendarResourceRevisionReference>(), Arg.Any<CancellationToken>())
+            .Returns<CalendarResourceDeleteResult>(_ => throw (failure == "io"
+                ? new IOException("secret upstream body")
+                : new InvalidOperationException("secret internal detail")));
+        var timeProvider = new FixedTimeProvider(DateTimeOffset.Parse("2026-08-16T12:00:00Z"));
+        var sut = CreateTool(service, timeProvider);
+        var firstRound = await BeginAsync(sut);
+
+        var result = await sut.DeleteRawAsync(
+            ValidArguments(),
+            firstRound.Result.RequestState,
+            AcceptedConfirmation(),
+            mrtrSupported: true,
+            CancellationToken.None);
+
+        result.IsError.ShouldBe(true);
+        var structured = result.StructuredContent!.Value;
+        structured.GetProperty("code").GetString().ShouldBe("indeterminate");
+        structured.GetProperty("phase").GetString().ShouldBe("postWriteVerificationOrReconciliation");
+        structured.GetProperty("mutationState").GetString().ShouldBe("unknown");
+        JsonSerializer.Serialize(result).ShouldNotContain("secret");
+    }
+
+    [Theory]
+    [InlineData("protocol", "upstream_protocol_error", "upstream", "targetRevision", false)]
+    [InlineData("xml", "upstream_protocol_error", "upstream", "targetRevision", false)]
+    [InlineData("unsupported", "unsupported_capability", "capabilityAndProjection", "selectionDiscoveryCapability", false)]
+    [InlineData("io", "upstream_unavailable", "upstream", "targetRevision", true)]
+    [InlineData("unexpected", "upstream_protocol_error", "upstream", "targetRevision", false)]
+    public async Task DeleteRawAsync_SanitizesPreviewFailures(
+        string failure,
+        string expectedCode,
+        string expectedCategory,
+        string expectedPhase,
+        bool expectedRetryable)
+    {
+        var service = Substitute.For<ICalendarService>();
+        service.GetResourceAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns<CalendarResourceRead>(_ => throw failure switch
+            {
+                "protocol" => new CalendarDiscoveryProtocolException("secret protocol"),
+                "xml" => new XmlException("secret xml"),
+                "unsupported" => new CalendarDiscoveryUnsupportedCapabilityException("secret unsupported"),
+                "io" => new IOException("secret io"),
+                _ => new InvalidOperationException("secret unexpected")
+            });
+        var timeProvider = new FixedTimeProvider(DateTimeOffset.Parse("2026-08-16T12:00:00Z"));
+        var sut = CreateTool(service, timeProvider);
+
+        var result = await sut.DeleteRawAsync(
+            ValidArguments(),
+            requestState: null,
+            inputResponses: null,
+            mrtrSupported: true,
+            CancellationToken.None);
+
+        result.IsError.ShouldBe(true);
+        var structured = result.StructuredContent!.Value;
+        structured.GetProperty("code").GetString().ShouldBe(expectedCode);
+        structured.GetProperty("category").GetString().ShouldBe(expectedCategory);
+        structured.GetProperty("phase").GetString().ShouldBe(expectedPhase);
+        structured.GetProperty("retryable").GetBoolean().ShouldBe(expectedRetryable);
+        structured.GetProperty("mutationState").GetString().ShouldBe("not_attempted");
+        JsonSerializer.Serialize(result).ShouldNotContain("secret");
+    }
+
+    [Theory]
+    [InlineData(401, "upstream_unauthorized", "selectionDiscoveryCapability", false)]
+    [InlineData(403, "upstream_forbidden", "selectionDiscoveryCapability", false)]
+    [InlineData(404, "upstream_protocol_error", "selectionDiscoveryCapability", false)]
+    [InlineData(409, "conflict", "selectionDiscoveryCapability", false)]
+    [InlineData(412, "conflict", "selectionDiscoveryCapability", false)]
+    [InlineData(413, "payload_too_large", "selectionDiscoveryCapability", false)]
+    [InlineData(429, "upstream_rate_limited", "selectionDiscoveryCapability", true)]
+    [InlineData(405, "unsupported_capability", "selectionDiscoveryCapability", false)]
+    [InlineData(501, "unsupported_capability", "selectionDiscoveryCapability", false)]
+    [InlineData(507, "upstream_unavailable", "selectionDiscoveryCapability", false)]
+    [InlineData(503, "upstream_unavailable", "selectionDiscoveryCapability", true)]
+    public async Task DeleteRawAsync_MapsPreviewHttpStatusWithoutDeleting(
+        int statusCode,
+        string expectedCode,
+        string expectedPhase,
+        bool expectedRetryable)
+    {
+        var service = Substitute.For<ICalendarService>();
+        service.GetResourceAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns<CalendarResourceRead>(_ => throw new HttpRequestException(
+                "secret upstream response",
+                inner: null,
+                (System.Net.HttpStatusCode)statusCode));
+        var timeProvider = new FixedTimeProvider(DateTimeOffset.Parse("2026-08-16T12:00:00Z"));
+        var sut = CreateTool(service, timeProvider);
+
+        var result = await sut.DeleteRawAsync(
+            ValidArguments(),
+            requestState: null,
+            inputResponses: null,
+            mrtrSupported: true,
+            CancellationToken.None);
+
+        result.IsError.ShouldBe(true);
+        var structured = result.StructuredContent!.Value;
+        structured.GetProperty("code").GetString().ShouldBe(expectedCode);
+        structured.GetProperty("phase").GetString().ShouldBe(expectedPhase);
+        structured.GetProperty("retryable").GetBoolean().ShouldBe(expectedRetryable);
+        structured.GetProperty("mutationState").GetString().ShouldBe("not_attempted");
+        JsonSerializer.Serialize(result).ShouldNotContain("secret");
+        await service.DidNotReceive().DeleteResourceAsync(
+            Arg.Any<CalendarResourceRevisionReference>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task DeleteRawAsync_MapsPreviewDiscoveryLimitWithoutWrite()
+    {
+        var service = Substitute.For<ICalendarService>();
+        service.GetResourceAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns<CalendarResourceRead>(_ => throw new CalendarDiscoveryLimitException(257));
+        var timeProvider = new FixedTimeProvider(DateTimeOffset.Parse("2026-08-16T12:00:00Z"));
+        var sut = CreateTool(service, timeProvider);
+
+        var result = await sut.DeleteRawAsync(
+            ValidArguments(),
+            requestState: null,
+            inputResponses: null,
+            mrtrSupported: true,
+            CancellationToken.None);
+
+        result.IsError.ShouldBe(true);
+        var structured = result.StructuredContent!.Value;
+        structured.GetProperty("code").GetString().ShouldBe("limit_exhausted");
+        structured.GetProperty("phase").GetString().ShouldBe("selectionDiscoveryCapability");
+        structured.GetProperty("mutationState").GetString().ShouldBe("not_attempted");
+        structured.GetProperty("limits").GetProperty("calendarCount").GetInt32().ShouldBe(257);
+        await service.DidNotReceive().DeleteResourceAsync(
+            Arg.Any<CalendarResourceRevisionReference>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    private static CalendarResourceDeleteTools CreateTool(
+        ICalendarService service,
+        TimeProvider timeProvider,
+        CalendarMutationAdmission? admission = null)
+    {
+        var protector = new CalendarMutationRequestStateProtector(
+            timeProvider,
+            Options.Create(CreateOptions()),
+            Enumerable.Range(0, 64).Select(value => (byte)value).ToArray());
+        return new CalendarResourceDeleteTools(
+            service,
+            protector,
+            timeProvider,
+            admission ?? new CalendarMutationAdmission(timeProvider));
+    }
+
+    private static Task<InputRequiredException> BeginAsync(CalendarResourceDeleteTools sut) =>
+        Should.ThrowAsync<InputRequiredException>(() => sut.DeleteRawAsync(
+            ValidArguments(),
+            requestState: null,
+            inputResponses: null,
+            mrtrSupported: true,
+            CancellationToken.None));
+
+    private static ICalendarService ReviewedService()
+    {
+        var snapshot = TodoSnapshot();
+        var service = Substitute.For<ICalendarService>();
+        service.GetResourceAsync(snapshot.ResourceHref, Arg.Any<CancellationToken>()).Returns(
+            CalendarResourceRead.Success(snapshot.ResourceHref, snapshot.EntityTag, snapshot.AuthoritativeUtf8) with
+            {
+                Snapshot = snapshot
+            });
+        return service;
+    }
+
+    private static Dictionary<string, InputResponse> AcceptedConfirmation() => new()
+    {
+        ["confirm_delete"] = InputResponse.FromElicitResult(new ElicitResult
+        {
+            Action = "accept",
+            Content = new Dictionary<string, JsonElement>
+            {
+                ["confirm"] = JsonSerializer.SerializeToElement(true)
+            }
+        })
+    };
+
+    private static string MutationStateText(CalendarMutationState state) => state switch
+    {
+        CalendarMutationState.NotAttempted => "not_attempted",
+        CalendarMutationState.NotCommitted => "not_committed",
+        CalendarMutationState.Committed => "committed",
+        _ => "unknown"
+    };
+
+    private static Dictionary<string, JsonElement> ValidArguments() => JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(
+        """
+        {"revision":{"href":"https://cal.example/tasks/a.ics","entityUid":"todo-1","entityKind":"todo","entityTag":"\"r1\""}}
+        """)!;
+
+    private static Dictionary<string, JsonElement> ArgumentsWithHref(string href) =>
+        ArgumentsWithIdentity(href, "todo-1");
+
+    private static Dictionary<string, JsonElement> ArgumentsWithIdentity(string href, string entityUid) => new()
+    {
+        ["revision"] = JsonSerializer.SerializeToElement(new
+        {
+            href,
+            entityUid,
+            entityKind = "todo",
+            entityTag = "\"r1\""
+        })
+    };
+
+    private static CalendarResourceSnapshot TodoSnapshot()
+    {
+        var bytes = Encoding.UTF8.GetBytes("BEGIN:VCALENDAR\r\nBEGIN:VTODO\r\nUID:todo-1\r\nSUMMARY:Private\r\nEND:VTODO\r\nEND:VCALENDAR\r\n");
+        return new CalendarResourceSnapshot(
+            "https://cal.example/tasks/",
+            "https://cal.example/tasks/a.ics",
+            "\"r1\"",
+            bytes,
+            [],
+            new CalendarResourceProjection(CalendarResourceProjectionKind.Todo, "todo-1", "Private"),
+            []);
+    }
+
+    private static CalDavOptions CreateOptions() => new()
+    {
+        BaseUrl = "https://cal.example/",
+        Username = "user",
+        Password = "secret",
+        CalendarHrefs = "https://cal.example/tasks/"
+    };
+
+    private sealed class FixedTimeProvider(DateTimeOffset now) : TimeProvider
+    {
+        private readonly List<ManualTimer> _timers = [];
+        private DateTimeOffset _now = now;
+
+        public override DateTimeOffset GetUtcNow() => _now;
+
+        public override ITimer CreateTimer(
+            TimerCallback callback,
+            object? state,
+            TimeSpan dueTime,
+            TimeSpan period)
+        {
+            var timer = new ManualTimer(this, callback, state, dueTime, period);
+            _timers.Add(timer);
+            return timer;
+        }
+
+        public void Advance(TimeSpan duration)
+        {
+            _now += duration;
+            foreach (var timer in _timers.ToArray())
+                timer.FireIfDue();
+        }
+
+        private sealed class ManualTimer(
+            FixedTimeProvider owner,
+            TimerCallback callback,
+            object? state,
+            TimeSpan dueTime,
+            TimeSpan period) : ITimer
+        {
+            private DateTimeOffset? _dueAt = dueTime == Timeout.InfiniteTimeSpan
+                ? null
+                : owner.GetUtcNow() + dueTime;
+            private bool _disposed;
+
+            public bool Change(TimeSpan newDueTime, TimeSpan newPeriod)
+            {
+                if (_disposed)
+                    return false;
+                period = newPeriod;
+                _dueAt = newDueTime == Timeout.InfiniteTimeSpan
+                    ? null
+                    : owner.GetUtcNow() + newDueTime;
+                return true;
+            }
+
+            public void Dispose() => _disposed = true;
+
+            public ValueTask DisposeAsync()
+            {
+                Dispose();
+                return ValueTask.CompletedTask;
+            }
+
+            public void FireIfDue()
+            {
+                if (_disposed || _dueAt is null || owner.GetUtcNow() < _dueAt)
+                    return;
+                _dueAt = period == Timeout.InfiniteTimeSpan ? null : owner.GetUtcNow() + period;
+                callback(state);
+            }
+        }
+    }
+}

--- a/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/StrictToolInputGuardTests.cs
+++ b/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/StrictToolInputGuardTests.cs
@@ -50,6 +50,9 @@ public sealed class StrictToolInputGuardTests
     [InlineData("todos.create", 262_144, false, null)]
     [InlineData("todos.create", 262_145, true, "payload_too_large")]
     [InlineData("todos.create", 1, true, "invalid_input")]
+    [InlineData("calendar_resources.delete", 262_144, false, null)]
+    [InlineData("calendar_resources.delete", 262_145, true, "payload_too_large")]
+    [InlineData("calendar_resources.delete", 1, true, "invalid_input")]
     public void Reject_AppliesQuerySpecificAdmissionBeforeDuplicateValidation(
         string toolName,
         int? argumentBytes,


### PR DESCRIPTION
## Summary

- Add the frozen `calendar_resources.delete` semantic tool to the default host.
- Delete one complete Calendar Object Resource from an explicit revision reference containing href, UID, kind, and exact strong ETag.
- Return a verified deletion receipt only after an authoritative 404 refetch.

## Safety, mutation truth, and MRTR evidence

- Performs a read-only preview, validates canonical origin and Calendar Scope, rechecks the reviewed UID, kind, and ETag, and requires MCP MRTR confirmation before DELETE.
- Protects opaque requestState with authenticated encryption, a random nonce, credential and argument binding, a ten-minute expiry, a 2 KiB limit, and key-rotation invalidation.
- Shows the exact reviewed operation, href, UID, kind, and ETag in the human preview; enforces the exact 64 KiB human-readable boundary without truncating identity.
- Uses exact `If-Match`, bounded same-origin method-preserving redirects, one mutation admission lease, and no blind write retry.
- Reconciles ambiguous dispatch deterministically: verified absence is committed, the unchanged consumed revision is not committed and non-retryable, and a changed or recreated revision remains indeterminate.
- Maps definite 2xx verification failure to committed-but-unverified, refreshes authorized conflict snapshots, preserves bounded Retry-After, and keeps all errors redacted and schema-valid.

## Local verification

- Release build: 0 warnings, 0 errors.
- Core unit tests: 809/809 passed.
- MCP unit tests: 511/511 passed.
- Focused delete tests: Core service 52/52 and MCP tool 65/65 passed.
- Raw non-Docker stdio delete tests: 9/9 passed, including native SDK MRTR continuation, decline/cancel, tamper/change rejection, duplicate properties, and the exact 256 KiB argument boundary.
- Contract catalog, MCP metadata, and host registration/order tests: 33/33 passed.
- Filtered Core/MCP coverage: 94.5% lines and 85.3% branches; required 90%/85% thresholds passed.
- Slopwatch: 0 findings; staged diff check clean.
- Independent Standards and Spec reviews: PASS.

## Local Docker limitation

The pinned Radicale MRTR success test is included, but the bounded local run stopped before the test body in `RadicaleFixture.InitializeAsync` because Testcontainers could not initialize Ryuk (`ResourceReaperException: Initialization has been cancelled`). Deterministic Core/MCP/raw tests cover stale preconditions and ambiguous mutation truth locally; the Radicale profiles remain authoritative in CI.

Closes #42

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
