### PR TITLE
Bound occurrence-query latency to Calendar resource count

### DIFF
--- a/src/DotnetAgents.CalDav.Core/Abstractions/ICalendarClient.cs
+++ b/src/DotnetAgents.CalDav.Core/Abstractions/ICalendarClient.cs
@@ -30,6 +30,18 @@ public interface ICalendarClient
         string href,
         CancellationToken cancellationToken) => await GetCalendarResourceAsync(href, cancellationToken);
 
+    /// <summary>Reads one bounded batch of complete Calendar Object Resource revisions for query evaluation.</summary>
+    async Task<IReadOnlyList<CalendarResourceRead>> GetCalendarResourcesForQueryAsync(
+        string calendarHref,
+        IReadOnlyList<string> hrefs,
+        CancellationToken cancellationToken)
+    {
+        var reads = new List<CalendarResourceRead>(hrefs.Count);
+        foreach (var href in hrefs)
+            reads.Add(await GetCalendarResourceAsync(href, cancellationToken));
+        return reads;
+    }
+
     /// <summary>Conditionally creates one complete Calendar Object Resource without overwriting.</summary>
     Task<CalendarResourceCreateResult> CreateCalendarResourceAsync(
         CalendarResourceCreateRequest request,

--- a/src/DotnetAgents.CalDav.Core/Internal/CalDavClient.cs
+++ b/src/DotnetAgents.CalDav.Core/Internal/CalDavClient.cs
@@ -4,6 +4,7 @@ using System.Buffers;
 using System.IO.Compression;
 using System.Collections.Concurrent;
 using System.Net;
+using System.Net.Http.Headers;
 using System.Text;
 using DotnetAgents.CalDav.Core.Abstractions;
 using DotnetAgents.CalDav.Core.Configuration;
@@ -221,16 +222,28 @@ internal sealed class CalDavClient : ICalendarClient
         string href,
         CancellationToken cancellationToken)
     {
+        var reads = await GetCalendarResourcesForQueryAsync(calendarHref, [href], cancellationToken);
+        return reads[0];
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<CalendarResourceRead>> GetCalendarResourcesForQueryAsync(
+        string calendarHref,
+        IReadOnlyList<string> hrefs,
+        CancellationToken cancellationToken)
+    {
         CalendarOperationProgress.SetPhase(CalendarOperationPhase.Fetch);
+        if (hrefs.Count == 0)
+            return [];
         EnsureCapabilityConfiguration();
         var generation = Volatile.Read(ref _capabilityGeneration);
-        var origin = new Uri(_options.Value.BaseUrl, UriKind.Absolute);
-        if (!TryCanonicalizeCalendarHref(origin, calendarHref, out var canonicalCalendarHref)
-            || !TryValidateAbsoluteResourceHref(href, out var resourceUri)
-            || !IsDirectResourceOf(new Uri(canonicalCalendarHref, UriKind.Absolute), resourceUri))
+        if (!TryCreateMultigetPlan(calendarHref, hrefs, out var canonicalCalendarHref, out var resourceUris))
         {
-            return new CalendarResourceRead(CalendarResourceReadCode.InvalidInput);
+            return hrefs.Select(href => new CalendarResourceRead(
+                CalendarResourceReadCode.InvalidInput,
+                ResourceHref: href)).ToArray();
         }
+        var calendarUri = new Uri(canonicalCalendarHref, UriKind.Absolute);
 
         var capabilityKey = CapabilityKey.CalendarMultiget(canonicalCalendarHref);
         if (IsUnavailable(capabilityKey))
@@ -241,7 +254,7 @@ internal sealed class CalDavClient : ICalendarClient
         {
             response = await SendReportAsync(
                 canonicalCalendarHref,
-                DavRequestBuilder.BuildCalendarMultiget(resourceUri.AbsoluteUri),
+                DavRequestBuilder.BuildCalendarMultiget(resourceUris.Select(resourceUri => resourceUri.AbsoluteUri).ToArray()),
                 cancellationToken);
         }
         catch (CalendarQueryFilterUnsupportedException exception)
@@ -249,17 +262,78 @@ internal sealed class CalDavClient : ICalendarClient
             ObserveCapability(capabilityKey, CapabilityState.Unavailable, generation);
             throw new CalendarDiscoveryUnsupportedCapabilityException(exception.Message);
         }
-        var returned = new List<string>();
-        foreach (var candidate in DavResponseParser.ParseCalendarResourceHrefs(response.Content))
+        var requested = resourceUris.Select(resourceUri => resourceUri.AbsoluteUri).ToHashSet(StringComparer.Ordinal);
+        var returned = new Dictionary<string, CalendarMultigetResource>(StringComparer.Ordinal);
+        foreach (var candidate in DavResponseParser.ParseCalendarMultigetResources(response.Content))
         {
-            if (!TryCanonicalizeResourceHref(response.RequestUri, candidate, out var canonical))
+            if (!TryAddMultigetResource(response.RequestUri, calendarUri, requested, returned, candidate))
                 throw new CalendarDiscoveryProtocolException("The Calendar multiget response contained an unsafe resource href.");
-            returned.Add(canonical);
         }
         ObserveCapability(capabilityKey, CapabilityState.Verified, generation);
-        if (!returned.Contains(resourceUri.AbsoluteUri, StringComparer.Ordinal))
-            return new CalendarResourceRead(CalendarResourceReadCode.NotFound);
-        return await GetCalendarResourceAsync(resourceUri.AbsoluteUri, cancellationToken);
+        return resourceUris.Select(resourceUri => ToCalendarResourceRead(
+                resourceUri.AbsoluteUri,
+                returned.GetValueOrDefault(resourceUri.AbsoluteUri)))
+            .ToArray();
+    }
+
+    private bool TryCreateMultigetPlan(
+        string calendarHref,
+        IReadOnlyList<string> hrefs,
+        out string canonicalCalendarHref,
+        out IReadOnlyList<Uri> resourceUris)
+    {
+        canonicalCalendarHref = string.Empty;
+        resourceUris = [];
+        var origin = new Uri(_options.Value.BaseUrl, UriKind.Absolute);
+        if (hrefs.Count > CalendarQueryPolicy.MaximumMultigetBatchSize
+            || !TryCanonicalizeCalendarHref(origin, calendarHref, out canonicalCalendarHref))
+            return false;
+
+        var calendarUri = new Uri(canonicalCalendarHref, UriKind.Absolute);
+        var validated = new List<Uri>(hrefs.Count);
+        foreach (var href in hrefs)
+        {
+            if (!TryValidateAbsoluteResourceHref(href, out var resourceUri)
+                || !IsDirectResourceOf(calendarUri, resourceUri))
+                return false;
+            validated.Add(resourceUri);
+        }
+        resourceUris = validated;
+        return true;
+    }
+
+    private bool TryAddMultigetResource(
+        Uri responseUri,
+        Uri calendarUri,
+        IReadOnlySet<string> requested,
+        IDictionary<string, CalendarMultigetResource> returned,
+        CalendarMultigetResource candidate)
+    {
+        if (!TryCanonicalizeResourceHref(responseUri, candidate.Href, out var canonical)
+            || !IsDirectResourceOf(calendarUri, new Uri(canonical, UriKind.Absolute))
+            || !requested.Contains(canonical))
+            return false;
+        return returned.TryAdd(canonical, candidate);
+    }
+
+    private static CalendarResourceRead ToCalendarResourceRead(
+        string resourceHref,
+        CalendarMultigetResource? resource)
+    {
+        if (resource is null || resource.StatusCode == (int)HttpStatusCode.NotFound)
+            return new CalendarResourceRead(CalendarResourceReadCode.NotFound, ResourceHref: resourceHref);
+        if (resource.StatusCode is < 200 or > 299 || resource.CalendarData is null)
+            return new CalendarResourceRead(CalendarResourceReadCode.UpstreamProtocolError, ResourceHref: resourceHref);
+
+        var content = StrictUtf8.GetBytes(resource.CalendarData.ReplaceLineEndings("\r\n"));
+        if (!EntityTagHeaderValue.TryParse(resource.EntityTag, out var entityTag) || entityTag.IsWeak)
+        {
+            return new CalendarResourceRead(
+                CalendarResourceReadCode.ConcurrencyUnavailable,
+                ResourceHref: resourceHref,
+                AuthoritativeUtf8: content);
+        }
+        return CalendarResourceRead.Success(resourceHref, entityTag.ToString(), content);
     }
 
     /// <inheritdoc />

--- a/src/DotnetAgents.CalDav.Core/Internal/CalendarQueryPolicy.cs
+++ b/src/DotnetAgents.CalDav.Core/Internal/CalendarQueryPolicy.cs
@@ -1,0 +1,7 @@
+namespace DotnetAgents.CalDav.Core.Internal;
+
+/// <summary>Shared bounded-query transport policy.</summary>
+internal static class CalendarQueryPolicy
+{
+    public const int MaximumMultigetBatchSize = 50;
+}

--- a/src/DotnetAgents.CalDav.Core/Internal/Xml/DavRequestBuilder.cs
+++ b/src/DotnetAgents.CalDav.Core/Internal/Xml/DavRequestBuilder.cs
@@ -8,6 +8,10 @@ namespace DotnetAgents.CalDav.Core.Internal.Xml;
 /// </summary>
 internal static class DavRequestBuilder
 {
+    // CalDAV servers evaluate time-range against the complete resource, including recurrences and
+    // detached overrides. This is only a representation envelope for DATE values and UTC offsets;
+    // it is deliberately not a recurrence lookback window.
+    private static readonly TimeSpan CandidatePlanningMargin = TimeSpan.FromDays(2);
     private static readonly XNamespace Dav = "DAV:";
     private static readonly XNamespace CalDav = "urn:ietf:params:xml:ns:caldav";
     private static readonly XNamespace AppleCs = "http://apple.com/ns/ical/";
@@ -76,8 +80,8 @@ internal static class DavRequestBuilder
         return document.ToString(SaveOptions.DisableFormatting);
     }
 
-    /// <summary>Builds a Calendar multiget request for one authoritative GET candidate.</summary>
-    public static string BuildCalendarMultiget(string resourceHref)
+    /// <summary>Builds a Calendar multiget request for one bounded authoritative resource batch.</summary>
+    public static string BuildCalendarMultiget(IReadOnlyList<string> resourceHrefs)
     {
         var document = new XDocument(
             new XDeclaration("1.0", "utf-8", null),
@@ -87,7 +91,7 @@ internal static class DavRequestBuilder
                 new XElement(Dav + "prop",
                     new XElement(Dav + "getetag"),
                     new XElement(CalDav + "calendar-data")),
-                new XElement(Dav + "href", resourceHref)));
+                resourceHrefs.Select(resourceHref => new XElement(Dav + "href", resourceHref))));
         return document.ToString(SaveOptions.DisableFormatting);
     }
 
@@ -97,14 +101,34 @@ internal static class DavRequestBuilder
         out DateTimeOffset reportFrom,
         out DateTimeOffset reportTo)
     {
-        reportFrom = from.AddTicks(-(from.Ticks % TimeSpan.TicksPerSecond));
-        var remainder = to.Ticks % TimeSpan.TicksPerSecond;
-        if (remainder == 0)
+        if (from.Ticks < DateTimeOffset.MinValue.Ticks + CandidatePlanningMargin.Ticks
+            || to.Ticks > DateTimeOffset.MaxValue.Ticks - CandidatePlanningMargin.Ticks)
         {
-            reportTo = to;
-            return true;
+            reportFrom = default;
+            reportTo = default;
+            return false;
         }
-        var ticksToAdd = TimeSpan.TicksPerSecond - remainder;
+        from -= CandidatePlanningMargin;
+        to += CandidatePlanningMargin;
+
+        var fromRemainder = from.Ticks % TimeSpan.TicksPerSecond;
+        if (fromRemainder == 0)
+        {
+            if (from.Ticks < DateTimeOffset.MinValue.Ticks + TimeSpan.TicksPerSecond)
+            {
+                reportFrom = default;
+                reportTo = default;
+                return false;
+            }
+            reportFrom = from.AddSeconds(-1);
+        }
+        else
+        {
+            reportFrom = from.AddTicks(-fromRemainder);
+        }
+
+        var toRemainder = to.Ticks % TimeSpan.TicksPerSecond;
+        var ticksToAdd = toRemainder == 0 ? TimeSpan.TicksPerSecond : TimeSpan.TicksPerSecond - toRemainder;
         if (to.Ticks > DateTimeOffset.MaxValue.Ticks - ticksToAdd)
         {
             reportTo = default;

--- a/src/DotnetAgents.CalDav.Core/Internal/Xml/DavResponseParser.cs
+++ b/src/DotnetAgents.CalDav.Core/Internal/Xml/DavResponseParser.cs
@@ -54,6 +54,15 @@ internal static class DavResponseParser
             .ToArray();
     }
 
+    /// <summary>Parses Calendar multiget resources with their response status, strong-tag candidate, and content.</summary>
+    public static IReadOnlyList<CalendarMultigetResource> ParseCalendarMultigetResources(string multistatusXml)
+    {
+        var document = ParseDocument(multistatusXml);
+        return document.Descendants(Dav + "response")
+            .Select(ParseCalendarMultigetResource)
+            .ToArray();
+    }
+
     /// <summary>Recognizes the bounded CalDAV precondition that rejects a REPORT filter.</summary>
     public static bool IsSupportedFilterError(string responseXml)
     {
@@ -119,6 +128,44 @@ internal static class DavResponseParser
             throw new XmlException("A successful WebDAV response is missing its href.");
 
         return href;
+    }
+
+    private static CalendarMultigetResource ParseCalendarMultigetResource(XElement response)
+    {
+        var href = GetRequiredMultigetHref(response);
+        var properties = GetSuccessfulMultigetProperties(response);
+        if (properties is null)
+            return new CalendarMultigetResource(href, GetMultigetFailureStatus(response), null, null);
+
+        return new CalendarMultigetResource(
+            href,
+            200,
+            properties.Element(Dav + "getetag")?.Value.Trim(),
+            properties.Element(CalDav + "calendar-data")?.Value);
+    }
+
+    private static string GetRequiredMultigetHref(XElement response)
+    {
+        var href = response.Element(Dav + "href")?.Value?.Trim();
+        return string.IsNullOrEmpty(href)
+            ? throw new XmlException("A Calendar multiget response is missing its href.")
+            : href;
+    }
+
+    private static XElement? GetSuccessfulMultigetProperties(XElement response) => response.Elements(Dav + "propstat")
+        .FirstOrDefault(IsSuccessfulPropStat)
+        ?.Element(Dav + "prop");
+
+    private static bool IsSuccessfulPropStat(XElement propStat) => propStat.Element(Dav + "status") is { } status
+        && IsSuccessStatus(status.Value);
+
+    private static int GetMultigetFailureStatus(XElement response)
+    {
+        var statusText = response.Element(Dav + "status")?.Value
+            ?? response.Elements(Dav + "propstat").Select(item => item.Element(Dav + "status")?.Value).FirstOrDefault();
+        return statusText is null
+            ? throw new XmlException("A Calendar multiget response is missing its status.")
+            : ParseStatusCode(statusText);
     }
 
     private static XDocument ParseDocument(string xml)
@@ -237,7 +284,9 @@ internal static class DavResponseParser
             && propStat.Element(Dav + "prop")?.Element(propertyName) is not null;
     }
 
-    private static bool IsSuccessStatus(string rawStatus)
+    private static bool IsSuccessStatus(string rawStatus) => ParseStatusCode(rawStatus) is >= 200 and <= 299;
+
+    private static int ParseStatusCode(string rawStatus)
     {
         var parts = rawStatus.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries);
         if (parts.Length < 2
@@ -249,8 +298,7 @@ internal static class DavResponseParser
         {
             throw new XmlException("The WebDAV response contains a malformed HTTP status line.");
         }
-
-        return statusCode is >= 200 and <= 299;
+        return statusCode;
     }
 
     private static bool IsHttpVersion(string value)
@@ -267,3 +315,9 @@ internal static class DavResponseParser
                 && version[(dot + 1)..].ContainsAnyExceptInRange('0', '9') is false;
     }
 }
+
+internal sealed record CalendarMultigetResource(
+    string Href,
+    int StatusCode,
+    string? EntityTag,
+    string? CalendarData);

--- a/src/DotnetAgents.CalDav.Core/Services/CalendarEntityQueryEngine.cs
+++ b/src/DotnetAgents.CalDav.Core/Services/CalendarEntityQueryEngine.cs
@@ -33,7 +33,8 @@ internal sealed class CalendarEntityQueryEngine
 
     public async Task<CalendarEntityQueryResult> QueryAsync(
         CalendarEntityQuery query,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        bool applyTemporalFilters = true)
     {
         if (!IsValidQueryShape(query))
             return CalendarEntityQueryResult.Failure(CalendarEntityQueryCode.InvalidInput);
@@ -63,6 +64,11 @@ internal sealed class CalendarEntityQueryEngine
         var fetched = await FetchSnapshotsAsync(candidates, plan.Diagnostics, cancellationToken);
         if (fetched.Code != CalendarEntityQueryCode.Success)
             return CalendarEntityQueryResult.Failure(fetched.Code, limits: fetched.Limits);
+        if (!applyTemporalFilters)
+        {
+            CalendarOperationProgress.SetPhase(CalendarOperationPhase.Filter);
+            return CalendarEntityQueryResult.Success(fetched.Snapshots, fetched.Diagnostics);
+        }
 
         CalendarOperationProgress.SetPhase(CalendarOperationPhase.Filter);
         var filtered = ApplyFilters(fetched.Snapshots, query, fetched.Diagnostics, cancellationToken);
@@ -110,52 +116,93 @@ internal sealed class CalendarEntityQueryEngine
         var snapshots = new List<CalendarResourceSnapshot>();
         var snapshotKeys = new HashSet<(string CalendarHref, string ResourceHref)>();
         var diagnostics = initialDiagnostics.ToList();
-        foreach (var candidate in candidates)
+        foreach (var calendarCandidates in candidates.GroupBy(candidate => candidate.Value.Href, StringComparer.Ordinal))
         {
-            cancellationToken.ThrowIfCancellationRequested();
-            CalendarResourceRead read;
-            try
+            var calendar = calendarCandidates.First().Value;
+            foreach (var batch in calendarCandidates.Select(candidate => candidate.Key)
+                         .Chunk(CalendarQueryPolicy.MaximumMultigetBatchSize))
             {
-                read = await ReadSnapshotAsync(candidate.Value, candidate.Key, cancellationToken);
-            }
-            catch (Exception exception) when (exception is CalendarDiscoveryProtocolException or XmlException)
-            {
-                return CandidateFetchResult.Failure(CalendarEntityQueryCode.UpstreamProtocolError);
-            }
-            if (read.Code == CalendarResourceReadCode.NotFound)
-            {
-                AddDiagnostic(diagnostics, "resource_disappeared_during_query",
-                    "A REPORT candidate disappeared before its authoritative snapshot was read.");
-                continue;
-            }
-            if (read.Code != CalendarResourceReadCode.Success || read.Snapshot is null)
-                return CandidateFetchResult.Failure(
-                    MapReadFailure(read.Code),
-                    read.ObservedByteCount is null
-                        ? null
-                        : new CalendarEntityQueryExecutionLimits(ByteCount: read.ObservedByteCount));
-            if (snapshotKeys.Add((read.Snapshot.CalendarHref, read.Snapshot.ResourceHref)))
-                snapshots.Add(read.Snapshot);
-            if (read.Snapshot.Projection.Kind == CalendarResourceProjectionKind.Opaque)
-            {
-                AddDiagnostic(diagnostics, "opaque_filter_unresolved",
-                    "An opaque Calendar Object Resource could not be classified by the requested semantic filters.");
+                cancellationToken.ThrowIfCancellationRequested();
+                IReadOnlyList<CalendarResourceRead> reads;
+                try
+                {
+                    reads = await ReadBatchAsync(calendar, batch, cancellationToken);
+                }
+                catch (Exception exception) when (exception is CalendarDiscoveryProtocolException or XmlException)
+                {
+                    return CandidateFetchResult.Failure(CalendarEntityQueryCode.UpstreamProtocolError);
+                }
+                foreach (var read in reads)
+                {
+                    var failure = AccumulateRead(read, snapshots, snapshotKeys, diagnostics);
+                    if (failure is not null)
+                        return failure;
+                }
             }
         }
         return CandidateFetchResult.Success(snapshots, diagnostics);
     }
 
-    private async Task<CalendarResourceRead> ReadSnapshotAsync(
+    private async Task<IReadOnlyList<CalendarResourceRead>> ReadBatchAsync(
         CalendarDescriptor calendar,
-        string href,
+        IReadOnlyList<string> hrefs,
         CancellationToken cancellationToken)
     {
-        var read = await _calendarClient.GetCalendarResourceForQueryAsync(calendar.Href, href, cancellationToken);
-        if (read is null)
-            read = await _calendarClient.GetCalendarResourceAsync(href, cancellationToken);
-        if (read.Code != CalendarResourceReadCode.Success)
-            return read;
-        return CalendarResourceProjector.AttachSnapshot(calendar.Href, read);
+        IReadOnlyList<CalendarResourceRead>? reads;
+        try
+        {
+            reads = await _calendarClient.GetCalendarResourcesForQueryAsync(calendar.Href, hrefs, cancellationToken);
+        }
+        catch (CalendarDiscoveryUnsupportedCapabilityException)
+        {
+            reads = null;
+        }
+        if (reads is null || reads.Count != hrefs.Count)
+            reads = await ReadDirectlyAsync(hrefs, cancellationToken);
+        return reads.Select(read => read.Code == CalendarResourceReadCode.Success
+                ? CalendarResourceProjector.AttachSnapshot(calendar.Href, read)
+                : read)
+            .ToArray();
+    }
+
+    private async Task<IReadOnlyList<CalendarResourceRead>> ReadDirectlyAsync(
+        IReadOnlyList<string> hrefs,
+        CancellationToken cancellationToken)
+    {
+        var reads = new List<CalendarResourceRead>(hrefs.Count);
+        foreach (var href in hrefs)
+            reads.Add(await _calendarClient.GetCalendarResourceAsync(href, cancellationToken));
+        return reads;
+    }
+
+    private static CandidateFetchResult? AccumulateRead(
+        CalendarResourceRead read,
+        ICollection<CalendarResourceSnapshot> snapshots,
+        ISet<(string CalendarHref, string ResourceHref)> snapshotKeys,
+        ICollection<CalendarResourceDiagnostic> diagnostics)
+    {
+        if (read.Code == CalendarResourceReadCode.NotFound)
+        {
+            AddDiagnostic(diagnostics, "resource_disappeared_during_query",
+                "A REPORT candidate disappeared before its authoritative snapshot was read.");
+            return null;
+        }
+        if (read.Code != CalendarResourceReadCode.Success || read.Snapshot is null)
+        {
+            return CandidateFetchResult.Failure(
+                MapReadFailure(read.Code),
+                read.ObservedByteCount is null
+                    ? null
+                    : new CalendarEntityQueryExecutionLimits(ByteCount: read.ObservedByteCount));
+        }
+        if (snapshotKeys.Add((read.Snapshot.CalendarHref, read.Snapshot.ResourceHref)))
+            snapshots.Add(read.Snapshot);
+        if (read.Snapshot.Projection.Kind == CalendarResourceProjectionKind.Opaque)
+        {
+            AddDiagnostic(diagnostics, "opaque_filter_unresolved",
+                "An opaque Calendar Object Resource could not be classified by the requested semantic filters.");
+        }
+        return null;
     }
 
     private static FilterResult ApplyFilters(

--- a/src/DotnetAgents.CalDav.Core/Services/CalendarOccurrenceQueryEngine.cs
+++ b/src/DotnetAgents.CalDav.Core/Services/CalendarOccurrenceQueryEngine.cs
@@ -31,8 +31,13 @@ internal sealed class CalendarOccurrenceQueryEngine
             return CalendarOccurrenceQueryResult.Failure(CalendarOccurrenceQueryCode.InvalidInput);
 
         var resources = await _entityQueryEngine.QueryAsync(
-            new CalendarEntityQuery(query.Scope, [CalendarEntityKind.Event, CalendarEntityKind.Todo]),
-            cancellationToken);
+            new CalendarEntityQuery(
+                query.Scope,
+                [CalendarEntityKind.Event, CalendarEntityKind.Todo],
+                query.From,
+                query.To),
+            cancellationToken,
+            applyTemporalFilters: false);
         if (resources.Code != CalendarEntityQueryCode.Success)
             return MapResourceFailure(resources);
 

--- a/tests/DotnetAgents.CalDav.Core.Tests.Unit/Internal/CalDavClientTests.cs
+++ b/tests/DotnetAgents.CalDav.Core.Tests.Unit/Internal/CalDavClientTests.cs
@@ -17,7 +17,90 @@ namespace DotnetAgents.CalDav.Core.Tests.Unit.Internal;
 public class CalDavClientTests
 {
     [Fact]
-    public async Task GetCalendarResourceForQueryAsync_UsesCalendarMultigetThenAuthoritativeGet()
+    public async Task GetCalendarResourcesForQueryAsync_ReturnsFiveAuthoritativeResourcesFromOneMultiget()
+    {
+        const string calendarHref = "https://example.com/calendars/user/events/";
+        var hrefs = Enumerable.Range(1, 5).Select(index => $"{calendarHref}{index}.ics").ToArray();
+        var requests = new List<(HttpMethod Method, string Body)>();
+        var responses = string.Concat(hrefs.Select((href, index) =>
+            $"<d:response><d:href>{new Uri(href).AbsolutePath}</d:href><d:propstat><d:prop>"
+            + $"<d:getetag>&quot;r{index + 1}&quot;</d:getetag>"
+            + $"<c:calendar-data>BEGIN:VCALENDAR\nBEGIN:VEVENT\nUID:event-{index + 1}\n"
+            + "END:VEVENT\nEND:VCALENDAR\n</c:calendar-data>"
+            + "</d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat></d:response>"));
+        var handler = new StubHttpMessageHandler(request =>
+        {
+            requests.Add((request.Method, request.Content is null
+                ? string.Empty
+                : request.Content.ReadAsStringAsync(TestContext.Current.CancellationToken).GetAwaiter().GetResult()));
+            if (request.Method.Method == "REPORT")
+            {
+                return new HttpResponseMessage(HttpStatusCode.MultiStatus)
+                {
+                    Content = new StringContent(
+                        $"<d:multistatus xmlns:d='DAV:' xmlns:c='urn:ietf:params:xml:ns:caldav'>{responses}</d:multistatus>")
+                };
+            }
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Headers = { ETag = new EntityTagHeaderValue("\"fallback\"") },
+                Content = new StringContent("unexpected fallback")
+            };
+        });
+        var sut = CreateSut(handler);
+
+        var results = await sut.GetCalendarResourcesForQueryAsync(calendarHref, hrefs, CancellationToken.None);
+
+        results.Count.ShouldBe(5);
+        results.ShouldAllBe(result => result.Code == CalendarResourceReadCode.Success);
+        results.Select(result => result.ResourceHref).ShouldBe(hrefs);
+        results.Select(result => result.EntityTag).ShouldBe(Enumerable.Range(1, 5).Select(index => $"\"r{index}\"").ToArray());
+        Encoding.UTF8.GetString(results[0].AuthoritativeUtf8.Span).ShouldBe(
+            "BEGIN:VCALENDAR\r\nBEGIN:VEVENT\r\nUID:event-1\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n");
+        requests.Count.ShouldBe(1);
+        requests[0].Method.Method.ShouldBe("REPORT");
+        requests[0].Body.ShouldContain("calendar-multiget");
+        hrefs.ShouldAllBe(href => requests[0].Body.Contains(href, StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task GetCalendarResourcesForQueryAsync_ReturnsTypedPerResourceFailuresWithoutFallbackGets()
+    {
+        const string calendarHref = "https://example.com/calendars/user/events/";
+        var hrefs = Enumerable.Range(1, 5).Select(index => $"{calendarHref}{index}.ics").ToArray();
+        var requestCount = 0;
+        var sut = CreateSut(new StubHttpMessageHandler(request =>
+        {
+            requestCount++;
+            request.Method.Method.ShouldBe("REPORT");
+            return new HttpResponseMessage(HttpStatusCode.MultiStatus)
+            {
+                Content = new StringContent("""
+                    <d:multistatus xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:caldav">
+                      <d:response><d:href>/calendars/user/events/2.ics</d:href><d:status>HTTP/1.1 404 Not Found</d:status></d:response>
+                      <d:response><d:href>/calendars/user/events/3.ics</d:href><d:propstat><d:prop><d:getetag>W/&quot;r3&quot;</d:getetag><c:calendar-data>weak</c:calendar-data></d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat></d:response>
+                      <d:response><d:href>/calendars/user/events/4.ics</d:href><d:status>HTTP/1.1 500 Server Error</d:status></d:response>
+                      <d:response><d:href>/calendars/user/events/5.ics</d:href><d:propstat><d:prop><d:getetag>&quot;r5&quot;</d:getetag></d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat></d:response>
+                    </d:multistatus>
+                    """)
+            };
+        }));
+
+        var results = await sut.GetCalendarResourcesForQueryAsync(calendarHref, hrefs, CancellationToken.None);
+
+        results.Select(result => result.Code).ShouldBe([
+            CalendarResourceReadCode.NotFound,
+            CalendarResourceReadCode.NotFound,
+            CalendarResourceReadCode.ConcurrencyUnavailable,
+            CalendarResourceReadCode.UpstreamProtocolError,
+            CalendarResourceReadCode.UpstreamProtocolError
+        ]);
+        Encoding.UTF8.GetString(results[2].AuthoritativeUtf8.Span).ShouldBe("weak");
+        requestCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task GetCalendarResourceForQueryAsync_UsesCalendarMultigetAsAuthoritativeRead()
     {
         const string calendarHref = "https://example.com/calendars/user/events/";
         const string resourceHref = "https://example.com/calendars/user/events/a.ics";
@@ -45,8 +128,8 @@ public class CalDavClientTests
         var result = await sut.GetCalendarResourceForQueryAsync(calendarHref, resourceHref, CancellationToken.None);
 
         result.Code.ShouldBe(CalendarResourceReadCode.Success);
-        Encoding.UTF8.GetString(result.AuthoritativeUtf8.Span).ShouldBe("authoritative\r\nX-KEEP:opaque\r\n");
-        requests.Select(request => request.Method.Method).ShouldBe(["REPORT", "GET"]);
+        Encoding.UTF8.GetString(result.AuthoritativeUtf8.Span).ShouldBe("normalized-only-for-capability");
+        requests.Select(request => request.Method.Method).ShouldBe(["REPORT"]);
         requests[0].Body.ShouldContain("calendar-multiget");
         requests[0].Body.ShouldContain("calendar-data");
         requests[0].Body.ShouldContain(resourceHref);
@@ -611,8 +694,8 @@ public class CalDavClientTests
         captured.Headers.GetValues("Depth").ShouldBe(["1"]);
         var body = await captured.Content!.ReadAsStringAsync(CancellationToken.None);
         body.ShouldContain("name=\"VEVENT\"");
-        body.ShouldContain("start=\"20260816T100000Z\"");
-        body.ShouldContain("end=\"20260817T100000Z\"");
+        body.ShouldContain("start=\"20260814T095959Z\"");
+        body.ShouldContain("end=\"20260819T100001Z\"");
         body.ShouldNotContain("calendar-data");
     }
 
@@ -638,8 +721,45 @@ public class CalDavClientTests
             CancellationToken.None);
 
         body.ShouldNotBeNull();
-        body.ShouldContain("start=\"20260816T100000Z\"");
-        body.ShouldContain("end=\"20260816T110001Z\"");
+        body.ShouldContain("start=\"20260814T100000Z\"");
+        body.ShouldContain("end=\"20260818T110001Z\"");
+    }
+
+    [Fact]
+    public async Task QueryCalendarResourceHrefsAsync_OmitsUnsafeNearLimitRanges()
+    {
+        var bodies = new List<string>();
+        var handler = new AsyncStubHttpMessageHandler(async request =>
+        {
+            bodies.Add(await request.Content!.ReadAsStringAsync(CancellationToken.None));
+            return new HttpResponseMessage(HttpStatusCode.MultiStatus)
+            {
+                Content = new StringContent("<d:multistatus xmlns:d=\"DAV:\"/>")
+            };
+        });
+        var sut = CreateSut(handler);
+        var minimumSafeFrom = DateTimeOffset.MinValue.AddDays(2);
+        var maximumSafeTo = DateTimeOffset.MaxValue.AddDays(-2);
+        (DateTimeOffset From, DateTimeOffset To)[] ranges =
+        [
+            (minimumSafeFrom.AddTicks(-1), minimumSafeFrom.AddHours(1)),
+            (minimumSafeFrom, minimumSafeFrom.AddHours(1)),
+            (maximumSafeTo.AddHours(-1), maximumSafeTo),
+            (maximumSafeTo.AddHours(-1), maximumSafeTo.AddTicks(1))
+        ];
+
+        foreach (var range in ranges)
+        {
+            await sut.QueryCalendarResourceHrefsAsync(
+                "https://example.com/calendars/user/events/",
+                CalendarEntityKind.Event,
+                range.From,
+                range.To,
+                CancellationToken.None);
+        }
+
+        bodies.Count.ShouldBe(ranges.Length);
+        bodies.ShouldAllBe(body => !body.Contains("time-range", StringComparison.Ordinal));
     }
 
     [Fact]

--- a/tests/DotnetAgents.CalDav.Core.Tests.Unit/Services/CalendarServiceTests.cs
+++ b/tests/DotnetAgents.CalDav.Core.Tests.Unit/Services/CalendarServiceTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Net;
 using System.Net.Http.Headers;
 using System.Text.Json;
@@ -56,15 +57,15 @@ public sealed class CalendarServiceTests
         client.QueryCalendarResourceHrefsAsync(
                 calendarHref,
                 CalendarEntityKind.Event,
-                null,
-                null,
+                Arg.Any<DateTimeOffset?>(),
+                Arg.Any<DateTimeOffset?>(),
                 Arg.Any<CancellationToken>())
             .Returns([resourceHref]);
         client.QueryCalendarResourceHrefsAsync(
                 calendarHref,
                 CalendarEntityKind.Todo,
-                null,
-                null,
+                Arg.Any<DateTimeOffset?>(),
+                Arg.Any<DateTimeOffset?>(),
                 Arg.Any<CancellationToken>())
             .Returns([]);
         client.GetCalendarResourceAsync(resourceHref, Arg.Any<CancellationToken>()).Returns(
@@ -92,6 +93,176 @@ public sealed class CalendarServiceTests
     }
 
     [Fact]
+    public async Task QueryOccurrencesAsync_PreservesRequestedWindowInCandidatePlanning()
+    {
+        const string calendarHref = "https://cal.example/events/";
+        const string resourceHref = "https://cal.example/events/recurring.ics";
+        var from = DateTimeOffset.Parse("2026-08-17T20:30:00Z");
+        var to = DateTimeOffset.Parse("2026-08-17T20:45:00Z");
+        var client = Substitute.For<ICalendarClient>();
+        var sut = new CalendarService(
+            client,
+            Options.Create(new CalDavOptions { BaseUrl = "https://cal.example" }),
+            Substitute.For<ILogger<CalendarService>>());
+        client.GetCalendarsAsync(Arg.Any<CancellationToken>()).Returns(
+            [EntityCalendar(calendarHref, "Events", EntityKindSupport.Advertised, EntityKindSupport.NotAdvertised)]);
+        client.QueryCalendarResourceHrefsAsync(
+                calendarHref,
+                CalendarEntityKind.Event,
+                from,
+                to,
+                Arg.Any<CancellationToken>())
+            .Returns([resourceHref]);
+        client.QueryCalendarResourceHrefsAsync(
+                calendarHref,
+                CalendarEntityKind.Todo,
+                from,
+                to,
+                Arg.Any<CancellationToken>())
+            .Returns([]);
+        client.GetCalendarResourceAsync(resourceHref, Arg.Any<CancellationToken>()).Returns(
+            CalendarResourceRead.Success(resourceHref, "\"r1\"", OverrideEvent()));
+
+        var result = await sut.QueryOccurrencesAsync(
+            new CalendarOccurrenceQuery(
+                CalendarEntityScope.Selected(new CalendarReference(Href: calendarHref)),
+                from,
+                to),
+            CancellationToken.None);
+
+        result.Code.ShouldBe(CalendarOccurrenceQueryCode.Success);
+        result.Items.ShouldHaveSingleItem().RecurrenceIdentity.Value.ShouldBe("2026-08-17T10:00:00Z");
+        await client.Received(1).QueryCalendarResourceHrefsAsync(
+            calendarHref,
+            CalendarEntityKind.Event,
+            from,
+            to,
+            Arg.Any<CancellationToken>());
+        await client.Received(1).QueryCalendarResourceHrefsAsync(
+            calendarHref,
+            CalendarEntityKind.Todo,
+            from,
+            to,
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task QueryOccurrencesAsync_FetchesFiveCandidatesInOneAuthoritativeBatch()
+    {
+        const string calendarHref = "https://cal.example/events/";
+        var from = DateTimeOffset.Parse("2026-08-16T10:00:00Z");
+        var to = DateTimeOffset.Parse("2026-08-16T11:00:00Z");
+        var hrefs = Enumerable.Range(1, 5).Select(index => $"{calendarHref}{index}.ics").ToArray();
+        var requests = new List<(HttpMethod Method, string Body)>();
+        var handler = new AsyncHttpMessageHandler(async (request, cancellationToken) =>
+        {
+            var body = await request.Content!.ReadAsStringAsync(cancellationToken);
+            requests.Add((request.Method, body));
+            _ = await Delayed(true);
+            var responseBody = body.Contains("calendar-multiget", StringComparison.Ordinal)
+                ? MultigetResponse(hrefs)
+                : body.Contains("name=\"VEVENT\"", StringComparison.Ordinal)
+                    ? CandidateResponse(hrefs)
+                    : CandidateResponse([]);
+            return new HttpResponseMessage(HttpStatusCode.MultiStatus)
+            {
+                Content = new StringContent(responseBody)
+            };
+        });
+        var options = Options.Create(new CalDavOptions
+        {
+            BaseUrl = "https://cal.example",
+            CalendarHrefs = calendarHref
+        });
+        using var httpClient = new HttpClient(handler);
+        var transport = new CalDavClient(httpClient, options, Substitute.For<ILogger<CalDavClient>>());
+        var client = new DelegatingQueryCalendarClient(
+            transport,
+            EntityCalendar(calendarHref, "Events", EntityKindSupport.Advertised, EntityKindSupport.NotAdvertised));
+        var sut = new CalendarService(client, options, Substitute.For<ILogger<CalendarService>>());
+
+        var stopwatch = Stopwatch.StartNew();
+        var result = await sut.QueryOccurrencesAsync(
+            new CalendarOccurrenceQuery(
+                CalendarEntityScope.Selected(new CalendarReference(Href: calendarHref)),
+                from,
+                to),
+            CancellationToken.None);
+        stopwatch.Stop();
+
+        result.Code.ShouldBe(CalendarOccurrenceQueryCode.Success);
+        result.Items.Count.ShouldBe(5);
+        stopwatch.Elapsed.ShouldBeLessThan(TimeSpan.FromSeconds(15));
+        requests.Count.ShouldBe(3);
+        requests.ShouldAllBe(request => request.Method.Method == "REPORT");
+        requests.Count(request => request.Body.Contains("calendar-query", StringComparison.Ordinal)).ShouldBe(2);
+        requests.Count(request => request.Body.Contains("calendar-multiget", StringComparison.Ordinal)).ShouldBe(1);
+        hrefs.ShouldAllBe(href => requests[2].Body.Contains(href, StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task QueryOccurrencesAsync_RequestCountGrowsByBoundedBatches()
+    {
+        const string calendarHref = "https://cal.example/events/";
+        var from = DateTimeOffset.Parse("2026-08-16T10:00:00Z");
+        var to = DateTimeOffset.Parse("2026-08-16T11:00:00Z");
+        var hrefs = Enumerable.Range(1, 51).Select(index => $"{calendarHref}{index}.ics").ToArray();
+        var batchSizes = new List<int>();
+        var client = Substitute.For<ICalendarClient>();
+        var sut = new CalendarService(
+            client,
+            Options.Create(new CalDavOptions { BaseUrl = "https://cal.example" }),
+            Substitute.For<ILogger<CalendarService>>());
+        client.GetCalendarsAsync(Arg.Any<CancellationToken>()).Returns(
+            [EntityCalendar(calendarHref, "Events", EntityKindSupport.Advertised, EntityKindSupport.NotAdvertised)]);
+        client.QueryCalendarResourceHrefsAsync(
+                calendarHref,
+                CalendarEntityKind.Event,
+                from,
+                to,
+                Arg.Any<CancellationToken>())
+            .Returns(hrefs);
+        client.QueryCalendarResourceHrefsAsync(
+                calendarHref,
+                CalendarEntityKind.Todo,
+                from,
+                to,
+                Arg.Any<CancellationToken>())
+            .Returns([]);
+        client.GetCalendarResourcesForQueryAsync(
+                calendarHref,
+                Arg.Any<IReadOnlyList<string>>(),
+                Arg.Any<CancellationToken>())
+            .Returns(call =>
+            {
+                var batch = call.ArgAt<IReadOnlyList<string>>(1);
+                batchSizes.Add(batch.Count);
+                return batch.Select((href, index) => CalendarResourceRead.Success(
+                    href,
+                    $"\"r{index + 1}\"",
+                    Event(href, "20260816T103000Z", href))).ToArray();
+            });
+
+        var result = await sut.QueryOccurrencesAsync(
+            new CalendarOccurrenceQuery(
+                CalendarEntityScope.Selected(new CalendarReference(Href: calendarHref)),
+                from,
+                to),
+            CancellationToken.None);
+
+        result.Code.ShouldBe(CalendarOccurrenceQueryCode.Success);
+        result.Items.Count.ShouldBe(51);
+        batchSizes.ShouldBe([50, 1]);
+        await client.Received(2).GetCalendarResourcesForQueryAsync(
+            calendarHref,
+            Arg.Any<IReadOnlyList<string>>(),
+            Arg.Any<CancellationToken>());
+        await client.DidNotReceive().GetCalendarResourceAsync(
+            Arg.Any<string>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public async Task QueryOccurrencesAsync_SelectedScopeIncludesEventsAndEveryTimedTodoForm()
     {
         const string calendarHref = "https://cal.example/mixed/";
@@ -104,9 +275,11 @@ public sealed class CalendarServiceTests
             Substitute.For<ILogger<CalendarService>>());
         client.GetCalendarsAsync(Arg.Any<CancellationToken>()).Returns(
             [EntityCalendar(calendarHref, "Mixed", EntityKindSupport.Advertised, EntityKindSupport.Advertised)]);
-        client.QueryCalendarResourceHrefsAsync(calendarHref, CalendarEntityKind.Event, null, null, Arg.Any<CancellationToken>())
+        client.QueryCalendarResourceHrefsAsync(calendarHref, CalendarEntityKind.Event,
+                Arg.Any<DateTimeOffset?>(), Arg.Any<DateTimeOffset?>(), Arg.Any<CancellationToken>())
             .Returns([hrefs["event"]]);
-        client.QueryCalendarResourceHrefsAsync(calendarHref, CalendarEntityKind.Todo, null, null, Arg.Any<CancellationToken>())
+        client.QueryCalendarResourceHrefsAsync(calendarHref, CalendarEntityKind.Todo,
+                Arg.Any<DateTimeOffset?>(), Arg.Any<DateTimeOffset?>(), Arg.Any<CancellationToken>())
             .Returns([hrefs["todo-span"], hrefs["todo-due"], hrefs["todo-start"], hrefs["todo-none"]]);
         client.GetCalendarResourceAsync(hrefs["event"], Arg.Any<CancellationToken>()).Returns(
             CalendarResourceRead.Success(hrefs["event"], "\"e1\"", Event("event", "20260816T101500Z", "Event")));
@@ -147,9 +320,19 @@ public sealed class CalendarServiceTests
             Substitute.For<ILogger<CalendarService>>());
         client.GetCalendarsAsync(Arg.Any<CancellationToken>()).Returns(
             [EntityCalendar(calendarHref, "Events", EntityKindSupport.Advertised, EntityKindSupport.NotAdvertised)]);
-        client.QueryCalendarResourceHrefsAsync(calendarHref, CalendarEntityKind.Event, null, null, Arg.Any<CancellationToken>())
+        client.QueryCalendarResourceHrefsAsync(
+                calendarHref,
+                CalendarEntityKind.Event,
+                Arg.Any<DateTimeOffset?>(),
+                Arg.Any<DateTimeOffset?>(),
+                Arg.Any<CancellationToken>())
             .Returns([resourceHref]);
-        client.QueryCalendarResourceHrefsAsync(calendarHref, CalendarEntityKind.Todo, null, null, Arg.Any<CancellationToken>())
+        client.QueryCalendarResourceHrefsAsync(
+                calendarHref,
+                CalendarEntityKind.Todo,
+                Arg.Any<DateTimeOffset?>(),
+                Arg.Any<DateTimeOffset?>(),
+                Arg.Any<CancellationToken>())
             .Returns([]);
         client.GetCalendarResourceAsync(resourceHref, Arg.Any<CancellationToken>()).Returns(
             CalendarResourceRead.Success(resourceHref, "\"r1\"", OverrideEvent()));
@@ -192,9 +375,11 @@ public sealed class CalendarServiceTests
             Substitute.For<ILogger<CalendarService>>());
         client.GetCalendarsAsync(Arg.Any<CancellationToken>()).Returns(
             [EntityCalendar(calendarHref, "Events", EntityKindSupport.Advertised, EntityKindSupport.NotAdvertised)]);
-        client.QueryCalendarResourceHrefsAsync(calendarHref, CalendarEntityKind.Event, null, null, Arg.Any<CancellationToken>())
+        client.QueryCalendarResourceHrefsAsync(calendarHref, CalendarEntityKind.Event,
+                Arg.Any<DateTimeOffset?>(), Arg.Any<DateTimeOffset?>(), Arg.Any<CancellationToken>())
             .Returns([resourceHref]);
-        client.QueryCalendarResourceHrefsAsync(calendarHref, CalendarEntityKind.Todo, null, null, Arg.Any<CancellationToken>())
+        client.QueryCalendarResourceHrefsAsync(calendarHref, CalendarEntityKind.Todo,
+                Arg.Any<DateTimeOffset?>(), Arg.Any<DateTimeOffset?>(), Arg.Any<CancellationToken>())
             .Returns([]);
         client.GetCalendarResourceAsync(resourceHref, Arg.Any<CancellationToken>()).Returns(
             CalendarResourceRead.Success(resourceHref, "\"r1\"", RangeOverrideEvent()));
@@ -1095,9 +1280,11 @@ public sealed class CalendarServiceTests
             Substitute.For<ILogger<CalendarService>>());
         client.GetCalendarsAsync(Arg.Any<CancellationToken>()).Returns(
             [EntityCalendar(calendarHref, "Events", EntityKindSupport.Advertised, EntityKindSupport.NotAdvertised)]);
-        client.QueryCalendarResourceHrefsAsync(calendarHref, CalendarEntityKind.Event, null, null, Arg.Any<CancellationToken>())
+        client.QueryCalendarResourceHrefsAsync(calendarHref, CalendarEntityKind.Event,
+                Arg.Any<DateTimeOffset?>(), Arg.Any<DateTimeOffset?>(), Arg.Any<CancellationToken>())
             .Returns([resourceHref]);
-        client.QueryCalendarResourceHrefsAsync(calendarHref, CalendarEntityKind.Todo, null, null, Arg.Any<CancellationToken>())
+        client.QueryCalendarResourceHrefsAsync(calendarHref, CalendarEntityKind.Todo,
+                Arg.Any<DateTimeOffset?>(), Arg.Any<DateTimeOffset?>(), Arg.Any<CancellationToken>())
             .Returns([]);
         client.GetCalendarResourceAsync(resourceHref, Arg.Any<CancellationToken>()).Returns(
             CalendarResourceRead.Success(resourceHref, "\"r1\"", EventWithRawStart("floating", string.Empty, "20260816T100000")));
@@ -1404,9 +1591,11 @@ public sealed class CalendarServiceTests
             Substitute.For<ILogger<CalendarService>>());
         client.GetCalendarsAsync(Arg.Any<CancellationToken>()).Returns(
             [EntityCalendar(calendarHref, "Events", EntityKindSupport.Advertised, EntityKindSupport.NotAdvertised)]);
-        client.QueryCalendarResourceHrefsAsync(calendarHref, CalendarEntityKind.Event, null, null, Arg.Any<CancellationToken>())
+        client.QueryCalendarResourceHrefsAsync(calendarHref, CalendarEntityKind.Event,
+                Arg.Any<DateTimeOffset?>(), Arg.Any<DateTimeOffset?>(), Arg.Any<CancellationToken>())
             .Returns([resourceHref]);
-        client.QueryCalendarResourceHrefsAsync(calendarHref, CalendarEntityKind.Todo, null, null, Arg.Any<CancellationToken>())
+        client.QueryCalendarResourceHrefsAsync(calendarHref, CalendarEntityKind.Todo,
+                Arg.Any<DateTimeOffset?>(), Arg.Any<DateTimeOffset?>(), Arg.Any<CancellationToken>())
             .Returns([]);
         client.GetCalendarResourceAsync(resourceHref, Arg.Any<CancellationToken>()).Returns(
             CalendarResourceRead.Success(resourceHref, "\"r1\"", ResourceLocalZoneEvent()));
@@ -1504,9 +1693,11 @@ public sealed class CalendarServiceTests
             Substitute.For<ILogger<CalendarService>>());
         client.GetCalendarsAsync(Arg.Any<CancellationToken>()).Returns(
             [EntityCalendar(calendarHref, "To-dos", EntityKindSupport.NotAdvertised, EntityKindSupport.Advertised)]);
-        client.QueryCalendarResourceHrefsAsync(calendarHref, CalendarEntityKind.Event, null, null, Arg.Any<CancellationToken>())
+        client.QueryCalendarResourceHrefsAsync(calendarHref, CalendarEntityKind.Event,
+                Arg.Any<DateTimeOffset?>(), Arg.Any<DateTimeOffset?>(), Arg.Any<CancellationToken>())
             .Returns([]);
-        client.QueryCalendarResourceHrefsAsync(calendarHref, CalendarEntityKind.Todo, null, null, Arg.Any<CancellationToken>())
+        client.QueryCalendarResourceHrefsAsync(calendarHref, CalendarEntityKind.Todo,
+                Arg.Any<DateTimeOffset?>(), Arg.Any<DateTimeOffset?>(), Arg.Any<CancellationToken>())
             .Returns([startHref, dueHref]);
         client.GetCalendarResourceAsync(startHref, Arg.Any<CancellationToken>()).Returns(
             CalendarResourceRead.Success(startHref, "\"s1\"", TodoWithTemporalLines("start", "DTSTART;VALUE=DATE:20260816\r\n")));
@@ -1706,11 +1897,14 @@ public sealed class CalendarServiceTests
             EntityCalendar(laterCalendar, "Z", EntityKindSupport.Advertised, EntityKindSupport.NotAdvertised),
             EntityCalendar(firstCalendar, "A", EntityKindSupport.Advertised, EntityKindSupport.NotAdvertised)
         ]);
-        client.QueryCalendarResourceHrefsAsync(firstCalendar, CalendarEntityKind.Event, null, null, Arg.Any<CancellationToken>())
+        client.QueryCalendarResourceHrefsAsync(firstCalendar, CalendarEntityKind.Event,
+                Arg.Any<DateTimeOffset?>(), Arg.Any<DateTimeOffset?>(), Arg.Any<CancellationToken>())
             .Returns([laterUidHref, recurringHref]);
-        client.QueryCalendarResourceHrefsAsync(laterCalendar, CalendarEntityKind.Event, null, null, Arg.Any<CancellationToken>())
+        client.QueryCalendarResourceHrefsAsync(laterCalendar, CalendarEntityKind.Event,
+                Arg.Any<DateTimeOffset?>(), Arg.Any<DateTimeOffset?>(), Arg.Any<CancellationToken>())
             .Returns([laterCalendarHref]);
-        client.QueryCalendarResourceHrefsAsync(Arg.Any<string>(), CalendarEntityKind.Todo, null, null, Arg.Any<CancellationToken>())
+        client.QueryCalendarResourceHrefsAsync(Arg.Any<string>(), CalendarEntityKind.Todo,
+                Arg.Any<DateTimeOffset?>(), Arg.Any<DateTimeOffset?>(), Arg.Any<CancellationToken>())
             .Returns([]);
         client.GetCalendarResourceAsync(recurringHref, Arg.Any<CancellationToken>()).Returns(
             CalendarResourceRead.Success(recurringHref, "\"r1\"", SameEffectiveStartRecurrence("a")));
@@ -1750,9 +1944,11 @@ public sealed class CalendarServiceTests
             Substitute.For<ILogger<CalendarService>>());
         client.GetCalendarsAsync(Arg.Any<CancellationToken>()).Returns(
             [EntityCalendar(calendarHref, "Events", EntityKindSupport.Advertised, EntityKindSupport.NotAdvertised)]);
-        client.QueryCalendarResourceHrefsAsync(calendarHref, CalendarEntityKind.Event, null, null, Arg.Any<CancellationToken>())
+        client.QueryCalendarResourceHrefsAsync(calendarHref, CalendarEntityKind.Event,
+                Arg.Any<DateTimeOffset?>(), Arg.Any<DateTimeOffset?>(), Arg.Any<CancellationToken>())
             .Returns([vanished, current]);
-        client.QueryCalendarResourceHrefsAsync(calendarHref, CalendarEntityKind.Todo, null, null, Arg.Any<CancellationToken>())
+        client.QueryCalendarResourceHrefsAsync(calendarHref, CalendarEntityKind.Todo,
+                Arg.Any<DateTimeOffset?>(), Arg.Any<DateTimeOffset?>(), Arg.Any<CancellationToken>())
             .Returns([]);
         client.GetCalendarResourceAsync(vanished, Arg.Any<CancellationToken>()).Returns(
             new CalendarResourceRead(CalendarResourceReadCode.NotFound));
@@ -1783,9 +1979,11 @@ public sealed class CalendarServiceTests
             Substitute.For<ILogger<CalendarService>>());
         client.GetCalendarsAsync(Arg.Any<CancellationToken>()).Returns(
             [EntityCalendar(calendarHref, "Events", EntityKindSupport.Advertised, EntityKindSupport.NotAdvertised)]);
-        client.QueryCalendarResourceHrefsAsync(calendarHref, CalendarEntityKind.Event, null, null, Arg.Any<CancellationToken>())
+        client.QueryCalendarResourceHrefsAsync(calendarHref, CalendarEntityKind.Event,
+                Arg.Any<DateTimeOffset?>(), Arg.Any<DateTimeOffset?>(), Arg.Any<CancellationToken>())
             .Returns([resourceHref]);
-        client.QueryCalendarResourceHrefsAsync(calendarHref, CalendarEntityKind.Todo, null, null, Arg.Any<CancellationToken>())
+        client.QueryCalendarResourceHrefsAsync(calendarHref, CalendarEntityKind.Todo,
+                Arg.Any<DateTimeOffset?>(), Arg.Any<DateTimeOffset?>(), Arg.Any<CancellationToken>())
             .Returns([]);
         client.GetCalendarResourceAsync(resourceHref, Arg.Any<CancellationToken>())
             .Returns<Task<CalendarResourceRead>>(_ => throw new CalendarDiscoveryProtocolException("candidate failure"));
@@ -3586,6 +3784,32 @@ public sealed class CalendarServiceTests
     private static byte[] Mixed(string eventUid, string todoUid) => System.Text.Encoding.UTF8.GetBytes(
         $"BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Example//EN\r\nBEGIN:VEVENT\r\nUID:{eventUid}\r\nDTSTAMP:20260815T120000Z\r\nDTSTART:20260816T090000Z\r\nEND:VEVENT\r\nBEGIN:VTODO\r\nUID:{todoUid}\r\nDTSTAMP:20260815T120000Z\r\nEND:VTODO\r\nEND:VCALENDAR\r\n");
 
+    private static async Task<T> Delayed<T>(T result)
+    {
+        using var timer = new PeriodicTimer(TimeSpan.FromSeconds(2.5));
+        _ = await timer.WaitForNextTickAsync(TestContext.Current.CancellationToken);
+        return result;
+    }
+
+    private static string CandidateResponse(IReadOnlyList<string> hrefs) =>
+        "<d:multistatus xmlns:d=\"DAV:\">"
+        + string.Concat(hrefs.Select(href =>
+            $"<d:response><d:href>{href}</d:href><d:status>HTTP/1.1 200 OK</d:status></d:response>"))
+        + "</d:multistatus>";
+
+    private static string MultigetResponse(IReadOnlyList<string> hrefs) =>
+        "<d:multistatus xmlns:d=\"DAV:\" xmlns:c=\"urn:ietf:params:xml:ns:caldav\">"
+        + string.Concat(hrefs.Select((href, index) =>
+        {
+            var content = System.Text.Encoding.UTF8.GetString(
+                Event($"event-{index + 1}", $"20260816T10{index:D2}00Z", $"Event {index + 1}"));
+            return $"<d:response><d:href>{href}</d:href><d:propstat><d:prop>"
+                + $"<d:getetag>&quot;r{index + 1}&quot;</d:getetag>"
+                + $"<c:calendar-data>{System.Security.SecurityElement.Escape(content)}</c:calendar-data>"
+                + "</d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat></d:response>";
+        }))
+        + "</d:multistatus>";
+
     private static async Task<CalendarEntityQueryResult> QuerySingleEventAsync(
         string temporalLines,
         string from,
@@ -3631,9 +3855,19 @@ public sealed class CalendarServiceTests
             Substitute.For<ILogger<CalendarService>>());
         client.GetCalendarsAsync(Arg.Any<CancellationToken>()).Returns(
             [EntityCalendar(calendarHref, "Events", EntityKindSupport.Advertised, EntityKindSupport.NotAdvertised)]);
-        client.QueryCalendarResourceHrefsAsync(calendarHref, CalendarEntityKind.Event, null, null, Arg.Any<CancellationToken>())
+        client.QueryCalendarResourceHrefsAsync(
+                calendarHref,
+                CalendarEntityKind.Event,
+                Arg.Any<DateTimeOffset?>(),
+                Arg.Any<DateTimeOffset?>(),
+                Arg.Any<CancellationToken>())
             .Returns([resourceHref]);
-        client.QueryCalendarResourceHrefsAsync(calendarHref, CalendarEntityKind.Todo, null, null, Arg.Any<CancellationToken>())
+        client.QueryCalendarResourceHrefsAsync(
+                calendarHref,
+                CalendarEntityKind.Todo,
+                Arg.Any<DateTimeOffset?>(),
+                Arg.Any<DateTimeOffset?>(),
+                Arg.Any<CancellationToken>())
             .Returns([]);
         var bytes = System.Text.Encoding.UTF8.GetBytes(
             "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Example//EN\r\n" + calendarLines
@@ -3670,13 +3904,18 @@ public sealed class CalendarServiceTests
                 kind == CalendarEntityKind.Event ? EntityKindSupport.Advertised : EntityKindSupport.NotAdvertised,
                 kind == CalendarEntityKind.Todo ? EntityKindSupport.Advertised : EntityKindSupport.NotAdvertised)
         ]);
-        client.QueryCalendarResourceHrefsAsync(calendarHref, kind, null, null, Arg.Any<CancellationToken>())
+        client.QueryCalendarResourceHrefsAsync(
+                calendarHref,
+                kind,
+                Arg.Any<DateTimeOffset?>(),
+                Arg.Any<DateTimeOffset?>(),
+                Arg.Any<CancellationToken>())
             .Returns([resourceHref]);
         client.QueryCalendarResourceHrefsAsync(
                 calendarHref,
                 kind == CalendarEntityKind.Event ? CalendarEntityKind.Todo : CalendarEntityKind.Event,
-                null,
-                null,
+                Arg.Any<DateTimeOffset?>(),
+                Arg.Any<DateTimeOffset?>(),
                 Arg.Any<CancellationToken>())
             .Returns([]);
         client.GetCalendarResourceAsync(resourceHref, Arg.Any<CancellationToken>()).Returns(
@@ -3701,9 +3940,19 @@ public sealed class CalendarServiceTests
             Substitute.For<ILogger<CalendarService>>());
         client.GetCalendarsAsync(Arg.Any<CancellationToken>()).Returns(
             [EntityCalendar(calendarHref, "Events", EntityKindSupport.Advertised, EntityKindSupport.NotAdvertised)]);
-        client.QueryCalendarResourceHrefsAsync(calendarHref, CalendarEntityKind.Event, null, null, Arg.Any<CancellationToken>())
+        client.QueryCalendarResourceHrefsAsync(
+                calendarHref,
+                CalendarEntityKind.Event,
+                Arg.Any<DateTimeOffset?>(),
+                Arg.Any<DateTimeOffset?>(),
+                Arg.Any<CancellationToken>())
             .Returns(hrefs);
-        client.QueryCalendarResourceHrefsAsync(calendarHref, CalendarEntityKind.Todo, null, null, Arg.Any<CancellationToken>())
+        client.QueryCalendarResourceHrefsAsync(
+                calendarHref,
+                CalendarEntityKind.Todo,
+                Arg.Any<DateTimeOffset?>(),
+                Arg.Any<DateTimeOffset?>(),
+                Arg.Any<CancellationToken>())
             .Returns([]);
         for (var index = 0; index < hrefs.Length; index++)
         {
@@ -3802,6 +4051,14 @@ public sealed class CalendarServiceTests
         public Task<CalendarResourceRead> GetCalendarResourceAsync(string href, CancellationToken cancellationToken) =>
             transport.GetCalendarResourceAsync(href, cancellationToken);
 
+        public Task<IReadOnlyList<CalendarResourceRead>> GetCalendarResourcesForQueryAsync(
+            string calendarHref,
+            IReadOnlyList<string> hrefs,
+            CancellationToken cancellationToken) => transport.GetCalendarResourcesForQueryAsync(
+                calendarHref,
+                hrefs,
+                cancellationToken);
+
         public Task<CalendarResourceCreateResult> CreateCalendarResourceAsync(
             CalendarResourceCreateRequest request,
             CancellationToken cancellationToken) => transport.CreateCalendarResourceAsync(request, cancellationToken);
@@ -3816,5 +4073,13 @@ public sealed class CalendarServiceTests
         protected override Task<HttpResponseMessage> SendAsync(
             HttpRequestMessage request,
             CancellationToken cancellationToken) => Task.FromResult(handler(request));
+    }
+
+    private sealed class AsyncHttpMessageHandler(
+        Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> handler) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken) => handler(request, cancellationToken);
     }
 }

--- a/tests/DotnetAgents.CalDav.IntegrationTests/CalendarMcpStdioIntegrationTests.cs
+++ b/tests/DotnetAgents.CalDav.IntegrationTests/CalendarMcpStdioIntegrationTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Diagnostics;
 using System.Globalization;
 using System.Net;
 using System.Net.Http.Headers;
@@ -218,6 +219,41 @@ public sealed class CalendarMcpStdioIntegrationTests
         advertised.Meta!["cache"]!["ttlMs"]!.GetValue<int>().ShouldBe(5000);
         advertised.Meta!["cache"]!["cacheScope"]!.GetValue<string>().ShouldBe("private");
         stderr.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task CalendarOccurrenceQuery_ReturnsFiveSelectedCalendarResourcesBeforeReadDeadline()
+    {
+        var hrefs = new List<string>();
+        try
+        {
+            foreach (var index in Enumerable.Range(1, 5))
+            {
+                hrefs.Add(await PutResourceAsync(
+                    $"occurrence-five-{index}.ics",
+                    Todo($"occurrence-five-{index}", "DUE:20260823T100000Z\r\n")));
+            }
+
+            var stderr = new ConcurrentQueue<string>();
+            await using var client = await CreateClientAsync(stderr, exposeExact: false);
+
+            var stopwatch = Stopwatch.StartNew();
+            var result = await CallOccurrenceAsync(client, "2026-08-23T09:59:00Z", "2026-08-23T10:01:00Z");
+            stopwatch.Stop();
+
+            result.IsError.ShouldBe(false);
+            result.StructuredContent!.Value.GetProperty("outcome").GetString().ShouldBe("success");
+            result.StructuredContent.Value.GetProperty("items").EnumerateArray()
+                .Select(item => item.GetProperty("snapshot").GetProperty("projection").GetProperty("uid").GetString())
+                .ShouldBe(Enumerable.Range(1, 5).Select(index => $"occurrence-five-{index}").ToArray(), ignoreOrder: true);
+            stopwatch.Elapsed.ShouldBeLessThan(TimeSpan.FromSeconds(30));
+            stderr.ShouldBeEmpty();
+        }
+        finally
+        {
+            foreach (var href in hrefs)
+                await DeleteResourceAsync(href);
+        }
     }
 
     [Fact]

--- a/tests/DotnetAgents.CalDav.IntegrationTests/RadicaleConformanceHarnessTests.cs
+++ b/tests/DotnetAgents.CalDav.IntegrationTests/RadicaleConformanceHarnessTests.cs
@@ -967,14 +967,14 @@ public sealed class RadicaleConformanceHarnessTests(RadicaleConformanceFixture f
 
     private static string RangeEvent() =>
         "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Conformance//EN\r\n"
-        + "BEGIN:VEVENT\r\nUID:range\r\nDTSTAMP:20260815T120000Z\r\nDTSTART:20260814T090000Z\r\n"
-        + "DURATION:PT1H\r\nRRULE:FREQ=DAILY;COUNT=5\r\nEND:VEVENT\r\n"
+        + "BEGIN:VEVENT\r\nUID:range\r\nDTSTAMP:20260815T120000Z\r\nDTSTART:20260801T090000Z\r\n"
+        + "DURATION:PT1H\r\nRRULE:FREQ=DAILY;COUNT=30\r\nEND:VEVENT\r\n"
         + "BEGIN:VEVENT\r\nUID:range\r\nDTSTAMP:20260815T120000Z\r\n"
-        + "RECURRENCE-ID;RANGE=THISANDFUTURE:20260816T090000Z\r\n"
-        + "DTSTART:20260816T110000Z\r\nDURATION:PT1H\r\nEND:VEVENT\r\n"
+        + "RECURRENCE-ID;RANGE=THISANDFUTURE:20260805T090000Z\r\n"
+        + "DTSTART:20260805T110000Z\r\nDURATION:PT1H\r\nEND:VEVENT\r\n"
         + "BEGIN:VEVENT\r\nUID:range\r\nDTSTAMP:20260815T120000Z\r\n"
-        + "RECURRENCE-ID;RANGE=THISANDFUTURE:20260817T090000Z\r\n"
-        + "DTSTART:20260817T130000Z\r\nDURATION:PT2H\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n";
+        + "RECURRENCE-ID;RANGE=THISANDFUTURE:20260810T090000Z\r\n"
+        + "DTSTART:20260810T130000Z\r\nDURATION:PT2H\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n";
 
     private static CalendarTemporalValue Zoned(string value, string timeZoneId) =>
         new(CalendarTemporalKind.ZonedDateTime, value, timeZoneId);


### PR DESCRIPTION
## Summary

- preserve the requested occurrence window in CalDAV candidate planning with a safe DATE/UTC-offset representation envelope
- fetch authoritative Calendar Object Resources in bounded 50-resource `calendar-multiget` batches, preserving strong ETags and typed failures without successful-path GET fallbacks
- keep local occurrence evaluation as the semantic authority for recurrence sets and detached overrides
- add deterministic delayed-WebDAV, batch-scaling, line-ending fidelity, pinned-Radicale, and real MCP-over-stdio coverage

## Stack

Stacked on #72. Merge that PR first; this PR targets `codex/issue-53-release-gates` intentionally.

Closes #73

## Validation

- `dotnet build -c Release --no-restore` — 0 warnings, 0 errors
- full coverage suite — 1,695 Core unit + 900 MCP unit + 85 integration tests passed
- coverage — 93.9% line, 85.0% branch (thresholds met)
- deterministic WebDAV latency contract — five candidates, three sequential 2.5-second responses, success in about 7 seconds; exactly two `calendar-query` REPORTs and one batch `calendar-multiget`, no GET
- pinned Radicale — range override anchored seven days outside the queried window remains authoritative
- `dotnet tool run slopwatch analyze --config .slopwatch/slopwatch.json --fail-on warning` — 0 issues
- Hermes Agent 0.20.3 against this branch's built stdio DLL — connected, discovered 20 tools, `calendars.list` succeeded, and direct read-only `calendar_occurrences.query` returned typed `success`

## Review

Two-axis review found no repository-standard violations and no remaining incorrect or missing implementation behavior. Review-driven changes centralized the batch policy and strengthened the HTTP and outside-window recurrence evidence.
