### PR TITLE
test: remove AGENTS.md prose assertion

### DIFF
--- a/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/ContractCatalogTests.cs
+++ b/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/ContractCatalogTests.cs
@@ -354,16 +354,6 @@ public sealed class ContractCatalogTests
         matrix.ShouldContain("an unverified transcript remains operable, but no interoperability claim is made");
     }
 
-    [Fact]
-    public void Agent_instructions_name_the_additive_default_semantic_catalog()
-    {
-        var instructions = File.ReadAllText(Path.Combine(RepositoryRoot(), "AGENTS.md"));
-
-        instructions.ShouldContain("default host exposes a 17-tool semantic catalog");
-        instructions.ShouldContain("including `todos.complete`");
-        instructions.ShouldContain("It contains no legacy aliases");
-    }
-
     private const string RadicaleConformanceIndexDigest = "sha256:3a0080ea51ac69dcd74e345b9587dc14a8c8af0652046069005749f9a75c5c80";
 
     private static JsonObject ReadJson(string fileName) => JsonNode.Parse(File.ReadAllText(


### PR DESCRIPTION
## Summary

- remove the contract test that reads `AGENTS.md` and asserts exact prose
- keep contract coverage focused on runtime and published contract artifacts instead of contributor guidance wording
- restore the CI gate after the unrelated `AGENTS.md` guidance cleanup

## Validation

- `dotnet test --project tests/DotnetAgents.CalDav.Mcp.Tests.Unit/DotnetAgents.CalDav.Mcp.Tests.Unit.csproj -c Release --filter-class *ContractCatalogTests` (6 passed)
- `dotnet test --project tests/DotnetAgents.CalDav.Mcp.Tests.Unit/DotnetAgents.CalDav.Mcp.Tests.Unit.csproj -c Release` (969 passed)
- `dotnet tool run slopwatch analyze --config .slopwatch/slopwatch.json --fail-on warning` (0 issues)
- `git diff --check`