### PR TITLE
ci: dispatch releases from explicit tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,16 +1,19 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - 'v*'
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: Existing v-prefixed semantic-version tag to publish
+        required: true
+        type: string
 
 permissions:
   contents: write
   id-token: write
 
 concurrency:
-  group: release-${{ github.ref }}
+  group: release-${{ inputs.release_tag }}
   cancel-in-progress: false
 
 jobs:
@@ -23,12 +26,14 @@ jobs:
       PACKAGE_OUTPUT_DIRECTORY: ${{ github.workspace }}/artifacts
       PACKAGE_PROJECT_PATH: src/DotnetAgents.CalDav.Mcp/DotnetAgents.CalDav.Mcp.csproj
       MCP_SERVER_METADATA_PATH: ${{ runner.temp }}/dotnet-agents-caldav-server.json
+      RELEASE_TAG: ${{ inputs.release_tag }}
 
     steps:
       - name: Checkout
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          ref: ${{ inputs.release_tag }}
 
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v5
@@ -46,7 +51,7 @@ jobs:
         id: version
         shell: bash
         run: |
-          PACKAGE_VERSION="${GITHUB_REF_NAME#v}"
+          PACKAGE_VERSION="${RELEASE_TAG#v}"
           echo "package_version=${PACKAGE_VERSION}" >> "$GITHUB_OUTPUT"
           VERSION_WITHOUT_BUILD="${PACKAGE_VERSION%%+*}"
           if [[ "$VERSION_WITHOUT_BUILD" == *-* ]]; then
@@ -57,7 +62,7 @@ jobs:
 
       - name: Prepare tag-versioned server metadata
         shell: bash
-        run: bash scripts/prepare-release-metadata.sh "$GITHUB_REF_NAME" "$MCP_SERVER_METADATA_PATH"
+        run: bash scripts/prepare-release-metadata.sh "$RELEASE_TAG" "$MCP_SERVER_METADATA_PATH"
 
       - name: Build Release
         run: >
@@ -157,6 +162,7 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v3
         with:
+          tag_name: ${{ inputs.release_tag }}
           generate_release_notes: true
           files: |
             ${{ env.PACKAGE_OUTPUT_DIRECTORY }}/*.nupkg

--- a/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/PackageArtifactTests.cs
+++ b/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/PackageArtifactTests.cs
@@ -263,7 +263,12 @@ public sealed class PackageArtifactTests
     {
         var workflow = File.ReadAllText(Path.Combine(RepositoryRoot(), ".github", "workflows", "release.yml"));
 
+        workflow.ShouldContain("workflow_dispatch:");
+        workflow.ShouldContain("release_tag:");
+        workflow.ShouldContain("ref: ${{ inputs.release_tag }}");
+        workflow.ShouldContain("tag_name: ${{ inputs.release_tag }}");
         workflow.ShouldContain("generate_release_notes: true");
+        workflow.ShouldNotContain("push:\n    tags:");
         workflow.ShouldNotContain("RELEASE_NOTES_LATEST.md");
         workflow.ShouldNotContain("body_path: RELEASE_NOTES_LATEST.md");
     }


### PR DESCRIPTION
## What changed

The release workflow now runs only through manual dispatch. It requires an existing semantic-version tag, checks out that tag, and publishes the resulting package.

GitHub generates the release notes. No push to `main` can start a release.

## Validation

- `dotnet test tests/DotnetAgents.CalDav.Mcp.Tests.Unit/DotnetAgents.CalDav.Mcp.Tests.Unit.csproj -c Release --filter "FullyQualifiedName~ReleaseWorkflow_GeneratesGitHubReleaseNotes|FullyQualifiedName~ReleaseWorkflow_RepeatsTheNormativeGatesBeforePacking"`
- Parsed `.github/workflows/release.yml` successfully