### PR TITLE
fix: use workspace path for release metadata

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
       PACKAGE_OUTPUT_DIRECTORY: ${{ github.workspace }}/artifacts
       PACKAGE_PROJECT_PATH: src/DotnetAgents.CalDav.Mcp/DotnetAgents.CalDav.Mcp.csproj
-      MCP_SERVER_METADATA_PATH: ${{ runner.temp }}/dotnet-agents-caldav-server.json
+      MCP_SERVER_METADATA_PATH: ${{ github.workspace }}/.release-metadata/server.json
       RELEASE_TAG: ${{ inputs.release_tag }}
 
     steps:

--- a/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/PackageArtifactTests.cs
+++ b/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/PackageArtifactTests.cs
@@ -268,6 +268,7 @@ public sealed class PackageArtifactTests
         workflow.ShouldContain("ref: ${{ inputs.release_tag }}");
         workflow.ShouldContain("tag_name: ${{ inputs.release_tag }}");
         workflow.ShouldContain("generate_release_notes: true");
+        workflow.ShouldNotContain("${{ runner.temp }}");
         workflow.ShouldNotContain("push:\n    tags:");
         workflow.ShouldNotContain("RELEASE_NOTES_LATEST.md");
         workflow.ShouldNotContain("body_path: RELEASE_NOTES_LATEST.md");


### PR DESCRIPTION
## What changed

Release dispatch failed before jobs started because `runner.temp` is unavailable in job-level environment expressions. The metadata file now uses a workspace-local path.

## Validation

- `dotnet test tests/DotnetAgents.CalDav.Mcp.Tests.Unit/DotnetAgents.CalDav.Mcp.Tests.Unit.csproj -c Release --filter "FullyQualifiedName~ReleaseWorkflow_GeneratesGitHubReleaseNotes"`