### PR TITLE
feat: add opt-in OpenTelemetry observability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
-- Telemetry export now applies explicit span, metric, log, and resource allowlists that exclude CalDAV identifiers, credentials, payloads, URLs, OTLP headers, and exception details.
+- Telemetry export now applies explicit span, metric, log, and resource allowlists that exclude CalDAV identifiers, credentials, payloads, URLs, OTLP headers, trace state, client-controlled metric labels, and exception details.
 
 ## [0.2.2] - 2026-08-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added opt-in OTLP traces, MCP metrics, and trace-correlated safe logs for the stdio server, including CalDAV aggregate-phase and outbound HTTP attempt waterfalls.
+- Added automated loopback OTLP coverage for trace parentage, metrics, log correlation, redaction, disabled defaults, collector failure isolation, and stdin-EOF shutdown.
+
 ### Changed
 
 - Migrated test execution from VSTest to Microsoft.Testing.Platform v2 and xUnit 4.
 - Isolated coverage and TRX evidence per run so historical or nested runner artifacts cannot affect quality gates.
+
+### Security
+
+- Telemetry export now applies explicit span, metric, log, and resource allowlists that exclude CalDAV identifiers, credentials, payloads, URLs, OTLP headers, and exception details.
 
 ## [0.2.2] - 2026-08-21
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,6 +14,9 @@
   <ItemGroup Label="MCP">
     <PackageVersion Include="JsonSchema.Net" Version="9.4.0" />
     <PackageVersion Include="ModelContextProtocol" Version="$(McpSdkVersion)" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.17.0" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.17.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.17.0" />
     <PackageVersion Include="SSH.NET" Version="2026.0.0" />
   </ItemGroup>
   <!-- Core Dependencies -->

--- a/README.md
+++ b/README.md
@@ -37,6 +37,11 @@ Add this MCP server to VS Code, Claude Desktop, Cursor, or any MCP client:
 | `CALDAV_DEFAULT_TODO_CALENDAR_NAME` | No | Display name of the default Calendar for To-do operations |
 | `CALDAV_DEFAULT_EVENT_CALENDAR_NAME` | No | Display name of the default Calendar for Event operations |
 | `CALDAV_EXPOSE_EXACT_TOOLS` | No | Set to `true` to expose protected exact Calendar Object Resource tools |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | No | Non-empty OTLP endpoint that opts into telemetry export; no exporter is registered when omitted |
+| `OTEL_EXPORTER_OTLP_PROTOCOL` | No | Standard OTLP protocol such as `http/protobuf` or `grpc` |
+| `OTEL_EXPORTER_OTLP_HEADERS` | No | Secret OTLP authentication or routing headers; never included in exported telemetry |
+| `OTEL_SERVICE_NAME` | No | Service name override; defaults to `dotnet-agents-caldav` |
+| `OTEL_SDK_DISABLED` | No | Set to `true` to disable the SDK even when an endpoint is configured |
 
 ## Available tools
 
@@ -70,6 +75,30 @@ The 0.2.2 default catalog contains exactly these 17 tools in the order shown. It
 - `calendar_resources.exact_move` — Atomically move a strong-tagged resource to an explicit href after MRTR confirmation.
 
 The four exact tools are enabled with `CALDAV_EXPOSE_EXACT_TOOLS=true`; this flag controls the deterministic stdio catalog without contacting the server. The configured CalDAV credentials are the stdio authorization context, 401/403 responses become typed call failures, and exact writes require client support for MCP Multi Round-Trip Requests.
+
+## Optional OpenTelemetry observability
+
+Telemetry is disabled by default: the process registers no exporter and makes no collector connection unless `OTEL_EXPORTER_OTLP_ENDPOINT` is non-empty and `OTEL_SDK_DISABLED` is not `true`. The MCP SDK and .NET runtime provide MCP and outbound HTTP signals; this server adds the in-process provider/export pipeline, CalDAV operation and aggregate-phase spans, correlated safe logs, and an export allowlist. It does not add Aspire libraries, an AppHost, health endpoints, console/file exporters, or a hosted backend.
+
+For local troubleshooting, run the standalone Aspire Dashboard on loopback only:
+
+```bash
+docker run --rm --detach \
+  --name caldav-otel-dashboard \
+  --publish 127.0.0.1:18888:18888 \
+  --publish 127.0.0.1:4318:18890 \
+  mcr.microsoft.com/dotnet/aspire-dashboard:13.4.2@sha256:76d05882595dd43e708d6ef3e269d98ca763694c0c822bbe98edc99790eaad1b
+```
+
+Keep the generated browser token enabled, open `http://127.0.0.1:18888`, and launch the current-checkout MCP process through a real stdio client with:
+
+```text
+OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:4318
+OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+OTEL_SERVICE_NAME=dotnet-agents-caldav
+```
+
+Exported spans show the MCP request, `caldav.operation`, the applicable `discovery`, `fetch`, `filter`, `expand`, and `reconcile` phases, and individual HTTP attempts. The allowlist excludes credentials, OTLP headers, URLs/hrefs, Calendar Names, UIDs, Entity Tags, cursors, iCalendar/XML/HTTP bodies, MCP payloads/results, and exception messages or stack traces. Collector failure cannot change tool results or write telemetry diagnostics to stdout/stderr.
 
 ## Supported servers
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ The four exact tools are enabled with `CALDAV_EXPOSE_EXACT_TOOLS=true`; this fla
 
 ## Optional OpenTelemetry observability
 
-Telemetry is disabled by default: the process registers no exporter and makes no collector connection unless `OTEL_EXPORTER_OTLP_ENDPOINT` is non-empty and `OTEL_SDK_DISABLED` is not `true`. The MCP SDK and .NET runtime provide MCP and outbound HTTP signals; this server adds the in-process provider/export pipeline, CalDAV operation and aggregate-phase spans, correlated safe logs, and an export allowlist. It does not add Aspire libraries, an AppHost, health endpoints, console/file exporters, or a hosted backend.
+Telemetry is disabled by default: the process registers no exporter and makes no collector connection unless `OTEL_EXPORTER_OTLP_ENDPOINT` is non-empty and `OTEL_SDK_DISABLED` is not `true`. The MCP SDK and .NET runtime provide MCP and outbound HTTP signals; this server adds the in-process provider/export pipeline, CalDAV operation and aggregate-phase spans, correlated safe logs, and an export allowlist. It does not add Aspire libraries, an AppHost, health endpoints, console/file exporters, or a hosted backend. Each OTLP export call is capped at 250 milliseconds so an accepting but unresponsive collector cannot hold the stdio child process past its shutdown bound.
 
 For local troubleshooting, run the standalone Aspire Dashboard on loopback only:
 

--- a/src/DotnetAgents.CalDav.Core/Internal/CalDavClient.cs
+++ b/src/DotnetAgents.CalDav.Core/Internal/CalDavClient.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using System.Globalization;
 using System.Buffers;
 using System.IO.Compression;
@@ -25,7 +24,6 @@ internal sealed class CalDavClient : ICalendarClient, ICalendarCreateTransport
 {
     private const int MaximumCalendarResourceBytes = 4 * 1024 * 1024;
     private static readonly UTF8Encoding StrictUtf8 = new(false, true);
-    private static readonly ActivitySource ActivitySource = new("DotnetAgents.CalDav", "0.2.0");
     private static readonly HttpMethod PropFindMethod = new("PROPFIND");
     private static readonly HttpMethod ReportMethod = new("REPORT");
 
@@ -56,7 +54,6 @@ internal sealed class CalDavClient : ICalendarClient, ICalendarCreateTransport
     public async Task<IReadOnlyList<CalendarDescriptor>> GetCalendarsAsync(CancellationToken cancellationToken)
     {
         CalendarOperationProgress.SetPhase(CalendarOperationPhase.Discovery);
-        using var activity = ActivitySource.StartActivity("caldav.get_calendars", ActivityKind.Client);
 
         var homeSetHref = await DiscoverCalendarHomeSetAsync(cancellationToken, failOnNotFound: true);
         if (homeSetHref is null)

--- a/src/DotnetAgents.CalDav.Mcp/.mcp/server.json
+++ b/src/DotnetAgents.CalDav.Mcp/.mcp/server.json
@@ -49,6 +49,32 @@
           "name": "CALDAV_EXPOSE_EXACT_TOOLS",
           "description": "Set to true to expose protected exact Calendar Object Resource tools (optional)",
           "isRequired": false
+        },
+        {
+          "name": "OTEL_EXPORTER_OTLP_ENDPOINT",
+          "description": "OTLP collector endpoint; a non-empty value opts into telemetry export",
+          "isRequired": false
+        },
+        {
+          "name": "OTEL_EXPORTER_OTLP_PROTOCOL",
+          "description": "Standard OTLP transport protocol, such as http/protobuf or grpc (optional)",
+          "isRequired": false
+        },
+        {
+          "name": "OTEL_EXPORTER_OTLP_HEADERS",
+          "description": "Optional OTLP authentication or routing headers",
+          "isRequired": false,
+          "isSecret": true
+        },
+        {
+          "name": "OTEL_SERVICE_NAME",
+          "description": "Telemetry service name override; defaults to dotnet-agents-caldav",
+          "isRequired": false
+        },
+        {
+          "name": "OTEL_SDK_DISABLED",
+          "description": "Set to true to disable the OpenTelemetry SDK even when an endpoint is configured",
+          "isRequired": false
         }
       ]
     }

--- a/src/DotnetAgents.CalDav.Mcp/DotnetAgents.CalDav.Mcp.csproj
+++ b/src/DotnetAgents.CalDav.Mcp/DotnetAgents.CalDav.Mcp.csproj
@@ -17,6 +17,9 @@
     <PackageReference Include="ModelContextProtocol" />
     <PackageReference Include="Microsoft.Extensions.Hosting" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/DotnetAgents.CalDav.Mcp/Hosting/CalDavHostBuilder.cs
+++ b/src/DotnetAgents.CalDav.Mcp/Hosting/CalDavHostBuilder.cs
@@ -21,11 +21,15 @@ public sealed class CalDavHostBuilder
     /// before calling <see cref="HostApplicationBuilder.Build"/>.
     /// </summary>
     /// <param name="exposeExactTools">Whether to expose the protected exact resource tools.</param>
-    public static HostApplicationBuilder CreateBuilder(bool exposeExactTools = false)
+    /// <param name="environmentProvider">Optional environment-variable source used by startup tests.</param>
+    public static HostApplicationBuilder CreateBuilder(
+        bool exposeExactTools = false,
+        Func<string, string?>? environmentProvider = null)
     {
         var builder = Host.CreateApplicationBuilder();
 
         builder.Logging.ClearProviders();
+        OpenTelemetryHostConfiguration.Configure(builder, environmentProvider);
 
         var mcpBuilder = builder.Services.AddMcpServer(options => options.ProtocolVersion = "2026-07-28")
             .WithStdioServerTransport()

--- a/src/DotnetAgents.CalDav.Mcp/Hosting/CalendarExecutionPolicy.cs
+++ b/src/DotnetAgents.CalDav.Mcp/Hosting/CalendarExecutionPolicy.cs
@@ -19,25 +19,51 @@ internal static class CalendarExecutionPolicy
         {
             var services = request.Services!;
             var admission = services.GetRequiredService<CalendarOperationAdmission>();
-            var mutation = IsMutation(request.Params?.Name);
+            var requestedToolName = request.Params?.Name;
+            var toolName = CalendarTelemetry.NormalizeToolName(requestedToolName);
+            var mutation = IsMutation(requestedToolName);
+            using var telemetry = CalendarTelemetry.StartOperation(
+                toolName,
+                EntityKind(requestedToolName));
             var report = request.Params?.ProgressToken is { } token
                 ? (Func<ProgressNotificationValue, CancellationToken, Task>)((progress, progressCancellationToken) =>
                     request.Server.NotifyProgressAsync(token, progress, options: null, progressCancellationToken))
                 : null;
-            await using var execution = await AcquireWithProgressAsync(
-                services.GetRequiredService<TimeProvider>(),
-                admission,
-                mutation,
-                report,
-                cancellationToken).ConfigureAwait(false);
-            if (execution.Lease is null)
-                return CreateBusyResult(mutation);
-            using var progress = execution.AttachProgress();
-            return await ExecuteWithinBudgetAsync(
-                services.GetRequiredService<TimeProvider>(),
-                mutation,
-                token => next(request, token),
-                cancellationToken).ConfigureAwait(false);
+            try
+            {
+                await using var execution = await AcquireWithProgressAsync(
+                    services.GetRequiredService<TimeProvider>(),
+                    admission,
+                    mutation,
+                    report,
+                    cancellationToken,
+                    telemetry is null ? null : telemetry.StartPhase).ConfigureAwait(false);
+                if (execution.Lease is null)
+                {
+                    var busy = CreateBusyResult(mutation);
+                    CompleteTelemetry(telemetry, busy);
+                    return busy;
+                }
+                telemetry?.StartPhase(CalendarOperationPhase.Discovery);
+                using var progress = execution.AttachProgress();
+                var result = await ExecuteWithinBudgetAsync(
+                    services.GetRequiredService<TimeProvider>(),
+                    mutation,
+                    token => next(request, token),
+                    cancellationToken).ConfigureAwait(false);
+                CompleteTelemetry(telemetry, result);
+                return result;
+            }
+            catch (OperationCanceledException)
+            {
+                telemetry?.Complete("cancelled");
+                throw;
+            }
+            catch (Exception exception)
+            {
+                telemetry?.Fail(exception);
+                throw;
+            }
         };
 
     private static async ValueTask<CallToolResult> ExecuteWithinBudgetAsync(
@@ -67,9 +93,15 @@ internal static class CalendarExecutionPolicy
         CalendarOperationAdmission admission,
         bool mutation,
         Func<ProgressNotificationValue, CancellationToken, Task>? report,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        Action<CalendarOperationPhase>? phaseObserver = null)
     {
-        var execution = new CalendarExecutionLease(timeProvider, admission, report, cancellationToken);
+        var execution = new CalendarExecutionLease(
+            timeProvider,
+            admission,
+            report,
+            cancellationToken,
+            phaseObserver);
         try
         {
             execution.Lease = await admission.AcquireAsync(mutation, cancellationToken).ConfigureAwait(false);
@@ -90,6 +122,56 @@ internal static class CalendarExecutionPolicy
         or "calendar_occurrences.restore_cancellation" or "calendar_resources.move"
         or "calendar_resources.delete" or "calendar_resources.exact_create"
         or "calendar_resources.exact_replace" or "calendar_resources.exact_move";
+
+    private static CalendarTelemetryEntityKind? EntityKind(string? toolName) => toolName switch
+    {
+        "events.create" or "events.patch" => CalendarTelemetryEntityKind.Event,
+        "todos.query" or "todos.create" or "todos.patch" or "todos.complete" =>
+            CalendarTelemetryEntityKind.Todo,
+        _ => null
+    };
+
+    private static void CompleteTelemetry(CalendarTelemetryOperation? telemetry, CallToolResult result)
+    {
+        if (telemetry is null)
+            return;
+
+        var structured = result.StructuredContent;
+        var errorCode = SafeDimension(structured, "code");
+        var errorCategory = SafeDimension(structured, "category");
+        var mutationState = SafeMutationState(structured);
+        telemetry.Complete(
+            result.IsError == true ? "error" : "success",
+            errorCode,
+            errorCategory,
+            mutationState);
+    }
+
+    private static string? SafeDimension(JsonElement? structured, string propertyName)
+    {
+        if (structured is not { ValueKind: JsonValueKind.Object } value
+            || !value.TryGetProperty(propertyName, out var property)
+            || property.ValueKind != JsonValueKind.String)
+        {
+            return null;
+        }
+
+        var candidate = property.GetString();
+        return candidate is { Length: > 0 and <= 64 }
+            && candidate.All(character => character is >= 'a' and <= 'z' or >= '0' and <= '9' or '_')
+                ? candidate
+                : null;
+    }
+
+    private static string? SafeMutationState(JsonElement? structured) =>
+        SafeDimension(structured, "mutationState") switch
+        {
+            "not_attempted" => "not_attempted",
+            "not_committed" => "not_committed",
+            "committed" => "committed",
+            "unknown" => "unknown",
+            _ => null
+        };
 
     internal static async Task ReportProgressAsync(
         TimeProvider timeProvider,
@@ -198,12 +280,13 @@ internal sealed class CalendarExecutionLease : IAsyncDisposable
         TimeProvider timeProvider,
         CalendarOperationAdmission admission,
         Func<ProgressNotificationValue, CancellationToken, Task>? report,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        Action<CalendarOperationPhase>? phaseObserver = null)
     {
         _timeProvider = timeProvider;
         _admission = admission;
         _report = report;
-        _progressState = CalendarOperationProgress.CreateState();
+        _progressState = CalendarOperationProgress.CreateState(phaseObserver);
         _progressCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
     }
 

--- a/src/DotnetAgents.CalDav.Mcp/Hosting/CalendarExecutionPolicy.cs
+++ b/src/DotnetAgents.CalDav.Mcp/Hosting/CalendarExecutionPolicy.cs
@@ -158,7 +158,7 @@ internal static class CalendarExecutionPolicy
 
         var candidate = property.GetString();
         return candidate is { Length: > 0 and <= 64 }
-            && candidate.All(character => character is >= 'a' and <= 'z' or >= '0' and <= '9' or '_')
+            && candidate.All(character => char.IsAsciiLetterOrDigit(character) || character == '_')
                 ? candidate
                 : null;
     }

--- a/src/DotnetAgents.CalDav.Mcp/Hosting/CalendarTelemetry.cs
+++ b/src/DotnetAgents.CalDav.Mcp/Hosting/CalendarTelemetry.cs
@@ -1,0 +1,132 @@
+using System.Diagnostics;
+using DotnetAgents.CalDav.Core.Services;
+
+namespace DotnetAgents.CalDav.Mcp.Hosting;
+
+internal static class CalendarTelemetry
+{
+    internal const string InstrumentationName = "DotnetAgents.CalDav";
+    internal const string InstrumentationVersion = "0.1.0";
+    private static readonly ActivitySource Source = new(InstrumentationName, InstrumentationVersion);
+
+    internal static CalendarTelemetryOperation? StartOperation(
+        string toolName,
+        CalendarTelemetryEntityKind? entityKind)
+    {
+        if (!Source.HasListeners())
+            return null;
+
+        var activity = Source.StartActivity("caldav.operation", ActivityKind.Internal);
+        if (activity is null)
+            return null;
+
+        if (activity.IsAllDataRequested)
+        {
+            activity.SetTag("caldav.tool.name", toolName);
+            if (entityKind is not null)
+                activity.SetTag("caldav.entity.kind", EntityKindName(entityKind.Value));
+        }
+
+        return new CalendarTelemetryOperation(Source, activity);
+    }
+
+    internal static string NormalizeToolName(string? toolName) => toolName switch
+    {
+        "calendars.list" or "calendar_entities.query" or "calendar_occurrences.query"
+            or "todos.query" or "calendar_resources.get" or "events.create" or "events.patch"
+            or "todos.create" or "todos.patch" or "todos.complete" or "calendar_occurrences.add"
+            or "calendar_occurrences.exclude" or "calendar_occurrences.restore_exclusion"
+            or "calendar_occurrences.cancel" or "calendar_occurrences.restore_cancellation"
+            or "calendar_resources.move" or "calendar_resources.delete"
+            or "calendar_resources.exact_get" or "calendar_resources.exact_create"
+            or "calendar_resources.exact_replace" or "calendar_resources.exact_move" => toolName,
+        _ => "unknown"
+    };
+
+    private static string EntityKindName(CalendarTelemetryEntityKind entityKind) => entityKind switch
+    {
+        CalendarTelemetryEntityKind.Event => "event",
+        CalendarTelemetryEntityKind.Todo => "todo",
+        _ => throw new ArgumentOutOfRangeException(nameof(entityKind), entityKind, null)
+    };
+}
+
+internal enum CalendarTelemetryEntityKind
+{
+    Event,
+    Todo
+}
+
+internal sealed class CalendarTelemetryOperation : IDisposable
+{
+    private readonly ActivitySource _source;
+    private readonly Activity _operation;
+    private Activity? _phase;
+
+    internal CalendarTelemetryOperation(ActivitySource source, Activity operation)
+    {
+        _source = source;
+        _operation = operation;
+    }
+
+    internal void StartPhase(CalendarOperationPhase phase)
+    {
+        _phase?.Stop();
+        _phase = _source.StartActivity(PhaseActivityName(phase), ActivityKind.Internal);
+        if (_phase?.IsAllDataRequested == true)
+            _phase.SetTag("caldav.phase", PhaseName(phase));
+    }
+
+    internal void Complete(
+        string outcome,
+        string? errorCode = null,
+        string? errorCategory = null,
+        string? mutationState = null)
+    {
+        if (!_operation.IsAllDataRequested)
+            return;
+
+        _operation.SetTag("caldav.outcome", outcome);
+        _operation.SetTag("caldav.error.code", errorCode);
+        _operation.SetTag("caldav.error.category", errorCategory);
+        _operation.SetTag("caldav.mutation.state", mutationState);
+        if (string.Equals(outcome, "error", StringComparison.Ordinal))
+            _operation.SetStatus(ActivityStatusCode.Error);
+    }
+
+    internal void Fail(Exception exception)
+    {
+        if (!_operation.IsAllDataRequested)
+            return;
+
+        _operation.SetTag("caldav.outcome", "error");
+        _operation.SetTag("error.type", exception.GetType().FullName);
+        _operation.SetStatus(ActivityStatusCode.Error);
+    }
+
+    public void Dispose()
+    {
+        _phase?.Dispose();
+        _operation.Dispose();
+    }
+
+    private static string PhaseActivityName(CalendarOperationPhase phase) => phase switch
+    {
+        CalendarOperationPhase.Discovery => "caldav.phase.discovery",
+        CalendarOperationPhase.Fetch => "caldav.phase.fetch",
+        CalendarOperationPhase.Filter => "caldav.phase.filter",
+        CalendarOperationPhase.Expand => "caldav.phase.expand",
+        CalendarOperationPhase.Reconcile => "caldav.phase.reconcile",
+        _ => throw new ArgumentOutOfRangeException(nameof(phase), phase, null)
+    };
+
+    private static string PhaseName(CalendarOperationPhase phase) => phase switch
+    {
+        CalendarOperationPhase.Discovery => "discovery",
+        CalendarOperationPhase.Fetch => "fetch",
+        CalendarOperationPhase.Filter => "filter",
+        CalendarOperationPhase.Expand => "expand",
+        CalendarOperationPhase.Reconcile => "reconcile",
+        _ => throw new ArgumentOutOfRangeException(nameof(phase), phase, null)
+    };
+}

--- a/src/DotnetAgents.CalDav.Mcp/Hosting/OpenTelemetryHostConfiguration.cs
+++ b/src/DotnetAgents.CalDav.Mcp/Hosting/OpenTelemetryHostConfiguration.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using OpenTelemetry.Exporter;
 using OpenTelemetry.Logs;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Resources;
@@ -13,6 +14,7 @@ internal static class OpenTelemetryHostConfiguration
     internal const string DefaultServiceName = "dotnet-agents-caldav";
     internal const string InstrumentationName = "DotnetAgents.CalDav";
     internal const string McpInstrumentationName = "Experimental.ModelContextProtocol";
+    internal const int ExporterTimeoutMilliseconds = 250;
 
     internal static bool IsEnabled(Func<string, string?>? environmentProvider = null)
     {
@@ -47,25 +49,25 @@ internal static class OpenTelemetryHostConfiguration
                 .AddSource(McpInstrumentationName, InstrumentationName)
                 .AddHttpClientInstrumentation(options => options.RecordException = false)
                 .AddProcessor(new TelemetryActivityAllowlistProcessor())
-                .AddOtlpExporter())
+                .AddOtlpExporter(ConfigureExporter))
             .WithMetrics(metrics => metrics
                 .AddMeter(McpInstrumentationName, InstrumentationName)
                 .AddView("mcp.server.operation.duration", new MetricStreamConfiguration
                 {
-                    TagKeys = ["mcp.method.name", "gen_ai.tool.name", "rpc.response.status_code"]
+                    TagKeys = ["rpc.response.status_code"]
                 })
                 .AddView("mcp.server.session.duration", new MetricStreamConfiguration
                 {
                     TagKeys = ["mcp.protocol.version", "network.protocol.name", "network.transport"]
                 })
-                .AddOtlpExporter());
+                .AddOtlpExporter(ConfigureExporter));
 
         builder.Logging.SetMinimumLevel(LogLevel.Debug);
         builder.Logging.AddFilter<OpenTelemetryLoggerProvider>(IsSafeLog);
         builder.Logging.AddOpenTelemetry(logging => logging
             .SetResourceBuilder(resource)
             .AddProcessor(new TelemetryLogAllowlistProcessor())
-            .AddOtlpExporter());
+            .AddOtlpExporter(ConfigureExporter));
     }
 
     internal static bool IsSafeLog(string? category, LogLevel level) =>
@@ -73,4 +75,9 @@ internal static class OpenTelemetryHostConfiguration
             ? level >= LogLevel.Debug
             : category?.StartsWith("ModelContextProtocol", StringComparison.Ordinal) == true
                 && level >= LogLevel.Information;
+
+    private static void ConfigureExporter(OtlpExporterOptions options) =>
+        options.TimeoutMilliseconds = Math.Min(
+            options.TimeoutMilliseconds,
+            ExporterTimeoutMilliseconds);
 }

--- a/src/DotnetAgents.CalDav.Mcp/Hosting/OpenTelemetryHostConfiguration.cs
+++ b/src/DotnetAgents.CalDav.Mcp/Hosting/OpenTelemetryHostConfiguration.cs
@@ -1,0 +1,76 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using OpenTelemetry.Logs;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
+
+namespace DotnetAgents.CalDav.Mcp.Hosting;
+
+internal static class OpenTelemetryHostConfiguration
+{
+    internal const string DefaultServiceName = "dotnet-agents-caldav";
+    internal const string InstrumentationName = "DotnetAgents.CalDav";
+    internal const string McpInstrumentationName = "Experimental.ModelContextProtocol";
+
+    internal static bool IsEnabled(Func<string, string?>? environmentProvider = null)
+    {
+        var getEnvironmentVariable = environmentProvider ?? Environment.GetEnvironmentVariable;
+        var endpoint = getEnvironmentVariable("OTEL_EXPORTER_OTLP_ENDPOINT");
+        var sdkDisabled = getEnvironmentVariable("OTEL_SDK_DISABLED");
+        return !string.IsNullOrWhiteSpace(endpoint)
+            && !string.Equals(sdkDisabled, "true", StringComparison.OrdinalIgnoreCase);
+    }
+
+    internal static void Configure(
+        HostApplicationBuilder builder,
+        Func<string, string?>? environmentProvider = null)
+    {
+        var getEnvironmentVariable = environmentProvider ?? Environment.GetEnvironmentVariable;
+        if (!IsEnabled(getEnvironmentVariable))
+            return;
+
+        var serviceName = getEnvironmentVariable("OTEL_SERVICE_NAME");
+        if (string.IsNullOrWhiteSpace(serviceName))
+            serviceName = DefaultServiceName;
+
+        var resource = ResourceBuilder.CreateEmpty()
+            .AddService(serviceName)
+            .AddTelemetrySdk();
+        builder.Services.AddOpenTelemetry()
+            .ConfigureResource(resourceBuilder => resourceBuilder
+                .Clear()
+                .AddService(serviceName)
+                .AddTelemetrySdk())
+            .WithTracing(tracing => tracing
+                .AddSource(McpInstrumentationName, InstrumentationName)
+                .AddHttpClientInstrumentation(options => options.RecordException = false)
+                .AddProcessor(new TelemetryActivityAllowlistProcessor())
+                .AddOtlpExporter())
+            .WithMetrics(metrics => metrics
+                .AddMeter(McpInstrumentationName, InstrumentationName)
+                .AddView("mcp.server.operation.duration", new MetricStreamConfiguration
+                {
+                    TagKeys = ["mcp.method.name", "gen_ai.tool.name", "rpc.response.status_code"]
+                })
+                .AddView("mcp.server.session.duration", new MetricStreamConfiguration
+                {
+                    TagKeys = ["mcp.protocol.version", "network.protocol.name", "network.transport"]
+                })
+                .AddOtlpExporter());
+
+        builder.Logging.SetMinimumLevel(LogLevel.Debug);
+        builder.Logging.AddFilter<OpenTelemetryLoggerProvider>(IsSafeLog);
+        builder.Logging.AddOpenTelemetry(logging => logging
+            .SetResourceBuilder(resource)
+            .AddProcessor(new TelemetryLogAllowlistProcessor())
+            .AddOtlpExporter());
+    }
+
+    internal static bool IsSafeLog(string? category, LogLevel level) =>
+        category?.StartsWith("DotnetAgents.CalDav", StringComparison.Ordinal) == true
+            ? level >= LogLevel.Debug
+            : category?.StartsWith("ModelContextProtocol", StringComparison.Ordinal) == true
+                && level >= LogLevel.Information;
+}

--- a/src/DotnetAgents.CalDav.Mcp/Hosting/TelemetryActivityAllowlistProcessor.cs
+++ b/src/DotnetAgents.CalDav.Mcp/Hosting/TelemetryActivityAllowlistProcessor.cs
@@ -64,18 +64,21 @@ internal sealed class TelemetryActivityAllowlistProcessor : BaseProcessor<Activi
     private static readonly SearchValues<char> ExceptionTypeCharacters =
         SearchValues.Create("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789._+`");
 
+    public override void OnStart(Activity data) => data.TraceStateString = null;
+
     public override void OnEnd(Activity data)
     {
+        data.TraceStateString = null;
         data.SetStatus(data.Status);
-        foreach (var tag in data.TagObjects.Where(tag => !AllowedTagNames.Contains(tag.Key)).ToArray())
-            data.SetTag(tag.Key, null);
-
         if (data.Source.Name == OpenTelemetryHostConfiguration.McpInstrumentationName)
             SanitizeMcpActivity(data);
         else if (data.Source.Name == "System.Net.Http")
             SanitizeHttpActivity(data);
         else if (data.Source.Name == OpenTelemetryHostConfiguration.InstrumentationName)
             data.DisplayName = data.OperationName;
+
+        foreach (var tag in data.TagObjects.Where(tag => !AllowedTagNames.Contains(tag.Key)).ToArray())
+            data.SetTag(tag.Key, null);
 
         SanitizeTextTag(data, "error.type", MaximumExceptionTypeLength, ExceptionTypeCharacters);
     }
@@ -99,7 +102,9 @@ internal sealed class TelemetryActivityAllowlistProcessor : BaseProcessor<Activi
 
     private static void SanitizeHttpActivity(Activity activity)
     {
-        var method = NormalizeHttpMethod(activity.GetTagItem("http.request.method") as string);
+        var method = NormalizeHttpMethod(
+            activity.GetTagItem("http.request.method_original") as string
+            ?? activity.GetTagItem("http.request.method") as string);
         activity.SetTag("http.request.method", method);
         activity.DisplayName = method;
     }

--- a/src/DotnetAgents.CalDav.Mcp/Hosting/TelemetryActivityAllowlistProcessor.cs
+++ b/src/DotnetAgents.CalDav.Mcp/Hosting/TelemetryActivityAllowlistProcessor.cs
@@ -1,0 +1,135 @@
+using System.Buffers;
+using System.Diagnostics;
+using OpenTelemetry;
+
+namespace DotnetAgents.CalDav.Mcp.Hosting;
+
+internal sealed class TelemetryActivityAllowlistProcessor : BaseProcessor<Activity>
+{
+    private static readonly HashSet<string> AllowedTagNames = new(StringComparer.Ordinal)
+    {
+        "caldav.tool.name",
+        "caldav.entity.kind",
+        "caldav.phase",
+        "caldav.outcome",
+        "caldav.error.code",
+        "caldav.error.category",
+        "caldav.mutation.state",
+        "error.type",
+        "gen_ai.operation.name",
+        "gen_ai.tool.name",
+        "http.request.method",
+        "http.response.status_code",
+        "mcp.method.name",
+        "mcp.protocol.version",
+        "network.protocol.name",
+        "network.protocol.version",
+        "network.transport",
+        "rpc.response.status_code"
+    };
+    private static readonly HashSet<string> KnownMcpMethods = new(StringComparer.Ordinal)
+    {
+        "completion/complete",
+        "initialize",
+        "logging/setLevel",
+        "notifications/cancelled",
+        "notifications/initialized",
+        "notifications/progress",
+        "ping",
+        "prompts/get",
+        "prompts/list",
+        "resources/list",
+        "resources/read",
+        "resources/templates/list",
+        "tools/call",
+        "tools/list"
+    };
+    private static readonly HashSet<string> KnownHttpMethods = new(StringComparer.Ordinal)
+    {
+        "DELETE",
+        "GET",
+        "HEAD",
+        "MKCALENDAR",
+        "MKCOL",
+        "MOVE",
+        "OPTIONS",
+        "POST",
+        "PROPFIND",
+        "PROPPATCH",
+        "PUT",
+        "REPORT"
+    };
+    private static readonly SearchValues<char> ProtocolVersionCharacters =
+        SearchValues.Create("0123456789-");
+    private static readonly SearchValues<char> ExceptionTypeCharacters =
+        SearchValues.Create("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789._+`");
+
+    public override void OnEnd(Activity data)
+    {
+        data.SetStatus(data.Status);
+        foreach (var tag in data.TagObjects.Where(tag => !AllowedTagNames.Contains(tag.Key)).ToArray())
+            data.SetTag(tag.Key, null);
+
+        if (data.Source.Name == OpenTelemetryHostConfiguration.McpInstrumentationName)
+            SanitizeMcpActivity(data);
+        else if (data.Source.Name == "System.Net.Http")
+            SanitizeHttpActivity(data);
+        else if (data.Source.Name == OpenTelemetryHostConfiguration.InstrumentationName)
+            data.DisplayName = data.OperationName;
+
+        SanitizeTextTag(data, "error.type", MaximumExceptionTypeLength, ExceptionTypeCharacters);
+    }
+
+    private static void SanitizeMcpActivity(Activity activity)
+    {
+        var method = NormalizeMcpMethod(activity.GetTagItem("mcp.method.name") as string);
+        activity.SetTag("mcp.method.name", method);
+        var toolName = CalendarTelemetry.NormalizeToolName(
+            activity.GetTagItem("gen_ai.tool.name") as string);
+        if (toolName == "unknown")
+            activity.SetTag("gen_ai.tool.name", null);
+        else
+            activity.SetTag("gen_ai.tool.name", toolName);
+        activity.SetTag("mcp.protocol.version", NormalizeProtocolVersion(
+            activity.GetTagItem("mcp.protocol.version") as string));
+        activity.DisplayName = method == "tools/call" && toolName != "unknown"
+            ? string.Concat(method, " ", toolName)
+            : method;
+    }
+
+    private static void SanitizeHttpActivity(Activity activity)
+    {
+        var method = NormalizeHttpMethod(activity.GetTagItem("http.request.method") as string);
+        activity.SetTag("http.request.method", method);
+        activity.DisplayName = method;
+    }
+
+    private static string NormalizeMcpMethod(string? method) =>
+        method is not null && KnownMcpMethods.Contains(method) ? method : "mcp.request";
+
+    private static string NormalizeHttpMethod(string? method) =>
+        method is not null && KnownHttpMethods.Contains(method) ? method : "HTTP";
+
+    private static string? NormalizeProtocolVersion(string? version) =>
+        version is { Length: > 0 and <= 16 }
+        && version.AsSpan().IndexOfAnyExcept(ProtocolVersionCharacters) < 0
+            ? version
+            : null;
+
+    private static void SanitizeTextTag(
+        Activity activity,
+        string tagName,
+        int maximumLength,
+        SearchValues<char> allowedCharacters)
+    {
+        if (activity.GetTagItem(tagName) is not string value
+            || value.Length == 0
+            || value.Length > maximumLength
+            || value.AsSpan().IndexOfAnyExcept(allowedCharacters) >= 0)
+        {
+            activity.SetTag(tagName, null);
+        }
+    }
+
+    private const int MaximumExceptionTypeLength = 160;
+}

--- a/src/DotnetAgents.CalDav.Mcp/Hosting/TelemetryLogAllowlistProcessor.cs
+++ b/src/DotnetAgents.CalDav.Mcp/Hosting/TelemetryLogAllowlistProcessor.cs
@@ -1,0 +1,32 @@
+using OpenTelemetry;
+using OpenTelemetry.Logs;
+
+namespace DotnetAgents.CalDav.Mcp.Hosting;
+
+internal sealed class TelemetryLogAllowlistProcessor : BaseProcessor<LogRecord>
+{
+    private static readonly HashSet<string> AllowedAttributeNames = new(StringComparer.Ordinal)
+    {
+        "Category",
+        "Code",
+        "MutationState",
+        "Outcome",
+        "Phase"
+    };
+
+    public override void OnEnd(LogRecord data)
+    {
+        data.Body = "CalDAV diagnostic";
+        data.FormattedMessage = null;
+        data.Exception = null;
+        data.Attributes = data.Attributes?
+            .Where(attribute => IsSafeAttribute(attribute))
+            .ToArray();
+    }
+
+    private static bool IsSafeAttribute(KeyValuePair<string, object?> attribute) =>
+        AllowedAttributeNames.Contains(attribute.Key)
+        && attribute.Value is string value
+        && value is { Length: > 0 and <= 64 }
+        && value.All(character => char.IsAsciiLetterOrDigit(character) || character is '_' or '-');
+}

--- a/tests/DotnetAgents.CalDav.IntegrationTests/Fixtures/OtlpLoopbackReceiver.cs
+++ b/tests/DotnetAgents.CalDav.IntegrationTests/Fixtures/OtlpLoopbackReceiver.cs
@@ -11,6 +11,7 @@ internal sealed class OtlpLoopbackReceiver : IAsyncDisposable
     private readonly CancellationTokenSource _shutdown = new();
     private readonly ConcurrentQueue<OtlpRequest> _requests = new();
     private readonly SemaphoreSlim _requestSignal = new(0);
+    private readonly TaskCompletionSource _shutdownSignal = new(TaskCreationOptions.RunContinuationsAsynchronously);
     private readonly bool _respond;
     private readonly Task _pump;
 
@@ -56,6 +57,7 @@ internal sealed class OtlpLoopbackReceiver : IAsyncDisposable
     public async ValueTask DisposeAsync()
     {
         await _shutdown.CancelAsync().ConfigureAwait(false);
+        _shutdownSignal.TrySetResult();
         _listener.Stop();
         try
         {
@@ -91,7 +93,7 @@ internal sealed class OtlpLoopbackReceiver : IAsyncDisposable
         _requestSignal.Release();
         if (!_respond)
         {
-            await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken).ConfigureAwait(false);
+            await _shutdownSignal.Task.ConfigureAwait(false);
             return;
         }
         context.Response.StatusCode = (int)HttpStatusCode.OK;

--- a/tests/DotnetAgents.CalDav.IntegrationTests/Fixtures/OtlpLoopbackReceiver.cs
+++ b/tests/DotnetAgents.CalDav.IntegrationTests/Fixtures/OtlpLoopbackReceiver.cs
@@ -11,10 +11,12 @@ internal sealed class OtlpLoopbackReceiver : IAsyncDisposable
     private readonly CancellationTokenSource _shutdown = new();
     private readonly ConcurrentQueue<OtlpRequest> _requests = new();
     private readonly SemaphoreSlim _requestSignal = new(0);
+    private readonly bool _respond;
     private readonly Task _pump;
 
-    private OtlpLoopbackReceiver(int port)
+    private OtlpLoopbackReceiver(int port, bool respond)
     {
+        _respond = respond;
         Endpoint = new Uri($"http://127.0.0.1:{port}", UriKind.Absolute);
         _listener.Prefixes.Add($"{Endpoint.GetLeftPart(UriPartial.Authority)}/");
         _listener.Start();
@@ -25,14 +27,17 @@ internal sealed class OtlpLoopbackReceiver : IAsyncDisposable
 
     internal IReadOnlyList<OtlpRequest> Requests => _requests.ToArray();
 
-    internal static OtlpLoopbackReceiver Start()
+    internal static OtlpLoopbackReceiver Start(bool respond = true)
     {
         using var reservation = new TcpListener(IPAddress.Loopback, 0);
         reservation.Start();
         var port = ((IPEndPoint)reservation.LocalEndpoint).Port;
         reservation.Stop();
-        return new OtlpLoopbackReceiver(port);
+        return new OtlpLoopbackReceiver(port, respond);
     }
+
+    internal Task<bool> WaitForRequestAsync(CancellationToken cancellationToken) =>
+        _requestSignal.WaitAsync(TimeSpan.FromSeconds(15), cancellationToken);
 
     internal async Task WaitForPathsAsync(
         IReadOnlyCollection<string> requiredPaths,
@@ -84,6 +89,11 @@ internal sealed class OtlpLoopbackReceiver : IAsyncDisposable
         await context.Request.InputStream.CopyToAsync(body, cancellationToken).ConfigureAwait(false);
         _requests.Enqueue(new OtlpRequest(context.Request.Url?.AbsolutePath ?? string.Empty, body.ToArray()));
         _requestSignal.Release();
+        if (!_respond)
+        {
+            await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken).ConfigureAwait(false);
+            return;
+        }
         context.Response.StatusCode = (int)HttpStatusCode.OK;
         context.Response.ContentLength64 = 0;
         context.Response.Close();
@@ -153,7 +163,11 @@ internal static class OtlpProtobufReader
             foreach (var metric in MessageFields(scopeMetrics, 2))
             {
                 var fields = ReadFields(metric);
-                yield return new OtlpMetric(scopeName, ReadString(fields, 1), ReadString(fields, 3));
+                yield return new OtlpMetric(
+                    scopeName,
+                    ReadString(fields, 1),
+                    ReadString(fields, 3),
+                    ReadMetricDataPointAttributes(fields));
             }
         }
     }
@@ -168,7 +182,28 @@ internal static class OtlpProtobufReader
             ReadBytes(fields, 2),
             ReadBytes(fields, 4),
             ReadAttributes(fields, 9),
+            ReadString(fields, 3),
             fields.Count(field => field.Number == 11));
+    }
+
+    private static IReadOnlyList<IReadOnlyDictionary<string, object?>> ReadMetricDataPointAttributes(
+        IReadOnlyList<ProtoField> metricFields)
+    {
+        var attributes = new List<IReadOnlyDictionary<string, object?>>();
+        foreach (var data in metricFields.Where(field => field.Number is 5 or 7 or 9 or 10 or 11
+                     && field.Bytes is not null))
+        {
+            var attributeFieldNumber = data.Number switch
+            {
+                5 or 7 or 11 => 7,
+                9 => 9,
+                10 => 1,
+                _ => throw new InvalidDataException("Unsupported OTLP metric data kind.")
+            };
+            foreach (var point in MessageFields(data.Bytes!, 1))
+                attributes.Add(ReadAttributes(ReadFields(point), attributeFieldNumber));
+        }
+        return attributes;
     }
 
     private static OtlpLogRecord ReadLogRecord(string scopeName, byte[] payload)
@@ -297,6 +332,7 @@ internal sealed record OtlpSpan(
     byte[] SpanId,
     byte[] ParentSpanId,
     IReadOnlyDictionary<string, object?> Attributes,
+    string TraceState,
     int EventCount);
 
 internal sealed record OtlpLogRecord(
@@ -306,4 +342,8 @@ internal sealed record OtlpLogRecord(
     byte[] SpanId,
     IReadOnlyDictionary<string, object?> Attributes);
 
-internal sealed record OtlpMetric(string ScopeName, string Name, string Unit);
+internal sealed record OtlpMetric(
+    string ScopeName,
+    string Name,
+    string Unit,
+    IReadOnlyList<IReadOnlyDictionary<string, object?>> DataPointAttributes);

--- a/tests/DotnetAgents.CalDav.IntegrationTests/Fixtures/OtlpLoopbackReceiver.cs
+++ b/tests/DotnetAgents.CalDav.IntegrationTests/Fixtures/OtlpLoopbackReceiver.cs
@@ -1,0 +1,309 @@
+using System.Collections.Concurrent;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+
+namespace DotnetAgents.CalDav.IntegrationTests.Fixtures;
+
+internal sealed class OtlpLoopbackReceiver : IAsyncDisposable
+{
+    private readonly HttpListener _listener = new();
+    private readonly CancellationTokenSource _shutdown = new();
+    private readonly ConcurrentQueue<OtlpRequest> _requests = new();
+    private readonly SemaphoreSlim _requestSignal = new(0);
+    private readonly Task _pump;
+
+    private OtlpLoopbackReceiver(int port)
+    {
+        Endpoint = new Uri($"http://127.0.0.1:{port}", UriKind.Absolute);
+        _listener.Prefixes.Add($"{Endpoint.GetLeftPart(UriPartial.Authority)}/");
+        _listener.Start();
+        _pump = PumpAsync();
+    }
+
+    internal Uri Endpoint { get; }
+
+    internal IReadOnlyList<OtlpRequest> Requests => _requests.ToArray();
+
+    internal static OtlpLoopbackReceiver Start()
+    {
+        using var reservation = new TcpListener(IPAddress.Loopback, 0);
+        reservation.Start();
+        var port = ((IPEndPoint)reservation.LocalEndpoint).Port;
+        reservation.Stop();
+        return new OtlpLoopbackReceiver(port);
+    }
+
+    internal async Task WaitForPathsAsync(
+        IReadOnlyCollection<string> requiredPaths,
+        CancellationToken cancellationToken)
+    {
+        var deadline = TimeProvider.System.GetUtcNow() + TimeSpan.FromSeconds(15);
+        while (!requiredPaths.All(path => _requests.Any(request => request.Path == path)))
+        {
+            var remaining = deadline - TimeProvider.System.GetUtcNow();
+            if (remaining <= TimeSpan.Zero)
+                throw new TimeoutException($"Timed out waiting for OTLP paths: {string.Join(", ", requiredPaths)}");
+            await _requestSignal.WaitAsync(remaining, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _shutdown.CancelAsync().ConfigureAwait(false);
+        _listener.Stop();
+        try
+        {
+            await _pump.ConfigureAwait(false);
+        }
+        catch (Exception exception) when (
+            _shutdown.IsCancellationRequested
+            && exception is HttpListenerException or ObjectDisposedException or OperationCanceledException)
+        {
+            System.Diagnostics.Debug.Assert(_shutdown.IsCancellationRequested);
+        }
+        _listener.Close();
+        _requestSignal.Dispose();
+        _shutdown.Dispose();
+    }
+
+    private async Task PumpAsync()
+    {
+        while (!_shutdown.IsCancellationRequested)
+        {
+            var context = await _listener.GetContextAsync()
+                .WaitAsync(_shutdown.Token)
+                .ConfigureAwait(false);
+            await CaptureAsync(context, _shutdown.Token).ConfigureAwait(false);
+        }
+    }
+
+    private async Task CaptureAsync(HttpListenerContext context, CancellationToken cancellationToken)
+    {
+        using var body = new MemoryStream();
+        await context.Request.InputStream.CopyToAsync(body, cancellationToken).ConfigureAwait(false);
+        _requests.Enqueue(new OtlpRequest(context.Request.Url?.AbsolutePath ?? string.Empty, body.ToArray()));
+        _requestSignal.Release();
+        context.Response.StatusCode = (int)HttpStatusCode.OK;
+        context.Response.ContentLength64 = 0;
+        context.Response.Close();
+    }
+}
+
+internal sealed record OtlpRequest(string Path, byte[] Body);
+
+internal static class OtlpProtobufReader
+{
+    internal static IReadOnlyList<OtlpSpan> ReadSpans(IEnumerable<OtlpRequest> requests) => requests
+        .Where(request => request.Path == "/v1/traces")
+        .SelectMany(request => ReadTraceRequest(request.Body))
+        .ToArray();
+
+    internal static IReadOnlyList<OtlpLogRecord> ReadLogs(IEnumerable<OtlpRequest> requests) => requests
+        .Where(request => request.Path == "/v1/logs")
+        .SelectMany(request => ReadLogRequest(request.Body))
+        .ToArray();
+
+    internal static IReadOnlyList<OtlpMetric> ReadMetrics(IEnumerable<OtlpRequest> requests) => requests
+        .Where(request => request.Path == "/v1/metrics")
+        .SelectMany(request => ReadMetricRequest(request.Body))
+        .ToArray();
+
+    internal static bool ContainsUtf8(IEnumerable<OtlpRequest> requests, string path, string value)
+    {
+        var needle = Encoding.UTF8.GetBytes(value);
+        return requests.Where(request => request.Path == path)
+            .Any(request => request.Body.AsSpan().IndexOf(needle) >= 0);
+    }
+
+    internal static bool ContainsUtf8(IEnumerable<OtlpRequest> requests, string value)
+    {
+        var needle = Encoding.UTF8.GetBytes(value);
+        return requests.Any(request => request.Body.AsSpan().IndexOf(needle) >= 0);
+    }
+
+    private static IEnumerable<OtlpSpan> ReadTraceRequest(byte[] payload)
+    {
+        foreach (var resourceSpans in MessageFields(payload, 1))
+        foreach (var scopeSpans in MessageFields(resourceSpans, 2))
+        {
+            var scopeName = ReadScopeName(scopeSpans);
+            foreach (var span in MessageFields(scopeSpans, 2))
+                yield return ReadSpan(scopeName, span);
+        }
+    }
+
+    private static IEnumerable<OtlpLogRecord> ReadLogRequest(byte[] payload)
+    {
+        foreach (var resourceLogs in MessageFields(payload, 1))
+        foreach (var scopeLogs in MessageFields(resourceLogs, 2))
+        {
+            var scopeName = ReadScopeName(scopeLogs);
+            foreach (var record in MessageFields(scopeLogs, 2))
+                yield return ReadLogRecord(scopeName, record);
+        }
+    }
+
+    private static IEnumerable<OtlpMetric> ReadMetricRequest(byte[] payload)
+    {
+        foreach (var resourceMetrics in MessageFields(payload, 1))
+        foreach (var scopeMetrics in MessageFields(resourceMetrics, 2))
+        {
+            var scopeName = ReadScopeName(scopeMetrics);
+            foreach (var metric in MessageFields(scopeMetrics, 2))
+            {
+                var fields = ReadFields(metric);
+                yield return new OtlpMetric(scopeName, ReadString(fields, 1), ReadString(fields, 3));
+            }
+        }
+    }
+
+    private static OtlpSpan ReadSpan(string scopeName, byte[] payload)
+    {
+        var fields = ReadFields(payload);
+        return new OtlpSpan(
+            scopeName,
+            ReadString(fields, 5),
+            ReadBytes(fields, 1),
+            ReadBytes(fields, 2),
+            ReadBytes(fields, 4),
+            ReadAttributes(fields, 9),
+            fields.Count(field => field.Number == 11));
+    }
+
+    private static OtlpLogRecord ReadLogRecord(string scopeName, byte[] payload)
+    {
+        var fields = ReadFields(payload);
+        return new OtlpLogRecord(
+            scopeName,
+            ReadAnyValue(fields.FirstOrDefault(field => field.Number == 5)?.Bytes),
+            ReadBytes(fields, 9),
+            ReadBytes(fields, 10),
+            ReadAttributes(fields, 6));
+    }
+
+    private static string ReadScopeName(byte[] scopePayload)
+    {
+        var scope = MessageFields(scopePayload, 1).FirstOrDefault();
+        return scope is null ? string.Empty : ReadString(ReadFields(scope), 1);
+    }
+
+    private static IReadOnlyDictionary<string, object?> ReadAttributes(
+        IReadOnlyList<ProtoField> fields,
+        int fieldNumber) => fields
+        .Where(field => field.Number == fieldNumber && field.Bytes is not null)
+        .Select(ReadKeyValue)
+        .Where(item => item.Key.Length > 0)
+        .ToDictionary(item => item.Key, item => item.Value, StringComparer.Ordinal);
+
+    private static KeyValuePair<string, object?> ReadKeyValue(ProtoField field)
+    {
+        var fields = ReadFields(field.Bytes!);
+        var key = ReadString(fields, 1);
+        var value = ReadAnyValue(fields.FirstOrDefault(candidate => candidate.Number == 2)?.Bytes);
+        return new KeyValuePair<string, object?>(key, value);
+    }
+
+    private static object? ReadAnyValue(byte[]? payload)
+    {
+        if (payload is null)
+            return null;
+        var field = ReadFields(payload).FirstOrDefault();
+        if (field is null)
+            return null;
+        return field.Number switch
+        {
+            1 => field.Bytes is null ? null : Encoding.UTF8.GetString(field.Bytes),
+            2 => field.Integer != 0,
+            3 => unchecked((long)field.Integer),
+            _ => null
+        };
+    }
+
+    private static IEnumerable<byte[]> MessageFields(byte[] payload, int fieldNumber) =>
+        ReadFields(payload)
+            .Where(field => field.Number == fieldNumber && field.Bytes is not null)
+            .Select(field => field.Bytes!);
+
+    private static string ReadString(IReadOnlyList<ProtoField> fields, int fieldNumber)
+    {
+        var bytes = fields.FirstOrDefault(field => field.Number == fieldNumber)?.Bytes;
+        return bytes is null ? string.Empty : Encoding.UTF8.GetString(bytes);
+    }
+
+    private static byte[] ReadBytes(IReadOnlyList<ProtoField> fields, int fieldNumber) =>
+        fields.FirstOrDefault(field => field.Number == fieldNumber)?.Bytes ?? [];
+
+    private static IReadOnlyList<ProtoField> ReadFields(byte[] payload)
+    {
+        var fields = new List<ProtoField>();
+        var offset = 0;
+        while (offset < payload.Length)
+        {
+            var key = ReadVarint(payload, ref offset);
+            var number = checked((int)(key >> 3));
+            var wireType = checked((int)(key & 7));
+            fields.Add(ReadField(payload, ref offset, number, wireType));
+        }
+        return fields;
+    }
+
+    private static ProtoField ReadField(byte[] payload, ref int offset, int number, int wireType) => wireType switch
+    {
+        0 => new ProtoField(number, ReadVarint(payload, ref offset), null),
+        1 => new ProtoField(number, 0, ReadFixed(payload, ref offset, 8)),
+        2 => new ProtoField(number, 0, ReadLengthDelimited(payload, ref offset)),
+        5 => new ProtoField(number, 0, ReadFixed(payload, ref offset, 4)),
+        _ => throw new InvalidDataException($"Unsupported protobuf wire type {wireType}.")
+    };
+
+    private static byte[] ReadLengthDelimited(byte[] payload, ref int offset)
+    {
+        var length = checked((int)ReadVarint(payload, ref offset));
+        return ReadFixed(payload, ref offset, length);
+    }
+
+    private static byte[] ReadFixed(byte[] payload, ref int offset, int length)
+    {
+        if (length < 0 || offset > payload.Length - length)
+            throw new InvalidDataException("Truncated protobuf field.");
+        var value = payload.AsSpan(offset, length).ToArray();
+        offset += length;
+        return value;
+    }
+
+    private static ulong ReadVarint(byte[] payload, ref int offset)
+    {
+        ulong value = 0;
+        for (var shift = 0; shift < 64; shift += 7)
+        {
+            if (offset >= payload.Length)
+                throw new InvalidDataException("Truncated protobuf varint.");
+            var current = payload[offset++];
+            value |= (ulong)(current & 0x7f) << shift;
+            if ((current & 0x80) == 0)
+                return value;
+        }
+        throw new InvalidDataException("Oversized protobuf varint.");
+    }
+
+    private sealed record ProtoField(int Number, ulong Integer, byte[]? Bytes);
+}
+
+internal sealed record OtlpSpan(
+    string ScopeName,
+    string Name,
+    byte[] TraceId,
+    byte[] SpanId,
+    byte[] ParentSpanId,
+    IReadOnlyDictionary<string, object?> Attributes,
+    int EventCount);
+
+internal sealed record OtlpLogRecord(
+    string ScopeName,
+    object? Body,
+    byte[] TraceId,
+    byte[] SpanId,
+    IReadOnlyDictionary<string, object?> Attributes);
+
+internal sealed record OtlpMetric(string ScopeName, string Name, string Unit);

--- a/tests/DotnetAgents.CalDav.IntegrationTests/OpenTelemetryStdioIntegrationTests.cs
+++ b/tests/DotnetAgents.CalDav.IntegrationTests/OpenTelemetryStdioIntegrationTests.cs
@@ -1,0 +1,301 @@
+using System.Collections.Concurrent;
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text;
+using DotnetAgents.CalDav.IntegrationTests.Fixtures;
+using ModelContextProtocol.Client;
+using ModelContextProtocol.Protocol;
+using Shouldly;
+using Xunit;
+
+namespace DotnetAgents.CalDav.IntegrationTests;
+
+[Collection("RadicaleCollection")]
+public sealed class OpenTelemetryStdioIntegrationTests
+{
+    private readonly RadicaleFixture _fixture;
+
+    public OpenTelemetryStdioIntegrationTests(RadicaleFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact]
+    public async Task OptIn_ExportsSafeParentedWaterfallLogsAndMcpMetricsOverLoopbackOtlp()
+    {
+        var suffix = Guid.NewGuid().ToString("N");
+        var recurringUid = $"private-recurring-{suffix}";
+        var createdUid = $"private-created-{suffix}";
+        var privateSummary = $"Private telemetry summary {suffix}";
+        var recurringHref = await PutResourceAsync(
+            _fixture.TodoCalendarHref,
+            $"{recurringUid}.ics",
+            RecurringTodo(recurringUid));
+        string? createdHref = null;
+        string? createdEntityTag = null;
+        await using var receiver = OtlpLoopbackReceiver.Start();
+        var stderr = new ConcurrentQueue<string>();
+
+        try
+        {
+            await using (var client = await CreateClientAsync(receiver.Endpoint, stderr))
+            {
+                var query = await client.CallToolAsync(
+                    "calendar_occurrences.query",
+                    OccurrenceQueryArguments(),
+                    cancellationToken: TestContext.Current.CancellationToken);
+                query.IsError.ShouldBe(false, query.StructuredContent?.ToString());
+
+                var created = await client.CallToolAsync(
+                    "events.create",
+                    CreateEventArguments(createdUid, privateSummary),
+                    cancellationToken: TestContext.Current.CancellationToken);
+                created.IsError.ShouldBe(false, created.StructuredContent?.ToString());
+                var revision = created.StructuredContent!.Value.GetProperty("snapshot")
+                    .GetProperty("resourceRevision");
+                createdHref = revision.GetProperty("href").GetString();
+                createdEntityTag = revision.GetProperty("entityTag").GetString();
+            }
+
+            await receiver.WaitForPathsAsync(
+                ["/v1/traces", "/v1/metrics", "/v1/logs"],
+                TestContext.Current.CancellationToken);
+
+            AssertTraceWaterfalls(receiver.Requests);
+            AssertLogsAndMetrics(receiver.Requests);
+            AssertProhibitedDataAbsent(
+                receiver.Requests,
+                recurringUid,
+                createdUid,
+                privateSummary,
+                recurringHref,
+                createdHref!);
+            stderr.ShouldBeEmpty();
+        }
+        finally
+        {
+            if (createdHref is not null)
+                await DeleteResourceAsync(createdHref, createdEntityTag);
+            await DeleteResourceAsync(recurringHref, entityTag: null);
+        }
+    }
+
+    private static void AssertTraceWaterfalls(IReadOnlyList<OtlpRequest> requests)
+    {
+        var spans = OtlpProtobufReader.ReadSpans(requests);
+        var queryMcp = spans.Single(span =>
+            span.ScopeName == "Experimental.ModelContextProtocol"
+            && span.Name == "tools/call calendar_occurrences.query");
+        var queryOperation = spans.Single(span =>
+            span.ScopeName == "DotnetAgents.CalDav"
+            && Equals(span.Attributes.GetValueOrDefault("caldav.tool.name"), "calendar_occurrences.query"));
+        queryOperation.ParentSpanId.ShouldBe(queryMcp.SpanId);
+        spans.ShouldContain(span =>
+            span.Name == "caldav.phase.expand"
+            && span.ParentSpanId.SequenceEqual(queryOperation.SpanId));
+
+        var createMcp = spans.Single(span =>
+            span.ScopeName == "Experimental.ModelContextProtocol"
+            && span.Name == "tools/call events.create");
+        var createOperation = spans.Single(span =>
+            span.ScopeName == "DotnetAgents.CalDav"
+            && Equals(span.Attributes.GetValueOrDefault("caldav.tool.name"), "events.create"));
+        createOperation.ParentSpanId.ShouldBe(createMcp.SpanId);
+        var createPhases = spans.Where(span => span.ParentSpanId.SequenceEqual(createOperation.SpanId)).ToArray();
+        createPhases.ShouldContain(span => span.Name == "caldav.phase.reconcile");
+        spans.ShouldContain(span =>
+            span.ScopeName == "System.Net.Http"
+            && createPhases.Any(phase => span.ParentSpanId.SequenceEqual(phase.SpanId))
+            && span.Attributes.ContainsKey("http.request.method"));
+        spans.ShouldAllBe(span => span.EventCount == 0);
+        spans.Where(span => span.ScopeName == "DotnetAgents.CalDav")
+            .ShouldAllBe(span =>
+                span.Name == "caldav.operation"
+                || span.Name.StartsWith("caldav.phase.", StringComparison.Ordinal));
+        spans.SelectMany(span => span.Attributes.Keys).ShouldNotContain("url.full");
+        spans.SelectMany(span => span.Attributes.Keys).ShouldNotContain("mcp.resource.uri");
+    }
+
+    private static void AssertLogsAndMetrics(IReadOnlyList<OtlpRequest> requests)
+    {
+        OtlpProtobufReader.ReadMetrics(requests).ShouldContain(metric =>
+            metric.ScopeName == "Experimental.ModelContextProtocol"
+            && metric.Name == "mcp.server.operation.duration"
+            && metric.Unit == "s");
+        var spans = OtlpProtobufReader.ReadSpans(requests);
+        var logs = OtlpProtobufReader.ReadLogs(requests);
+        logs.ShouldContain(log =>
+            Equals(log.Body, "CalDAV diagnostic")
+            && log.TraceId.Length == 16
+            && log.SpanId.Length == 8
+            && spans.Any(span => span.TraceId.SequenceEqual(log.TraceId)));
+        logs.SelectMany(log => log.Attributes.Keys)
+            .All(key => key is "Category" or "Code" or "MutationState" or "Outcome" or "Phase")
+            .ShouldBeTrue();
+    }
+
+    private void AssertProhibitedDataAbsent(
+        IReadOnlyList<OtlpRequest> requests,
+        params string[] privateValues)
+    {
+        var prohibited = privateValues.Concat([
+            _fixture.BaseUrl,
+            "caldavtest",
+            "caldavtest123",
+            "otlp-private-header",
+            "BEGIN:VCALENDAR",
+            "Authorization",
+            "structuredContent",
+            "exception.message",
+            "exception.stacktrace"
+        ]);
+        prohibited.ShouldAllBe(value => !OtlpProtobufReader.ContainsUtf8(requests, value));
+    }
+
+    private async Task<McpClient> CreateClientAsync(Uri endpoint, ConcurrentQueue<string> stderr)
+    {
+        var eventCalendarHref = $"{_fixture.BaseUrl}{_fixture.EventCalendarHref}";
+        var todoCalendarHref = $"{_fixture.BaseUrl}{_fixture.TodoCalendarHref}";
+        var transport = new StdioClientTransport(new StdioClientTransportOptions
+        {
+            Command = "dotnet",
+            Arguments = [GetServerAssemblyPath()],
+            WorkingDirectory = AppContext.BaseDirectory,
+            InheritEnvironmentVariables = true,
+            EnvironmentVariables = new Dictionary<string, string?>
+            {
+                ["CALDAV_URL"] = _fixture.BaseUrl,
+                ["CALDAV_USERNAME"] = "caldavtest",
+                ["CALDAV_PASSWORD"] = "caldavtest123",
+                ["CALDAV_CALENDAR_HREFS"] = $"{eventCalendarHref},{todoCalendarHref}",
+                ["OTEL_EXPORTER_OTLP_ENDPOINT"] = endpoint.GetLeftPart(UriPartial.Authority),
+                ["OTEL_EXPORTER_OTLP_PROTOCOL"] = "http/protobuf",
+                ["OTEL_EXPORTER_OTLP_HEADERS"] = "authorization=Bearer otlp-private-header",
+                ["OTEL_SERVICE_NAME"] = "dotnet-agents-caldav-test",
+                ["OTEL_SDK_DISABLED"] = "false",
+                ["OTEL_BSP_SCHEDULE_DELAY"] = "100",
+                ["OTEL_BLRP_SCHEDULE_DELAY"] = "100",
+                ["OTEL_METRIC_EXPORT_INTERVAL"] = "100"
+            },
+            StandardErrorLines = stderr.Enqueue
+        });
+        return await McpClient.CreateAsync(
+            transport,
+            new McpClientOptions
+            {
+                ProtocolVersion = "2026-07-28",
+                DiscoverProbeTimeout = TimeSpan.FromSeconds(10)
+            },
+            cancellationToken: TestContext.Current.CancellationToken);
+    }
+
+    private Dictionary<string, object?> OccurrenceQueryArguments() => new()
+    {
+        ["scope"] = new Dictionary<string, object?>
+        {
+            ["mode"] = "selected",
+            ["calendar"] = new Dictionary<string, object?>
+            {
+                ["by"] = "href",
+                ["href"] = $"{_fixture.BaseUrl}{_fixture.TodoCalendarHref}"
+            }
+        },
+        ["from"] = new Dictionary<string, object?>
+        {
+            ["kind"] = "utcDateTime",
+            ["value"] = "2026-08-16T10:15:00Z"
+        },
+        ["to"] = new Dictionary<string, object?>
+        {
+            ["kind"] = "utcDateTime",
+            ["value"] = "2026-08-16T10:20:00Z"
+        }
+    };
+
+    private Dictionary<string, object?> CreateEventArguments(string uid, string summary) => new()
+    {
+        ["destination"] = new Dictionary<string, object?>
+        {
+            ["mode"] = "selected",
+            ["calendar"] = new Dictionary<string, object?>
+            {
+                ["by"] = "href",
+                ["href"] = $"{_fixture.BaseUrl}{_fixture.EventCalendarHref}"
+            }
+        },
+        ["entity"] = new Dictionary<string, object?>
+        {
+            ["kind"] = "event",
+            ["uid"] = uid,
+            ["fields"] = new Dictionary<string, object?>
+            {
+                ["summary"] = summary,
+                ["start"] = new Dictionary<string, object?>
+                {
+                    ["kind"] = "utcDateTime",
+                    ["value"] = "2026-08-21T13:00:00Z"
+                },
+                ["duration"] = "PT1H"
+            }
+        }
+    };
+
+    private static string RecurringTodo(string uid) =>
+        "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Telemetry Test//EN\r\n"
+        + $"BEGIN:VTODO\r\nUID:{uid}\r\nDTSTAMP:20260821T120000Z\r\n"
+        + "DTSTART:20260815T100000Z\r\nDUE:20260815T103000Z\r\n"
+        + "RRULE:FREQ=DAILY;COUNT=3\r\nEND:VTODO\r\nEND:VCALENDAR\r\n";
+
+    private async Task<string> PutResourceAsync(string calendarPath, string name, string content)
+    {
+        var href = $"{_fixture.BaseUrl}{calendarPath}{name}";
+        using var client = CreateAuthenticatedClient();
+        using var request = new HttpRequestMessage(HttpMethod.Put, href)
+        {
+            Content = new StringContent(content, Encoding.UTF8, "text/calendar")
+        };
+        request.Headers.TryAddWithoutValidation("If-None-Match", "*");
+        using var response = await client.SendAsync(request, TestContext.Current.CancellationToken);
+        response.StatusCode.ShouldBe(HttpStatusCode.Created);
+        return href;
+    }
+
+    private static async Task DeleteResourceAsync(string href, string? entityTag)
+    {
+        using var client = CreateAuthenticatedClient();
+        using var request = new HttpRequestMessage(HttpMethod.Delete, href);
+        if (entityTag is not null)
+            request.Headers.TryAddWithoutValidation("If-Match", entityTag);
+        using var response = await client.SendAsync(request, TestContext.Current.CancellationToken);
+        response.StatusCode.ShouldBeOneOf(HttpStatusCode.OK, HttpStatusCode.NoContent, HttpStatusCode.NotFound);
+    }
+
+    private static HttpClient CreateAuthenticatedClient()
+    {
+        var client = new HttpClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(
+            "Basic",
+            Convert.ToBase64String(Encoding.UTF8.GetBytes("caldavtest:caldavtest123")));
+        return client;
+    }
+
+    private static string GetServerAssemblyPath()
+    {
+        var directory = AppContext.BaseDirectory;
+        while (directory is not null)
+        {
+            var candidate = Path.Combine(
+                directory,
+                "src",
+                "DotnetAgents.CalDav.Mcp",
+                "bin",
+                "Release",
+                "net10.0",
+                "DotnetAgents.CalDav.Mcp.dll");
+            if (File.Exists(candidate))
+                return candidate;
+            directory = Directory.GetParent(directory)?.FullName;
+        }
+        throw new FileNotFoundException("Could not locate the built MCP server assembly.");
+    }
+}

--- a/tests/DotnetAgents.CalDav.IntegrationTests/OpenTelemetryStdioIntegrationTests.cs
+++ b/tests/DotnetAgents.CalDav.IntegrationTests/OpenTelemetryStdioIntegrationTests.cs
@@ -1,7 +1,10 @@
 using System.Collections.Concurrent;
+using System.Diagnostics;
 using System.Net;
 using System.Net.Http.Headers;
+using System.Net.Sockets;
 using System.Text;
+using System.Text.Json;
 using DotnetAgents.CalDav.IntegrationTests.Fixtures;
 using ModelContextProtocol.Client;
 using ModelContextProtocol.Protocol;
@@ -27,6 +30,7 @@ public sealed class OpenTelemetryStdioIntegrationTests
         var recurringUid = $"private-recurring-{suffix}";
         var createdUid = $"private-created-{suffix}";
         var privateSummary = $"Private telemetry summary {suffix}";
+        var privateCalendarName = $"Private Calendar Name {suffix}";
         var recurringHref = await PutResourceAsync(
             _fixture.TodoCalendarHref,
             $"{recurringUid}.ics",
@@ -38,13 +42,21 @@ public sealed class OpenTelemetryStdioIntegrationTests
 
         try
         {
-            await using (var client = await CreateClientAsync(receiver.Endpoint, stderr))
+            string? nextCursor;
+            await using (var client = await CreateClientAsync(
+                             receiver.Endpoint,
+                             stderr,
+                             defaultTodoCalendarName: privateCalendarName))
             {
                 var query = await client.CallToolAsync(
                     "calendar_occurrences.query",
                     OccurrenceQueryArguments(),
                     cancellationToken: TestContext.Current.CancellationToken);
                 query.IsError.ShouldBe(false, query.StructuredContent?.ToString());
+                nextCursor = query.StructuredContent!.Value.GetProperty("pagination")
+                    .GetProperty("nextCursor")
+                    .GetString()
+                    .ShouldNotBeNull();
 
                 var created = await client.CallToolAsync(
                     "events.create",
@@ -68,8 +80,11 @@ public sealed class OpenTelemetryStdioIntegrationTests
                 recurringUid,
                 createdUid,
                 privateSummary,
+                privateCalendarName,
                 recurringHref,
-                createdHref!);
+                createdHref!,
+                createdEntityTag!,
+                nextCursor);
             stderr.ShouldBeEmpty();
         }
         finally
@@ -78,6 +93,184 @@ public sealed class OpenTelemetryStdioIntegrationTests
                 await DeleteResourceAsync(createdHref, createdEntityTag);
             await DeleteResourceAsync(recurringHref, entityTag: null);
         }
+    }
+
+    [Fact]
+    public async Task InvalidClientDimensionsTraceStateAndPayloadMarkersAreRedacted()
+    {
+        var suffix = Guid.NewGuid().ToString("N");
+        var privateMethod = $"private-exception-message-{suffix}";
+        var privateTool = $"private-tool-url-uid-{suffix}";
+        var privateCalendarName = $"private-calendar-name-{suffix}";
+        var privateCursor = $"private-cursor-{suffix}";
+        var privateMrtrHandle = $"private-mrtr-handle-{suffix}";
+        var privateTraceState = $"privatevendor=private-trace-state-{suffix}";
+        var reviewedUid = $"private-reviewed-mrtr-{suffix}";
+        var reviewedHref = await PutResourceAsync(
+            _fixture.TodoCalendarHref,
+            $"{reviewedUid}.ics",
+            PrivateTodo(reviewedUid));
+        var reviewedEntityTag = await GetEntityTagAsync(reviewedHref);
+        await using var receiver = OtlpLoopbackReceiver.Start();
+        using var process = CreateRawTelemetryProcess(receiver.Endpoint);
+        process.Start();
+        var stderrTask = process.StandardError.ReadToEndAsync(TestContext.Current.CancellationToken);
+
+        try
+        {
+            await WriteRawAsync(process,
+                "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":\"2026-07-28\",\"capabilities\":{},\"clientInfo\":{\"name\":\"privacy-test\",\"version\":\"1\"}}}");
+            _ = await ReadRawResponseAsync(process, 1);
+            await WriteRawAsync(process,
+                "{\"jsonrpc\":\"2.0\",\"method\":\"notifications/initialized\"}");
+            await WriteRawAsync(process, JsonSerializer.Serialize(new
+            {
+                jsonrpc = "2.0",
+                id = 2,
+                method = privateMethod,
+                @params = new
+                {
+                    _meta = new Dictionary<string, object?>
+                    {
+                        ["traceparent"] = "00-0123456789abcdef0123456789abcdef-0123456789abcdef-01",
+                        ["tracestate"] = privateTraceState
+                    }
+                }
+            }));
+            _ = await ReadRawResponseAsync(process, 2);
+            await WriteRawAsync(process, JsonSerializer.Serialize(new
+            {
+                jsonrpc = "2.0",
+                id = 3,
+                method = "tools/call",
+                @params = new
+                {
+                    _meta = new Dictionary<string, object?>
+                    {
+                        ["traceparent"] = "00-1123456789abcdef0123456789abcdef-1123456789abcdef-01",
+                        ["tracestate"] = privateTraceState
+                    },
+                    name = privateTool,
+                    arguments = new
+                    {
+                        scope = new { mode = "selected", calendar = new { by = "name", name = privateCalendarName } },
+                        cursor = privateCursor
+                    },
+                    requestState = privateMrtrHandle
+                }
+            }));
+            _ = await ReadRawResponseAsync(process, 3);
+            await WriteRawAsync(process, JsonSerializer.Serialize(new
+            {
+                jsonrpc = "2.0",
+                id = 4,
+                method = "tools/call",
+                @params = new
+                {
+                    _meta = new Dictionary<string, object?>
+                    {
+                        ["io.modelcontextprotocol/protocolVersion"] = "2026-07-28",
+                        ["io.modelcontextprotocol/clientInfo"] = new { name = "privacy-test", version = "1" },
+                        ["io.modelcontextprotocol/clientCapabilities"] = new { }
+                    },
+                    name = "calendar_resources.delete",
+                    arguments = new
+                    {
+                        revision = new
+                        {
+                            href = reviewedHref,
+                            entityUid = reviewedUid,
+                            entityKind = "todo",
+                            entityTag = reviewedEntityTag
+                        }
+                    }
+                }
+            }));
+            var inputRequired = (await ReadRawResponseAsync(process, 4)).GetProperty("result");
+            inputRequired.GetProperty("inputRequests").TryGetProperty("confirm_delete", out _)
+                .ShouldBeTrue();
+            var actualMrtrHandle = inputRequired.GetProperty("requestState").GetString()
+                .ShouldNotBeNull();
+            process.StandardInput.Close();
+            await process.WaitForExitAsync(TestContext.Current.CancellationToken);
+
+            await receiver.WaitForPathsAsync(
+                ["/v1/traces", "/v1/metrics"],
+                TestContext.Current.CancellationToken);
+            var privateValues = new[]
+            {
+                privateMethod,
+                privateTool,
+                privateCalendarName,
+                privateCursor,
+                privateMrtrHandle,
+                privateTraceState,
+                reviewedUid,
+                reviewedHref,
+                reviewedEntityTag,
+                actualMrtrHandle
+            };
+            privateValues.ShouldAllBe(value => !OtlpProtobufReader.ContainsUtf8(receiver.Requests, value));
+            OtlpProtobufReader.ReadSpans(receiver.Requests)
+                .ShouldAllBe(span => span.TraceState.Length == 0);
+            var operationMetrics = OtlpProtobufReader.ReadMetrics(receiver.Requests)
+                .Where(metric => metric.Name == "mcp.server.operation.duration")
+                .ToArray();
+            operationMetrics.ShouldNotBeEmpty();
+            operationMetrics.SelectMany(metric => metric.DataPointAttributes)
+                .SelectMany(attributes => attributes.Keys)
+                .ShouldAllBe(key => key == "rpc.response.status_code");
+            (await process.StandardOutput.ReadToEndAsync(TestContext.Current.CancellationToken))
+                .ShouldBeEmpty();
+            (await stderrTask).ShouldBeEmpty();
+        }
+        finally
+        {
+            if (!process.HasExited)
+                process.Kill(entireProcessTree: true);
+            await DeleteResourceAsync(reviewedHref, reviewedEntityTag);
+        }
+    }
+
+    [Fact]
+    public async Task TransientReadFailure_ExportsDistinctSafeHttpAttempts()
+    {
+        await using var server = new RetryingDiscoveryServer();
+        await using var receiver = OtlpLoopbackReceiver.Start();
+        var stderr = new ConcurrentQueue<string>();
+
+        await using (var client = await CreateClientAsync(
+                         receiver.Endpoint,
+                         stderr,
+                         baseUrl: server.BaseUrl,
+                         calendarHrefs: server.CalendarHref))
+        {
+            var result = await client.CallToolAsync(
+                "calendars.list",
+                cancellationToken: TestContext.Current.CancellationToken);
+            result.IsError.ShouldBe(false, result.StructuredContent?.ToString());
+        }
+
+        await receiver.WaitForPathsAsync(["/v1/traces"], TestContext.Current.CancellationToken);
+        var spans = OtlpProtobufReader.ReadSpans(receiver.Requests);
+        var discoveryPhases = spans.Where(span => span.Name == "caldav.phase.discovery").ToArray();
+        var attempts = spans.Where(span =>
+            span.ScopeName == "System.Net.Http"
+            && Equals(span.Attributes.GetValueOrDefault("http.request.method"), "PROPFIND"))
+            .ToArray();
+        attempts.Length.ShouldBeGreaterThanOrEqualTo(2, string.Join(
+            Environment.NewLine,
+            spans.Select(span => $"{span.ScopeName} | {span.Name} | {string.Join(',', span.Attributes.Select(item => $"{item.Key}={item.Value}"))}")));
+        attempts.Select(span => Convert.ToHexString(span.SpanId)).Distinct(StringComparer.Ordinal).Count()
+            .ShouldBe(attempts.Length);
+        attempts.ShouldContain(span =>
+            Equals(span.Attributes.GetValueOrDefault("http.response.status_code"), 503L));
+        attempts.ShouldContain(span =>
+            Equals(span.Attributes.GetValueOrDefault("http.response.status_code"), 207L));
+        attempts.ShouldAllBe(attempt => discoveryPhases.Any(phase =>
+            attempt.ParentSpanId.SequenceEqual(phase.SpanId)));
+        server.TransientFailureCount.ShouldBe(1);
+        stderr.ShouldBeEmpty();
     }
 
     private static void AssertTraceWaterfalls(IReadOnlyList<OtlpRequest> requests)
@@ -118,10 +311,14 @@ public sealed class OpenTelemetryStdioIntegrationTests
 
     private static void AssertLogsAndMetrics(IReadOnlyList<OtlpRequest> requests)
     {
-        OtlpProtobufReader.ReadMetrics(requests).ShouldContain(metric =>
+        var metrics = OtlpProtobufReader.ReadMetrics(requests);
+        metrics.ShouldContain(metric =>
             metric.ScopeName == "Experimental.ModelContextProtocol"
             && metric.Name == "mcp.server.operation.duration"
             && metric.Unit == "s");
+        metrics.SelectMany(metric => metric.DataPointAttributes)
+            .SelectMany(attributes => attributes)
+            .ShouldAllBe(attribute => IsSafeMetricAttribute(attribute));
         var spans = OtlpProtobufReader.ReadSpans(requests);
         var logs = OtlpProtobufReader.ReadLogs(requests);
         logs.ShouldContain(log =>
@@ -152,10 +349,27 @@ public sealed class OpenTelemetryStdioIntegrationTests
         prohibited.ShouldAllBe(value => !OtlpProtobufReader.ContainsUtf8(requests, value));
     }
 
-    private async Task<McpClient> CreateClientAsync(Uri endpoint, ConcurrentQueue<string> stderr)
+    private static bool IsSafeMetricAttribute(KeyValuePair<string, object?> attribute) =>
+        attribute.Key switch
+        {
+            "rpc.response.status_code" => attribute.Value is long,
+            "mcp.protocol.version" => Equals(attribute.Value, "2026-07-28"),
+            "network.protocol.name" => Equals(attribute.Value, "mcp"),
+            "network.transport" => Equals(attribute.Value, "pipe"),
+            _ => false
+        };
+
+    private async Task<McpClient> CreateClientAsync(
+        Uri endpoint,
+        ConcurrentQueue<string> stderr,
+        string? baseUrl = null,
+        string? calendarHrefs = null,
+        string? defaultTodoCalendarName = null)
     {
-        var eventCalendarHref = $"{_fixture.BaseUrl}{_fixture.EventCalendarHref}";
-        var todoCalendarHref = $"{_fixture.BaseUrl}{_fixture.TodoCalendarHref}";
+        baseUrl ??= _fixture.BaseUrl;
+        var eventCalendarHref = $"{baseUrl}{_fixture.EventCalendarHref}";
+        var todoCalendarHref = $"{baseUrl}{_fixture.TodoCalendarHref}";
+        calendarHrefs ??= $"{eventCalendarHref},{todoCalendarHref}";
         var transport = new StdioClientTransport(new StdioClientTransportOptions
         {
             Command = "dotnet",
@@ -164,10 +378,11 @@ public sealed class OpenTelemetryStdioIntegrationTests
             InheritEnvironmentVariables = true,
             EnvironmentVariables = new Dictionary<string, string?>
             {
-                ["CALDAV_URL"] = _fixture.BaseUrl,
+                ["CALDAV_URL"] = baseUrl,
                 ["CALDAV_USERNAME"] = "caldavtest",
                 ["CALDAV_PASSWORD"] = "caldavtest123",
-                ["CALDAV_CALENDAR_HREFS"] = $"{eventCalendarHref},{todoCalendarHref}",
+                ["CALDAV_CALENDAR_HREFS"] = calendarHrefs,
+                ["CALDAV_DEFAULT_TODO_CALENDAR_NAME"] = defaultTodoCalendarName,
                 ["OTEL_EXPORTER_OTLP_ENDPOINT"] = endpoint.GetLeftPart(UriPartial.Authority),
                 ["OTEL_EXPORTER_OTLP_PROTOCOL"] = "http/protobuf",
                 ["OTEL_EXPORTER_OTLP_HEADERS"] = "authorization=Bearer otlp-private-header",
@@ -203,13 +418,14 @@ public sealed class OpenTelemetryStdioIntegrationTests
         ["from"] = new Dictionary<string, object?>
         {
             ["kind"] = "utcDateTime",
-            ["value"] = "2026-08-16T10:15:00Z"
+            ["value"] = "2026-08-15T09:00:00Z"
         },
         ["to"] = new Dictionary<string, object?>
         {
             ["kind"] = "utcDateTime",
-            ["value"] = "2026-08-16T10:20:00Z"
-        }
+            ["value"] = "2026-08-18T11:00:00Z"
+        },
+        ["pageSize"] = 1
     };
 
     private Dictionary<string, object?> CreateEventArguments(string uid, string summary) => new()
@@ -246,6 +462,11 @@ public sealed class OpenTelemetryStdioIntegrationTests
         + "DTSTART:20260815T100000Z\r\nDUE:20260815T103000Z\r\n"
         + "RRULE:FREQ=DAILY;COUNT=3\r\nEND:VTODO\r\nEND:VCALENDAR\r\n";
 
+    private static string PrivateTodo(string uid) =>
+        "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Telemetry Privacy Test//EN\r\n"
+        + $"BEGIN:VTODO\r\nUID:{uid}\r\nDTSTAMP:20260821T120000Z\r\n"
+        + "SUMMARY:Private reviewed MRTR resource\r\nEND:VTODO\r\nEND:VCALENDAR\r\n";
+
     private async Task<string> PutResourceAsync(string calendarPath, string name, string content)
     {
         var href = $"{_fixture.BaseUrl}{calendarPath}{name}";
@@ -270,6 +491,15 @@ public sealed class OpenTelemetryStdioIntegrationTests
         response.StatusCode.ShouldBeOneOf(HttpStatusCode.OK, HttpStatusCode.NoContent, HttpStatusCode.NotFound);
     }
 
+    private static async Task<string> GetEntityTagAsync(string href)
+    {
+        using var client = CreateAuthenticatedClient();
+        using var response = await client.GetAsync(href, TestContext.Current.CancellationToken);
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        return response.Headers.ETag?.Tag
+            ?? throw new InvalidDataException("Radicale response did not contain a strong Entity Tag.");
+    }
+
     private static HttpClient CreateAuthenticatedClient()
     {
         var client = new HttpClient();
@@ -277,6 +507,140 @@ public sealed class OpenTelemetryStdioIntegrationTests
             "Basic",
             Convert.ToBase64String(Encoding.UTF8.GetBytes("caldavtest:caldavtest123")));
         return client;
+    }
+
+    private Process CreateRawTelemetryProcess(Uri endpoint)
+    {
+        var process = new Process
+        {
+            StartInfo = new ProcessStartInfo
+            {
+                FileName = "dotnet",
+                Arguments = GetServerAssemblyPath(),
+                RedirectStandardInput = true,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            }
+        };
+        var environment = process.StartInfo.Environment;
+        environment["CALDAV_URL"] = _fixture.BaseUrl;
+        environment["CALDAV_USERNAME"] = "caldavtest";
+        environment["CALDAV_PASSWORD"] = "caldavtest123";
+        environment["CALDAV_CALENDAR_HREFS"] = $"{_fixture.BaseUrl}{_fixture.TodoCalendarHref}";
+        environment["OTEL_EXPORTER_OTLP_ENDPOINT"] = endpoint.GetLeftPart(UriPartial.Authority);
+        environment["OTEL_EXPORTER_OTLP_PROTOCOL"] = "http/protobuf";
+        environment["OTEL_BSP_SCHEDULE_DELAY"] = "50";
+        environment["OTEL_BLRP_SCHEDULE_DELAY"] = "50";
+        environment["OTEL_METRIC_EXPORT_INTERVAL"] = "50";
+        return process;
+    }
+
+    private static async Task WriteRawAsync(Process process, string message)
+    {
+        await process.StandardInput.WriteLineAsync(message);
+        await process.StandardInput.FlushAsync(TestContext.Current.CancellationToken);
+    }
+
+    private static async Task<JsonElement> ReadRawResponseAsync(Process process, int expectedId)
+    {
+        while (await process.StandardOutput.ReadLineAsync(TestContext.Current.CancellationToken) is { } line)
+        {
+            using var document = JsonDocument.Parse(line);
+            var message = document.RootElement;
+            if (message.TryGetProperty("id", out var id) && id.GetInt32() == expectedId)
+                return message.Clone();
+        }
+        throw new EndOfStreamException($"MCP process ended before response {expectedId}.");
+    }
+
+    private sealed class RetryingDiscoveryServer : IAsyncDisposable
+    {
+        private readonly HttpListener _listener = new();
+        private readonly CancellationTokenSource _stopping = new();
+        private readonly Task _serve;
+        private int _transientFailureCount;
+        private int _propFindCount;
+
+        internal RetryingDiscoveryServer()
+        {
+            using var reservation = new TcpListener(IPAddress.Loopback, 0);
+            reservation.Start();
+            var port = ((IPEndPoint)reservation.LocalEndpoint).Port;
+            reservation.Stop();
+            BaseUrl = $"http://127.0.0.1:{port}/";
+            CalendarHref = $"{BaseUrl}calendars/test/entities/";
+            _listener.Prefixes.Add(BaseUrl);
+            _listener.Start();
+            _serve = ServeAsync();
+        }
+
+        internal string BaseUrl { get; }
+
+        internal string CalendarHref { get; }
+
+        internal int TransientFailureCount => Volatile.Read(ref _transientFailureCount);
+
+        public async ValueTask DisposeAsync()
+        {
+            await _stopping.CancelAsync();
+            _listener.Stop();
+            try
+            {
+                await _serve;
+            }
+            catch (Exception exception) when (_stopping.IsCancellationRequested
+                && exception is HttpListenerException or ObjectDisposedException or OperationCanceledException)
+            {
+                System.Diagnostics.Debug.Assert(_stopping.IsCancellationRequested);
+            }
+            _listener.Close();
+            _stopping.Dispose();
+        }
+
+        private async Task ServeAsync()
+        {
+            while (!_stopping.IsCancellationRequested)
+            {
+                var context = await _listener.GetContextAsync()
+                    .WaitAsync(_stopping.Token)
+                    .ConfigureAwait(false);
+                await RespondAsync(context).ConfigureAwait(false);
+            }
+        }
+
+        private async Task RespondAsync(HttpListenerContext context)
+        {
+            if (context.Request.HttpMethod != "PROPFIND")
+            {
+                context.Response.StatusCode = (int)HttpStatusCode.MethodNotAllowed;
+                context.Response.Close();
+                return;
+            }
+
+            if (Interlocked.Increment(ref _propFindCount) == 1)
+            {
+                Interlocked.Increment(ref _transientFailureCount);
+                context.Response.StatusCode = (int)HttpStatusCode.ServiceUnavailable;
+                context.Response.Headers["Retry-After"] = "0";
+                context.Response.Close();
+                return;
+            }
+
+            var body = context.Request.Url!.AbsolutePath == "/"
+                ? "<d:response><d:href>/</d:href><d:propstat><d:prop><c:calendar-home-set><d:href>/calendars/test/</d:href></c:calendar-home-set></d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat></d:response>"
+                : "<d:response><d:href>/calendars/test/entities/</d:href><d:propstat><d:prop><d:resourcetype><c:calendar/></d:resourcetype><d:displayname>Retry Calendar</d:displayname><c:supported-calendar-component-set><c:comp name=\"VEVENT\"/><c:comp name=\"VTODO\"/></c:supported-calendar-component-set></d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat></d:response>";
+            var xml = "<?xml version=\"1.0\" encoding=\"utf-8\"?><d:multistatus xmlns:d=\"DAV:\" xmlns:c=\"urn:ietf:params:xml:ns:caldav\">"
+                + body
+                + "</d:multistatus>";
+            var bytes = Encoding.UTF8.GetBytes(xml);
+            context.Response.StatusCode = (int)HttpStatusCode.MultiStatus;
+            context.Response.ContentType = "application/xml; charset=utf-8";
+            context.Response.ContentLength64 = bytes.Length;
+            await context.Response.OutputStream.WriteAsync(bytes, TestContext.Current.CancellationToken);
+            context.Response.Close();
+        }
     }
 
     private static string GetServerAssemblyPath()

--- a/tests/DotnetAgents.CalDav.IntegrationTests/StdioLoggingIntegrationTests.cs
+++ b/tests/DotnetAgents.CalDav.IntegrationTests/StdioLoggingIntegrationTests.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Reflection;
+using System.Text.Json;
 using DotnetAgents.CalDav.IntegrationTests.Fixtures;
 using Shouldly;
 using Xunit;
@@ -116,19 +117,55 @@ public sealed class StdioLoggingIntegrationTests
         process.StartInfo.Environment["OTEL_EXPORTER_OTLP_PROTOCOL"] = "http/protobuf";
 
         process.Start();
-        var stdoutTask = process.StandardOutput.ReadToEndAsync(TestContext.Current.CancellationToken);
         var stderrTask = process.StandardError.ReadToEndAsync(TestContext.Current.CancellationToken);
+        var response = await CallCalendarsListAsync(process);
+        response.GetProperty("result").GetProperty("isError").GetBoolean().ShouldBeFalse();
         var beforeClose = DateTimeOffset.UtcNow;
         process.StandardInput.Close();
 
         await WaitForExitWithTimeoutAsync(process, TestContext.Current.CancellationToken);
 
         var elapsed = DateTimeOffset.UtcNow - beforeClose;
-        var stdout = await stdoutTask;
+        var stdout = await process.StandardOutput.ReadToEndAsync(TestContext.Current.CancellationToken);
         var stderr = await stderrTask;
         process.ExitCode.ShouldBe(0, $"stdout: {stdout}\nstderr: {stderr}");
         elapsed.ShouldBeLessThan(TimeSpan.FromSeconds(2),
             $"Unreachable OTLP endpoint delayed stdin-EOF shutdown. stdout: {stdout}\nstderr: {stderr}");
+        stdout.ShouldBeEmpty();
+        stderr.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task McpProcess_WithHangingOtlpCollector_PreservesToolResultAndTwoSecondShutdown()
+    {
+        await using var receiver = OtlpLoopbackReceiver.Start(respond: false);
+        using var process = CreateProcess();
+        _fixture.ConfigureCalDavEnvironment(process.StartInfo.Environment);
+        process.StartInfo.Environment["OTEL_EXPORTER_OTLP_ENDPOINT"] =
+            receiver.Endpoint.GetLeftPart(UriPartial.Authority);
+        process.StartInfo.Environment["OTEL_EXPORTER_OTLP_PROTOCOL"] = "http/protobuf";
+        process.StartInfo.Environment["OTEL_BSP_SCHEDULE_DELAY"] = "50";
+        process.StartInfo.Environment["OTEL_BLRP_SCHEDULE_DELAY"] = "50";
+        process.StartInfo.Environment["OTEL_METRIC_EXPORT_INTERVAL"] = "50";
+        process.StartInfo.Environment["OTEL_EXPORTER_OTLP_TIMEOUT"] = "10000";
+
+        process.Start();
+        var stderrTask = process.StandardError.ReadToEndAsync(TestContext.Current.CancellationToken);
+        var response = await CallCalendarsListAsync(process);
+        response.GetProperty("result").GetProperty("isError").GetBoolean().ShouldBeFalse();
+        (await receiver.WaitForRequestAsync(TestContext.Current.CancellationToken)).ShouldBeTrue();
+
+        var beforeClose = DateTimeOffset.UtcNow;
+        process.StandardInput.Close();
+        await WaitForExitWithTimeoutAsync(process, TestContext.Current.CancellationToken);
+
+        var elapsed = DateTimeOffset.UtcNow - beforeClose;
+        var stdout = await process.StandardOutput.ReadToEndAsync(TestContext.Current.CancellationToken);
+        var stderr = await stderrTask;
+        process.ExitCode.ShouldBe(0, $"stdout: {stdout}\nstderr: {stderr}");
+        elapsed.ShouldBeLessThan(TimeSpan.FromSeconds(2),
+            $"A collector that accepted but did not answer delayed stdin-EOF shutdown. " +
+            $"stdout: {stdout}\nstderr: {stderr}");
         stdout.ShouldBeEmpty();
         stderr.ShouldBeEmpty();
     }
@@ -170,6 +207,32 @@ public sealed class StdioLoggingIntegrationTests
             process.Kill(entireProcessTree: true);
             throw;
         }
+    }
+
+    private static async Task<JsonElement> CallCalendarsListAsync(Process process)
+    {
+        await process.StandardInput.WriteLineAsync(
+            "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":\"2026-07-28\",\"capabilities\":{},\"clientInfo\":{\"name\":\"otlp-failure-test\",\"version\":\"1\"}}}");
+        await process.StandardInput.FlushAsync(TestContext.Current.CancellationToken);
+        _ = await ReadResponseAsync(process, 1);
+        await process.StandardInput.WriteLineAsync(
+            "{\"jsonrpc\":\"2.0\",\"method\":\"notifications/initialized\"}");
+        await process.StandardInput.WriteLineAsync(
+            "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/call\",\"params\":{\"name\":\"calendars.list\",\"arguments\":{}}}");
+        await process.StandardInput.FlushAsync(TestContext.Current.CancellationToken);
+        return await ReadResponseAsync(process, 2);
+    }
+
+    private static async Task<JsonElement> ReadResponseAsync(Process process, int expectedId)
+    {
+        while (await process.StandardOutput.ReadLineAsync(TestContext.Current.CancellationToken) is { } line)
+        {
+            using var document = JsonDocument.Parse(line);
+            var message = document.RootElement;
+            if (message.TryGetProperty("id", out var id) && id.GetInt32() == expectedId)
+                return message.Clone();
+        }
+        throw new EndOfStreamException($"MCP process ended before response {expectedId}.");
     }
 
     private static Process CreateProcess()

--- a/tests/DotnetAgents.CalDav.IntegrationTests/StdioLoggingIntegrationTests.cs
+++ b/tests/DotnetAgents.CalDav.IntegrationTests/StdioLoggingIntegrationTests.cs
@@ -107,6 +107,32 @@ public sealed class StdioLoggingIntegrationTests
             $"stdout must remain empty for JSON-RPC, but contained:\n{stdout}");
     }
 
+    [Fact]
+    public async Task McpProcess_WithUnreachableOtlpEndpoint_StaysCleanAndExitsWithinTwoSeconds()
+    {
+        using var process = CreateProcess();
+        _fixture.ConfigureCalDavEnvironment(process.StartInfo.Environment);
+        process.StartInfo.Environment["OTEL_EXPORTER_OTLP_ENDPOINT"] = "http://127.0.0.1:1";
+        process.StartInfo.Environment["OTEL_EXPORTER_OTLP_PROTOCOL"] = "http/protobuf";
+
+        process.Start();
+        var stdoutTask = process.StandardOutput.ReadToEndAsync(TestContext.Current.CancellationToken);
+        var stderrTask = process.StandardError.ReadToEndAsync(TestContext.Current.CancellationToken);
+        var beforeClose = DateTimeOffset.UtcNow;
+        process.StandardInput.Close();
+
+        await WaitForExitWithTimeoutAsync(process, TestContext.Current.CancellationToken);
+
+        var elapsed = DateTimeOffset.UtcNow - beforeClose;
+        var stdout = await stdoutTask;
+        var stderr = await stderrTask;
+        process.ExitCode.ShouldBe(0, $"stdout: {stdout}\nstderr: {stderr}");
+        elapsed.ShouldBeLessThan(TimeSpan.FromSeconds(2),
+            $"Unreachable OTLP endpoint delayed stdin-EOF shutdown. stdout: {stdout}\nstderr: {stderr}");
+        stdout.ShouldBeEmpty();
+        stderr.ShouldBeEmpty();
+    }
+
     /// <summary>
     /// Resolves the path to the MCP server DLL relative to the test assembly,
     /// walking up from the test bin/ to the src project bin/.

--- a/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/CalendarExecutionPolicyTests.cs
+++ b/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/CalendarExecutionPolicyTests.cs
@@ -5,6 +5,7 @@ using ModelContextProtocol;
 using ModelContextProtocol.Protocol;
 using ModelContextProtocol.Server;
 using Shouldly;
+using System.Diagnostics;
 using System.Text.Json;
 using Xunit;
 
@@ -12,6 +13,65 @@ namespace DotnetAgents.CalDav.Mcp.Tests.Unit;
 
 public sealed class CalendarExecutionPolicyTests
 {
+    [Fact]
+    public async Task PublicToolFilter_EmitsParentedOperationPhaseAndSafeResultDimensions()
+    {
+        var stopped = new List<Activity>();
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == "DotnetAgents.CalDav",
+            Sample = static (ref ActivityCreationOptions<ActivityContext> _) =>
+                ActivitySamplingResult.AllDataAndRecorded,
+            ActivityStopped = stopped.Add
+        };
+        ActivitySource.AddActivityListener(listener);
+        using var mcpActivity = new Activity("tools/call").Start();
+        var services = new ServiceCollection()
+            .AddSingleton(TimeProvider.System)
+            .AddSingleton<CalendarOperationAdmission>()
+            .BuildServiceProvider();
+        await using var transport = new StreamServerTransport(
+            new MemoryStream(),
+            new MemoryStream(),
+            "execution-policy-telemetry-test",
+            Microsoft.Extensions.Logging.Abstractions.NullLoggerFactory.Instance);
+        await using var server = McpServer.Create(
+            transport,
+            new McpServerOptions(),
+            Microsoft.Extensions.Logging.Abstractions.NullLoggerFactory.Instance,
+            services);
+        var context = new RequestContext<CallToolRequestParams>(
+            server,
+            new JsonRpcRequest { Id = new RequestId(1L), Method = "tools/call" },
+            new CallToolRequestParams { Name = "todos.complete" });
+        var result = new CallToolResult
+        {
+            IsError = true,
+            StructuredContent = JsonSerializer.SerializeToElement(new
+            {
+                code = "entity_revision_conflict",
+                category = "concurrency",
+                phase = "reconcile",
+                mutationState = "not_committed"
+            })
+        };
+
+        var filtered = CalendarExecutionPolicy.CallTool((_, _) => ValueTask.FromResult(result));
+        await filtered(context, TestContext.Current.CancellationToken);
+
+        var operation = stopped.Single(activity => activity.OperationName == "caldav.operation");
+        var discovery = stopped.Single(activity => activity.OperationName == "caldav.phase.discovery");
+        operation.ParentId.ShouldBe(mcpActivity.Id);
+        discovery.ParentId.ShouldBe(operation.Id);
+        operation.GetTagItem("caldav.tool.name").ShouldBe("todos.complete");
+        operation.GetTagItem("caldav.entity.kind").ShouldBe("todo");
+        operation.GetTagItem("caldav.outcome").ShouldBe("error");
+        operation.GetTagItem("caldav.error.code").ShouldBe("entity_revision_conflict");
+        operation.GetTagItem("caldav.error.category").ShouldBe("concurrency");
+        operation.GetTagItem("caldav.mutation.state").ShouldBe("not_committed");
+        operation.Status.ShouldBe(ActivityStatusCode.Error);
+    }
+
     [Theory]
     [InlineData("calendars.list")]
     [InlineData("calendar_entities.query")]

--- a/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/CalendarExecutionPolicyTests.cs
+++ b/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/CalendarExecutionPolicyTests.cs
@@ -11,6 +11,7 @@ using Xunit;
 
 namespace DotnetAgents.CalDav.Mcp.Tests.Unit;
 
+[Collection("TelemetryActivityCollection")]
 public sealed class CalendarExecutionPolicyTests
 {
     [Fact]
@@ -50,7 +51,7 @@ public sealed class CalendarExecutionPolicyTests
             StructuredContent = JsonSerializer.SerializeToElement(new
             {
                 code = "entity_revision_conflict",
-                category = "concurrency",
+                category = "limitsAndAdmission",
                 phase = "reconcile",
                 mutationState = "not_committed"
             })
@@ -67,7 +68,7 @@ public sealed class CalendarExecutionPolicyTests
         operation.GetTagItem("caldav.entity.kind").ShouldBe("todo");
         operation.GetTagItem("caldav.outcome").ShouldBe("error");
         operation.GetTagItem("caldav.error.code").ShouldBe("entity_revision_conflict");
-        operation.GetTagItem("caldav.error.category").ShouldBe("concurrency");
+        operation.GetTagItem("caldav.error.category").ShouldBe("limitsAndAdmission");
         operation.GetTagItem("caldav.mutation.state").ShouldBe("not_committed");
         operation.Status.ShouldBe(ActivityStatusCode.Error);
     }

--- a/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/Hosting/CalendarTelemetryTests.cs
+++ b/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/Hosting/CalendarTelemetryTests.cs
@@ -1,0 +1,276 @@
+using System.Diagnostics;
+using DotnetAgents.CalDav.Core.Services;
+using DotnetAgents.CalDav.Mcp.Hosting;
+using OpenTelemetry.Logs;
+using Shouldly;
+using Xunit;
+
+namespace DotnetAgents.CalDav.Mcp.Tests.Unit.Hosting;
+
+public sealed class CalendarTelemetryTests
+{
+    [Fact]
+    public void Operation_EmitsStableParentedPhaseWaterfallWithSafeDimensions()
+    {
+        var stopped = new List<Activity>();
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == CalendarTelemetry.InstrumentationName,
+            Sample = static (ref ActivityCreationOptions<ActivityContext> _) =>
+                ActivitySamplingResult.AllDataAndRecorded,
+            ActivityStopped = stopped.Add
+        };
+        ActivitySource.AddActivityListener(listener);
+        using var mcpActivity = new Activity("tools/call").Start();
+
+        using (var operation = CalendarTelemetry.StartOperation(
+                   "calendar_occurrences.query",
+                   CalendarTelemetryEntityKind.Event))
+        {
+            operation.ShouldNotBeNull();
+            operation.StartPhase(CalendarOperationPhase.Discovery);
+            operation.StartPhase(CalendarOperationPhase.Fetch);
+            operation.StartPhase(CalendarOperationPhase.Filter);
+            operation.StartPhase(CalendarOperationPhase.Expand);
+            operation.Complete(outcome: "success");
+        }
+
+        var operationActivity = stopped.Single(activity => activity.OperationName == "caldav.operation");
+        operationActivity.Source.Name.ShouldBe("DotnetAgents.CalDav");
+        operationActivity.Source.Version.ShouldBe("0.1.0");
+        operationActivity.ParentId.ShouldBe(mcpActivity.Id);
+        operationActivity.GetTagItem("caldav.tool.name").ShouldBe("calendar_occurrences.query");
+        operationActivity.GetTagItem("caldav.entity.kind").ShouldBe("event");
+        operationActivity.GetTagItem("caldav.outcome").ShouldBe("success");
+
+        stopped.Where(activity => activity.OperationName.StartsWith("caldav.phase.", StringComparison.Ordinal))
+            .OrderBy(activity => activity.StartTimeUtc)
+            .Select(activity => (activity.OperationName, ParentId: activity.ParentId, Phase: activity.GetTagItem("caldav.phase")))
+            .ShouldBe([
+                ("caldav.phase.discovery", operationActivity.Id, (object?)"discovery"),
+                ("caldav.phase.fetch", operationActivity.Id, (object?)"fetch"),
+                ("caldav.phase.filter", operationActivity.Id, (object?)"filter"),
+                ("caldav.phase.expand", operationActivity.Id, (object?)"expand")
+            ]);
+    }
+
+    [Fact]
+    public void StartOperation_WithoutListeners_ReturnsNull()
+    {
+        CalendarTelemetry.StartOperation(
+            "todos.complete",
+            CalendarTelemetryEntityKind.Todo).ShouldBeNull();
+    }
+
+    [Fact]
+    public void ExportAllowlist_RemovesIdentifiersPayloadsUrlsAndExceptionDetails()
+    {
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = static _ => true,
+            Sample = static (ref ActivityCreationOptions<ActivityContext> _) =>
+                ActivitySamplingResult.AllDataAndRecorded
+        };
+        ActivitySource.AddActivityListener(listener);
+        using var source = new ActivitySource("Experimental.ModelContextProtocol");
+        using var activity = source.StartActivity("resources/read https://calendar.example/private/user.ics");
+        activity.ShouldNotBeNull();
+        activity.SetTag("mcp.method.name", "resources/read");
+        activity.SetTag("mcp.resource.uri", "caldav://snapshot/private-user-resource");
+        activity.SetTag("url.full", "https://calendar.example/private/user.ics?token=secret");
+        activity.SetTag("calendar.uid", "private-uid");
+        activity.SetTag("exception.message", "secret body");
+        activity.SetTag("error.type", "System.Net.Http.HttpRequestException");
+        activity.SetStatus(ActivityStatusCode.Error, "secret tool result");
+        activity.Stop();
+
+        new TelemetryActivityAllowlistProcessor().OnEnd(activity);
+
+        activity.DisplayName.ShouldBe("resources/read");
+        activity.GetTagItem("mcp.method.name").ShouldBe("resources/read");
+        activity.GetTagItem("error.type").ShouldBe("System.Net.Http.HttpRequestException");
+        activity.GetTagItem("mcp.resource.uri").ShouldBeNull();
+        activity.GetTagItem("url.full").ShouldBeNull();
+        activity.GetTagItem("calendar.uid").ShouldBeNull();
+        activity.GetTagItem("exception.message").ShouldBeNull();
+        activity.StatusDescription.ShouldBeNull();
+    }
+
+    [Fact]
+    public void ExportAllowlist_NormalizesMcpToolAndProtocolDimensions()
+    {
+        using var listener = ListenTo(OpenTelemetryHostConfiguration.McpInstrumentationName);
+        using var source = new ActivitySource(OpenTelemetryHostConfiguration.McpInstrumentationName);
+        using var activity = source.StartActivity("unsafe tool request");
+        activity.ShouldNotBeNull();
+        activity.SetTag("mcp.method.name", "tools/call");
+        activity.SetTag("gen_ai.tool.name", "todos.complete");
+        activity.SetTag("mcp.protocol.version", "2025-06-18");
+        activity.Stop();
+
+        new TelemetryActivityAllowlistProcessor().OnEnd(activity);
+
+        activity.DisplayName.ShouldBe("tools/call todos.complete");
+        activity.GetTagItem("mcp.method.name").ShouldBe("tools/call");
+        activity.GetTagItem("gen_ai.tool.name").ShouldBe("todos.complete");
+        activity.GetTagItem("mcp.protocol.version").ShouldBe("2025-06-18");
+    }
+
+    [Fact]
+    public void ExportAllowlist_ReplacesUnknownMcpDimensionsAndInvalidText()
+    {
+        using var listener = ListenTo(OpenTelemetryHostConfiguration.McpInstrumentationName);
+        using var source = new ActivitySource(OpenTelemetryHostConfiguration.McpInstrumentationName);
+        using var activity = source.StartActivity("unsafe request");
+        activity.ShouldNotBeNull();
+        activity.SetTag("mcp.method.name", "private/method");
+        activity.SetTag("gen_ai.tool.name", "private.tool");
+        activity.SetTag("mcp.protocol.version", "secret/version");
+        activity.SetTag("error.type", "secret exception message!");
+        activity.Stop();
+
+        new TelemetryActivityAllowlistProcessor().OnEnd(activity);
+
+        activity.DisplayName.ShouldBe("mcp.request");
+        activity.GetTagItem("mcp.method.name").ShouldBe("mcp.request");
+        activity.GetTagItem("gen_ai.tool.name").ShouldBeNull();
+        activity.GetTagItem("mcp.protocol.version").ShouldBeNull();
+        activity.GetTagItem("error.type").ShouldBeNull();
+    }
+
+    [Theory]
+    [InlineData("PROPFIND", "PROPFIND")]
+    [InlineData("PRIVATE", "HTTP")]
+    public void ExportAllowlist_NormalizesHttpSpansAndRemovesUrls(
+        string method,
+        string expectedDisplayName)
+    {
+        using var listener = ListenTo("System.Net.Http");
+        using var source = new ActivitySource("System.Net.Http");
+        using var activity = source.StartActivity("GET https://calendar.example/private.ics");
+        activity.ShouldNotBeNull();
+        activity.SetTag("http.request.method", method);
+        activity.SetTag("http.response.status_code", 207);
+        activity.SetTag("url.full", "https://calendar.example/private.ics?token=secret");
+        activity.Stop();
+
+        new TelemetryActivityAllowlistProcessor().OnEnd(activity);
+
+        activity.DisplayName.ShouldBe(expectedDisplayName);
+        activity.GetTagItem("http.request.method").ShouldBe(expectedDisplayName);
+        activity.GetTagItem("http.response.status_code").ShouldBe(207);
+        activity.GetTagItem("url.full").ShouldBeNull();
+    }
+
+    [Fact]
+    public void ExportAllowlist_UsesStableProductOperationName()
+    {
+        using var listener = ListenTo(CalendarTelemetry.InstrumentationName);
+        using var source = new ActivitySource(CalendarTelemetry.InstrumentationName);
+        using var activity = source.StartActivity("caldav.phase.fetch");
+        activity.ShouldNotBeNull();
+        activity.DisplayName = "private resource identifier";
+        activity.Stop();
+
+        new TelemetryActivityAllowlistProcessor().OnEnd(activity);
+
+        activity.DisplayName.ShouldBe("caldav.phase.fetch");
+    }
+
+    [Fact]
+    public void Operation_WithoutAllData_DoesNotAttachDimensions()
+    {
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == CalendarTelemetry.InstrumentationName,
+            Sample = static (ref ActivityCreationOptions<ActivityContext> _) =>
+                ActivitySamplingResult.PropagationData
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        using var operation = CalendarTelemetry.StartOperation(
+            "todos.complete",
+            CalendarTelemetryEntityKind.Todo);
+        operation.ShouldNotBeNull();
+        operation.StartPhase(CalendarOperationPhase.Reconcile);
+        operation.Complete("error", "private-code", "private-category", "changed");
+        operation.Fail(new InvalidOperationException("secret"));
+    }
+
+    [Fact]
+    public void Operation_FailureRecordsOnlyExceptionType()
+    {
+        Activity? stoppedOperation = null;
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == CalendarTelemetry.InstrumentationName,
+            Sample = static (ref ActivityCreationOptions<ActivityContext> _) =>
+                ActivitySamplingResult.AllDataAndRecorded,
+            ActivityStopped = activity =>
+            {
+                if (activity.OperationName == "caldav.operation")
+                    stoppedOperation = activity;
+            }
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        using (var operation = CalendarTelemetry.StartOperation("todos.complete", null))
+        {
+            operation.ShouldNotBeNull();
+            operation.StartPhase(CalendarOperationPhase.Reconcile);
+            operation.Fail(new InvalidOperationException("secret message"));
+        }
+
+        stoppedOperation.ShouldNotBeNull();
+        stoppedOperation.GetTagItem("caldav.outcome").ShouldBe("error");
+        stoppedOperation.GetTagItem("error.type").ShouldBe(typeof(InvalidOperationException).FullName);
+        stoppedOperation.Status.ShouldBe(ActivityStatusCode.Error);
+        stoppedOperation.StatusDescription.ShouldBeNull();
+    }
+
+    [Fact]
+    public void LogAllowlist_PreservesCorrelationAndSafeFieldsWithoutMessagesOrExceptions()
+    {
+        var record = (LogRecord)Activator.CreateInstance(typeof(LogRecord), nonPublic: true)!;
+        record.CategoryName = "DotnetAgents.CalDav.Core.Internal.CalDavClient";
+        record.Body = "CalDAV response contained https://calendar.example/private.ics";
+        record.FormattedMessage = "Authorization: Basic secret";
+        record.Exception = new InvalidOperationException("secret resource body");
+        record.TraceId = ActivityTraceId.CreateRandom();
+        record.SpanId = ActivitySpanId.CreateRandom();
+        record.Attributes =
+        [
+            new("Code", "principal_unavailable"),
+            new("Phase", "selectionDiscoveryCapability"),
+            new("Href", "https://calendar.example/private.ics"),
+            new("Authorization", "Basic secret"),
+            new("{OriginalFormat}", "CalDAV response from {Href}")
+        ];
+        var traceId = record.TraceId;
+        var spanId = record.SpanId;
+
+        new TelemetryLogAllowlistProcessor().OnEnd(record);
+
+        record.Body.ShouldBe("CalDAV diagnostic");
+        record.FormattedMessage.ShouldBeNull();
+        record.Exception.ShouldBeNull();
+        record.Attributes.ShouldBe([
+            new KeyValuePair<string, object?>("Code", "principal_unavailable"),
+            new KeyValuePair<string, object?>("Phase", "selectionDiscoveryCapability")
+        ]);
+        record.TraceId.ShouldBe(traceId);
+        record.SpanId.ShouldBe(spanId);
+    }
+
+    private static ActivityListener ListenTo(string sourceName)
+    {
+        var listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == sourceName,
+            Sample = static (ref ActivityCreationOptions<ActivityContext> _) =>
+                ActivitySamplingResult.AllDataAndRecorded
+        };
+        ActivitySource.AddActivityListener(listener);
+        return listener;
+    }
+}

--- a/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/Hosting/CalendarTelemetryTests.cs
+++ b/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/Hosting/CalendarTelemetryTests.cs
@@ -7,6 +7,7 @@ using Xunit;
 
 namespace DotnetAgents.CalDav.Mcp.Tests.Unit.Hosting;
 
+[Collection("TelemetryActivityCollection")]
 public sealed class CalendarTelemetryTests
 {
     [Fact]
@@ -81,10 +82,13 @@ public sealed class CalendarTelemetryTests
         activity.SetTag("calendar.uid", "private-uid");
         activity.SetTag("exception.message", "secret body");
         activity.SetTag("error.type", "System.Net.Http.HttpRequestException");
+        activity.TraceStateString = "private=trace-state-secret";
         activity.SetStatus(ActivityStatusCode.Error, "secret tool result");
         activity.Stop();
 
-        new TelemetryActivityAllowlistProcessor().OnEnd(activity);
+        var processor = new TelemetryActivityAllowlistProcessor();
+        processor.OnStart(activity);
+        processor.OnEnd(activity);
 
         activity.DisplayName.ShouldBe("resources/read");
         activity.GetTagItem("mcp.method.name").ShouldBe("resources/read");
@@ -93,6 +97,7 @@ public sealed class CalendarTelemetryTests
         activity.GetTagItem("url.full").ShouldBeNull();
         activity.GetTagItem("calendar.uid").ShouldBeNull();
         activity.GetTagItem("exception.message").ShouldBeNull();
+        activity.TraceStateString.ShouldBeNull();
         activity.StatusDescription.ShouldBeNull();
     }
 
@@ -149,7 +154,8 @@ public sealed class CalendarTelemetryTests
         using var source = new ActivitySource("System.Net.Http");
         using var activity = source.StartActivity("GET https://calendar.example/private.ics");
         activity.ShouldNotBeNull();
-        activity.SetTag("http.request.method", method);
+        activity.SetTag("http.request.method", "_OTHER");
+        activity.SetTag("http.request.method_original", method);
         activity.SetTag("http.response.status_code", 207);
         activity.SetTag("url.full", "https://calendar.example/private.ics?token=secret");
         activity.Stop();
@@ -159,6 +165,7 @@ public sealed class CalendarTelemetryTests
         activity.DisplayName.ShouldBe(expectedDisplayName);
         activity.GetTagItem("http.request.method").ShouldBe(expectedDisplayName);
         activity.GetTagItem("http.response.status_code").ShouldBe(207);
+        activity.GetTagItem("http.request.method_original").ShouldBeNull();
         activity.GetTagItem("url.full").ShouldBeNull();
     }
 
@@ -274,3 +281,6 @@ public sealed class CalendarTelemetryTests
         return listener;
     }
 }
+
+[CollectionDefinition("TelemetryActivityCollection", DisableParallelization = true)]
+public sealed class TelemetryActivityCollection;

--- a/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/Hosting/OpenTelemetryHostConfigurationTests.cs
+++ b/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/Hosting/OpenTelemetryHostConfigurationTests.cs
@@ -1,0 +1,130 @@
+using DotnetAgents.CalDav.Mcp.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Shouldly;
+using Xunit;
+
+namespace DotnetAgents.CalDav.Mcp.Tests.Unit.Hosting;
+
+public sealed class OpenTelemetryHostConfigurationTests
+{
+    [Fact]
+    public void TelemetryContract_UsesStableInstrumentationAndDefaultServiceNames()
+    {
+        OpenTelemetryHostConfiguration.InstrumentationName.ShouldBe("DotnetAgents.CalDav");
+        OpenTelemetryHostConfiguration.McpInstrumentationName.ShouldBe("Experimental.ModelContextProtocol");
+        OpenTelemetryHostConfiguration.DefaultServiceName.ShouldBe("dotnet-agents-caldav");
+    }
+
+    [Theory]
+    [InlineData("http://127.0.0.1:4318", null, true)]
+    [InlineData("http://127.0.0.1:4318", "false", true)]
+    [InlineData("http://127.0.0.1:4318", "TRUE", false)]
+    [InlineData("", null, false)]
+    [InlineData("   ", null, false)]
+    [InlineData(null, null, false)]
+    public void IsEnabled_RequiresEndpointAndHonorsSdkDisable(
+        string? endpoint,
+        string? sdkDisabled,
+        bool expected)
+    {
+        var environment = new Dictionary<string, string?>
+        {
+            ["OTEL_EXPORTER_OTLP_ENDPOINT"] = endpoint,
+            ["OTEL_SDK_DISABLED"] = sdkDisabled
+        };
+
+        OpenTelemetryHostConfiguration.IsEnabled(environment.GetValueOrDefault)
+            .ShouldBe(expected);
+    }
+
+    [Fact]
+    public void IsEnabled_ReadsOnlyStandardOpenTelemetryGateVariables()
+    {
+        var requestedNames = new List<string>();
+
+        OpenTelemetryHostConfiguration.IsEnabled(name =>
+        {
+            requestedNames.Add(name);
+            return null;
+        }).ShouldBeFalse();
+
+        requestedNames.ShouldBe([
+            "OTEL_EXPORTER_OTLP_ENDPOINT",
+            "OTEL_SDK_DISABLED"]);
+    }
+
+    [Fact]
+    public void CreateBuilder_WithoutOptIn_RegistersNoTelemetryProviders()
+    {
+        var builder = CalDavHostBuilder.CreateBuilder(
+            environmentProvider: _ => null);
+
+        var registeredTypes = GetRegisteredImplementationTypeNames(builder.Services);
+
+        registeredTypes.ShouldNotContain(type => type.Contains("OpenTelemetry", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void CreateBuilder_WithSdkDisabled_RegistersNoTelemetryProviders()
+    {
+        var environment = new Dictionary<string, string?>
+        {
+            ["OTEL_EXPORTER_OTLP_ENDPOINT"] = "http://127.0.0.1:4318",
+            ["OTEL_SDK_DISABLED"] = "true"
+        };
+
+        var builder = CalDavHostBuilder.CreateBuilder(
+            environmentProvider: environment.GetValueOrDefault);
+
+        GetRegisteredImplementationTypeNames(builder.Services)
+            .ShouldNotContain(type => type.Contains("OpenTelemetry", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void CreateBuilder_WithOptIn_RegistersOtlpPipelinesWithoutConsoleProviders()
+    {
+        var environment = new Dictionary<string, string?>
+        {
+            ["OTEL_EXPORTER_OTLP_ENDPOINT"] = "http://127.0.0.1:4318",
+            ["OTEL_EXPORTER_OTLP_PROTOCOL"] = "http/protobuf"
+        };
+
+        var builder = CalDavHostBuilder.CreateBuilder(
+            environmentProvider: environment.GetValueOrDefault);
+
+        var registeredTypes = GetRegisteredImplementationTypeNames(builder.Services);
+        registeredTypes.ShouldContain(type => type.Contains("TracerProvider", StringComparison.Ordinal));
+        registeredTypes.ShouldContain(type => type.Contains("MeterProvider", StringComparison.Ordinal));
+        builder.Services.Any(descriptor =>
+            descriptor.ServiceType == typeof(ILoggerProvider)
+            && (descriptor.ImplementationType?.FullName?.Contains("OpenTelemetry", StringComparison.Ordinal) == true
+                || descriptor.ImplementationFactory?.Method.DeclaringType?.FullName?.Contains(
+                    "OpenTelemetry",
+                    StringComparison.Ordinal) == true)).ShouldBeTrue();
+        registeredTypes.ShouldNotContain(type => type.Contains("ConsoleExporter", StringComparison.Ordinal));
+    }
+
+    [Theory]
+    [InlineData("DotnetAgents.CalDav.Core.Internal.CalDavClient", LogLevel.Debug, true)]
+    [InlineData("DotnetAgents.CalDav", LogLevel.Trace, false)]
+    [InlineData("ModelContextProtocol.Server", LogLevel.Information, true)]
+    [InlineData("ModelContextProtocol.Server", LogLevel.Debug, false)]
+    [InlineData("Microsoft.Hosting.Lifetime", LogLevel.Critical, false)]
+    [InlineData(null, LogLevel.Critical, false)]
+    public void LogFilter_AllowsOnlySafeProductAndMcpLevels(
+        string? category,
+        LogLevel level,
+        bool expected)
+    {
+        OpenTelemetryHostConfiguration.IsSafeLog(category, level).ShouldBe(expected);
+    }
+
+    private static string[] GetRegisteredImplementationTypeNames(IServiceCollection services) => services
+        .Select(descriptor => descriptor.ImplementationType?.FullName
+            ?? descriptor.ImplementationInstance?.GetType().FullName
+            ?? descriptor.ImplementationFactory?.Method.DeclaringType?.FullName)
+        .Where(name => name is not null)
+        .Select(name => name!)
+        .ToArray();
+}

--- a/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/Hosting/OpenTelemetryHostConfigurationTests.cs
+++ b/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/Hosting/OpenTelemetryHostConfigurationTests.cs
@@ -14,6 +14,7 @@ public sealed class OpenTelemetryHostConfigurationTests
         OpenTelemetryHostConfiguration.InstrumentationName.ShouldBe("DotnetAgents.CalDav");
         OpenTelemetryHostConfiguration.McpInstrumentationName.ShouldBe("Experimental.ModelContextProtocol");
         OpenTelemetryHostConfiguration.DefaultServiceName.ShouldBe("dotnet-agents-caldav");
+        OpenTelemetryHostConfiguration.ExporterTimeoutMilliseconds.ShouldBe(250);
     }
 
     [Theory]

--- a/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/McpMetadataTests.cs
+++ b/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/McpMetadataTests.cs
@@ -39,7 +39,7 @@ public class McpMetadataTests
     }
 
     [Fact]
-    public void McpServerJson_DeclaresOnlyFrozenCalendarEnvironmentVariables()
+    public void McpServerJson_DeclaresCalendarAndOptionalOpenTelemetryEnvironmentVariables()
     {
         var serverJsonPath = Path.Combine(GetMcpProjectDir(), ".mcp", "server.json");
         File.Exists(serverJsonPath).ShouldBeTrue(".mcp/server.json must exist for this test");
@@ -72,8 +72,16 @@ public class McpMetadataTests
             "CALDAV_CALENDAR_HREFS",
             "CALDAV_DEFAULT_TODO_CALENDAR_NAME",
             "CALDAV_DEFAULT_EVENT_CALENDAR_NAME",
-            "CALDAV_EXPOSE_EXACT_TOOLS"
+            "CALDAV_EXPOSE_EXACT_TOOLS",
+            "OTEL_EXPORTER_OTLP_ENDPOINT",
+            "OTEL_EXPORTER_OTLP_PROTOCOL",
+            "OTEL_EXPORTER_OTLP_HEADERS",
+            "OTEL_SERVICE_NAME",
+            "OTEL_SDK_DISABLED"
         ]);
+        envVars.EnumerateArray()
+            .Single(item => item.GetProperty("name").GetString() == "OTEL_EXPORTER_OTLP_HEADERS")
+            .GetProperty("isSecret").GetBoolean().ShouldBeTrue();
         var description = root.GetProperty("description").GetString()!;
         description.ShouldContain("Calendars");
         description.ShouldContain("Events");


### PR DESCRIPTION
Closes #85.

## Summary

- register an OTLP-only OpenTelemetry pipeline when the standard endpoint opt-in is present
- emit parented CalDAV operation and aggregate-phase spans beneath MCP tool spans
- sanitize exported MCP, HTTP, product, and log telemetry through explicit allowlists
- document the standalone loopback Aspire Dashboard workflow and packaged `OTEL_*` metadata
- verify recurrence-query and mutation-reconciliation waterfalls through real MCP stdio and pinned Radicale

## Validation

- `dotnet build -c Release --no-restore` — clean, 0 warnings
- Core unit coverage run — 1,745 passed, 0 skipped
- MCP unit coverage run — 970 passed, 0 skipped
- integration coverage run — 93 passed, 0 skipped
- coverage thresholds — 93.8% line, 85.0% branch
- strict-preconditions Radicale conformance — 10 passed
- alternate-time-zone Radicale conformance — 10 passed
- test-result evidence verification — 5 complete TRX files, no disabled evidence
- Slopwatch — 0 issues
- after rebasing onto current `origin/main`: clean build, 29 focused telemetry unit tests and 8 real telemetry/stdio integration tests passed
- reviewer hardening rerun: hostile MCP dimensions/tracestate/MRTR/cursor/ETag markers, hanging collector, and distinct 503→207 read attempts all pass
