### PR TITLE
chore: update compatible NuGet dependencies

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -36,7 +36,7 @@
   <ItemGroup Label="Testing">
     <PackageVersion Include="xunit.v3" Version="$(XunitV3Version)" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
     <PackageVersion Include="coverlet.collector" Version="10.0.1" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="NSubstitute.Analyzers.CSharp" Version="1.0.17" />
@@ -49,7 +49,7 @@
   </ItemGroup>
   <!-- Integration Testing -->
   <ItemGroup Label="Integration Testing">
-    <PackageVersion Include="Testcontainers" Version="4.13.0" />
+    <PackageVersion Include="Testcontainers" Version="4.14.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="$(MicrosoftExtensionsVersion)" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="$(MicrosoftExtensionsVersion)" />


### PR DESCRIPTION
## Summary\n\n- Update Microsoft.NET.Test.Sdk from 18.8.1 to 18.9.0.\n- Update Testcontainers from 4.13.0 to 4.14.0.\n- Keep NSubstitute at 5.3.0 because AutoFixture.AutoNSubstitute 4.18.1 requires NSubstitute < 6.0.0.\n- Keep xUnit at the current VSTest-compatible versions; xUnit 4 requires a separate Microsoft.Testing.Platform migration on .NET 10.\n\n## Validation\n\n-   Determining projects to restore...
  All projects are up-to-date for restore.\n-   DotnetAgents.CalDav.Core -> /home/jhow/.codex/worktrees/f4a9/dotnet-agents-caldav/src/DotnetAgents.CalDav.Core/bin/Release/net10.0/DotnetAgents.CalDav.Core.dll
  DotnetAgents.CalDav.Mcp -> /home/jhow/.codex/worktrees/f4a9/dotnet-agents-caldav/src/DotnetAgents.CalDav.Mcp/bin/Release/net10.0/DotnetAgents.CalDav.Mcp.dll
  DotnetAgents.CalDav.Core.Tests.Unit -> /home/jhow/.codex/worktrees/f4a9/dotnet-agents-caldav/tests/DotnetAgents.CalDav.Core.Tests.Unit/bin/Release/net10.0/DotnetAgents.CalDav.Core.Tests.Unit.dll
  DotnetAgents.CalDav.Mcp.Tests.Unit -> /home/jhow/.codex/worktrees/f4a9/dotnet-agents-caldav/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/bin/Release/net10.0/DotnetAgents.CalDav.Mcp.Tests.Unit.dll
  DotnetAgents.CalDav.IntegrationTests -> /home/jhow/.codex/worktrees/f4a9/dotnet-agents-caldav/tests/DotnetAgents.CalDav.IntegrationTests/bin/Release/net10.0/DotnetAgents.CalDav.IntegrationTests.dll

Build succeeded.
    0 Warning(s)
    0 Error(s)

Time Elapsed 00:00:08.63\n- Core unit tests: 1,745 passed\n- MCP unit tests: 941 passed\n- Integration tests: 88 passed\n- Coverage: 93.8% line, 85.0% branch\n- Radicale conformance: 10/10 strict-preconditions and 10/10 alternate-time-zone\n- Slopwatch: 0 issues\n