### PR TITLE
feat(query): resolve temporal context before I/O

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added immutable ten-minute Query Result Snapshot pagination for `calendar_entities.query`, including authenticated replayable Continuation Cursors, variable page sizes, and typed `cursor_expired` and `busy` failures.
 - Added a typed `ICalendarQueryModule`, a narrow CalDAV query transport, exact linear page-byte admission, bounded process-local snapshot retention, and privacy-safe query phases and aggregate work counters.
 - Added an automatic bounded Direct GET Compatibility Mode for verified `calendar-multiget` unavailability, with canonical four-wide waves, shared per-origin permits, closed execution-limit evidence, and strict all-or-nothing resource truth.
+- Added an explicit caller-or-configured IANA Temporal Evaluation Context for bounded Calendar Entity queries, including source-preserving DST and date-only evaluation and frozen context on every snapshot page.
 - Added opt-in OTLP traces, MCP metrics, and trace-correlated safe logs for the stdio server, including CalDAV aggregate-phase and outbound HTTP attempt waterfalls.
 - Added automated loopback OTLP coverage for trace parentage, metrics, log correlation, redaction, disabled defaults, collector failure isolation, and stdin-EOF shutdown.
 - Added truthful Operation outcome and Mutation State telemetry, explicit expected-absence observations, and per-wire-attempt retry recovery evidence through the built MCP stdio server.
@@ -20,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Replaced Calendar Entity cursor re-execution and MCP-owned page assembly with one complete Start execution and zero-CalDAV, zero-semantic-work Continue execution.
 - Changed `calendar_entities.query` input to a strict Start-or-Continue union and its pagination mode from `non_snapshot` to `query_result_snapshot`.
+- Bounded `calendar_entities.query` Start requests now reject a missing or invalid Temporal Evaluation Context before discovery; unbounded Starts reject an unused caller override.
 - Reused one immutable, authorization-bound CalDAV discovery result inside each MCP tool call while keeping MRTR continuations fresh and Capability State separate.
 - Kept successful query retrieval on 50-resource `calendar-multiget` batches with zero GETs, and made missing, duplicate, unsafe, unrequested, incomplete, or inconsistently tagged multiget results atomic protocol failures instead of fallback triggers.
 - Migrated test execution from VSTest to Microsoft.Testing.Platform v2 and xUnit 4.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -144,7 +144,7 @@ A date or date-time that preserves whether it is date-only, floating, UTC, or as
 _Avoid_: Timestamp, normalized date-time
 
 **Temporal Evaluation Context**:
-The explicit named time zone used to compare or expand floating and date-only Temporal Values without changing their preserved temporal kind.
+The explicit IANA time zone used to compare or expand floating and date-only Temporal Values without changing their preserved temporal kind. A caller context is distinct from a validated deployment configuration context; neither permits inference from Calendar, server, operating-system, process, host, locale, or location state.
 _Avoid_: Default time zone, host time zone
 
 **Effective Temporal Span**:

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Add this MCP server to VS Code, Claude Desktop, Cursor, or any MCP client:
         "CALDAV_URL": "https://caldav.example.com",
         "CALDAV_USERNAME": "user",
         "CALDAV_PASSWORD": "password",
+        "CALDAV_EVALUATION_TIME_ZONE": "America/Sao_Paulo",
         "CALDAV_DEFAULT_EVENT_CALENDAR_NAME": "Events",
         "CALDAV_DEFAULT_TODO_CALENDAR_NAME": "To-dos"
       }
@@ -36,6 +37,7 @@ Add this MCP server to VS Code, Claude Desktop, Cursor, or any MCP client:
 | `CALDAV_CALENDAR_HREFS` | No | Comma-separated exact canonical Calendar href allowlist; omit to discover every Calendar |
 | `CALDAV_DEFAULT_TODO_CALENDAR_NAME` | No | Display name of the default Calendar for To-do operations |
 | `CALDAV_DEFAULT_EVENT_CALENDAR_NAME` | No | Display name of the default Calendar for Event operations |
+| `CALDAV_EVALUATION_TIME_ZONE` | No | Exact IANA zone used as the configured Temporal Evaluation Context for bounded Calendar Entity Starts; invalid values fail startup and a caller `evaluationTimeZone` override wins. This is the shared policy for later Occurrence and To-do query-module cutovers |
 | `CALDAV_EXPOSE_EXACT_TOOLS` | No | Set to `true` to expose protected exact Calendar Object Resource tools |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | No | Non-empty OTLP endpoint that opts into telemetry export; no exporter is registered when omitted |
 | `OTEL_EXPORTER_OTLP_PROTOCOL` | No | Standard OTLP protocol such as `http/protobuf` or `grpc` |
@@ -48,7 +50,7 @@ Add this MCP server to VS Code, Claude Desktop, Cursor, or any MCP client:
 ### Semantic Calendar tools
 
 - `calendars.list` — Discover the configured Calendar Scope.
-- `calendar_entities.query` — Start a bounded persisted Event and To-do query across Calendar Scope, or continue its immutable Query Result Snapshot without repeating CalDAV work.
+- `calendar_entities.query` — Start a persisted Event and To-do query across Calendar Scope, or continue its immutable Query Result Snapshot without repeating CalDAV work. A bounded Start requires an explicit caller or configured IANA Temporal Evaluation Context and reports the frozen context on every page.
 - `calendar_occurrences.query` — Expand Event and To-do occurrences locally within a required half-open UTC window, using an explicit IANA evaluation time zone only when floating or date-only values require it.
 - `todos.query` — Read compact normalized To-do results in an explicit Calendar Scope; routine open-task reads use this surface instead of parsing full snapshots.
 - `calendar_resources.get` — Read an authoritative semantic-or-opaque snapshot by confirmed absolute href.

--- a/docs/adr/0005-configured-temporal-evaluation-context.md
+++ b/docs/adr/0005-configured-temporal-evaluation-context.md
@@ -1,0 +1,13 @@
+# ADR 0005: Configured Temporal Evaluation Context
+
+Status: Accepted
+
+Date: 2026-08-23
+
+Bounded Calendar Entity queries resolve one explicit IANA Temporal Evaluation Context before any Calendar discovery or CalDAV request. A valid caller `evaluationTimeZone` wins over the startup-validated `CALDAV_EVALUATION_TIME_ZONE`; absence of both or an invalid caller value is `invalid_input`. An unbounded Calendar Entity query does not evaluate temporal filters and therefore rejects a caller override rather than accepting an input with no observable effect.
+
+The context is query-level state, not Calendar Object Resource content. It is frozen into each applicable Query Result Snapshot, repeated on every page as `timeZone` plus caller/configuration source, and authenticated by the Continuation Cursor configuration binding. Changing relevant configuration makes a cursor generically invalid without revealing the changed value. Telemetry never records the zone, query arguments, cursor, or resource temporal content.
+
+UTC and named-zone values retain their source authority. Floating and date-only values evaluate in the explicit context while their projected form remains unchanged. Positive spans use half-open overlap, date-only Events without an explicit end occupy one civil day including 23-hour and 25-hour transition days, and date-only To-do boundaries retain point/span semantics. Unknown or conflicting resource-local zones fail the complete query atomically as `temporal_unresolved`.
+
+This forbids Calendar, CalDAV server, operating-system, process, host, locale, and location inference. It accepts the operational cost of explicit configuration because deterministic interpretation and pre-I/O failure are more valuable than environment-dependent convenience. The same typed policy is the required seam for later Occurrence and To-do query-module cutovers.

--- a/docs/performance-temporal-context-2026-08-23.md
+++ b/docs/performance-temporal-context-2026-08-23.md
@@ -2,7 +2,7 @@
 
 Date: 2026-08-23
 Baseline revision: `05f4973c8d4c1423da1c55cde4dbb0ee3c89b2f8`
-Implementation revision: `809cba3fc9bf6fad7eb50666935fec9eb498f5bf`
+Implementation revision: `4430b2d7943f9df1ae985bd3943642a20fd22055`
 Configuration: .NET 10 Release; deterministic scripted CalDAV port for zero-I/O and semantic work counts; real MCP stdio and digest-pinned Radicale 3.7.8 for the transport boundary
 
 ## Before

--- a/docs/performance-temporal-context-2026-08-23.md
+++ b/docs/performance-temporal-context-2026-08-23.md
@@ -1,0 +1,24 @@
+# Calendar Entity Temporal Evaluation Context observation
+
+Date: 2026-08-23
+Baseline revision: `05f4973`
+Implementation revision: `809cba3fc9bf6fad7eb50666935fec9eb498f5bf`
+Configuration: .NET 10 Release; deterministic scripted CalDAV port for zero-I/O and semantic work counts; real MCP stdio and digest-pinned Radicale 3.7.8 for the transport boundary
+
+## Before
+
+A bounded Calendar Entity Start over the deterministic one-Calendar, one-candidate date-only Event corpus reached one discovery acquisition, one candidate REPORT, and one multiget operation before returning `temporal_unresolved`; it retained zero snapshots. The work therefore scaled with the selected Calendar corpus even though the missing context was already knowable from the request and deployment configuration.
+
+## After
+
+Missing or invalid effective context is rejected before the CalDAV query transport is constructed. Over the same corpus, `CalendarQueryModuleTests.BoundedStartWithoutTemporalContextFailsBeforeAnyCalDavWork` records zero discovery acquisitions, zero candidate REPORTs, zero multiget operations, and zero retained snapshots: an exact Before/After change of `1/1/1/0` to `0/0/0/0`. A valid caller override takes precedence over configured `Europe/London` and reports `America/Sao_Paulo` with source `caller` on both Start and Continue while Continue performs no remote or semantic work.
+
+The focused deep-module temporal corpus covers recurring and non-recurring Events and To-dos, UTC and IANA named-zone authority, floating and named-zone spring-gap/nonexistent and autumn-overlap/ambiguous decisions, one valid authoritative resource-local VTIMEZONE, source-preserved date-only values, 23-hour and 25-hour implicit Event civil days, recurring and non-recurring date-only To-do spans, lone-DUE point inclusion, half-open boundaries, and atomic unknown or conflicting resource-zone failure. `CalendarQueryModuleTests.ExplicitTemporalContextProducesHostZoneIndependentItemsAndBytes` launches the same deep-module oracle under `TZ=UTC` and `TZ=Pacific/Kiritimati` and requires identical projected items and exact measured result bytes. These are deterministic semantic and work-count observations, not duration thresholds.
+
+`CalendarEntityQueryPageCodecTests.ActualAccountantAdmitsExactlyFourMiBAndRejectsOneByteMore` repeats the exact 4 MiB and one-byte-over boundary with non-empty retained Temporal Evaluation Context bytes. `CalendarEntityToolsTests.ActualSdkEnvelopeMatchesTheModuleAccountantWithTemporalContext` verifies that the module's `MeasuredCallToolResultBytes` equals serialization of the real SDK `CallToolResult`, while the SDK edge matrix independently verifies below, exact, and above-limit envelopes containing the same wire context shape.
+
+The real stdio/Radicale/OTLP witness is intentionally serialized with the repository integration gate. `OpenTelemetryStdioIntegrationTests.CalendarEntityStartContinue_ExportsSafeModulePhasesAndZeroContinuationWireWork` supplies `CALDAV_EVALUATION_TIME_ZONE` to the built MCP process, observes a context-bearing bounded result and clean stdout/stderr, verifies the pinned server request boundary, and searches exported telemetry for the absence of the zone, cursor, href, UID, Entity Tag, credentials, and resource content. `CalendarMcpStdioIntegrationTests.CalendarEntityQuery_ReturnsSchemaValidSnapshotsAndTypedFailureOverStdio` verifies the raw stdio environment mapping and returned schema against the pinned Radicale fixture.
+
+## Boundary and cleanup
+
+No 1,200-resource exercise, benchmark framework, allocation threshold, or latency SLA is introduced. The focused unit command is `dotnet test --project tests/DotnetAgents.CalDav.Core.Tests.Unit/DotnetAgents.CalDav.Core.Tests.Unit.csproj -c Release --filter-class '*CalendarQueryModuleTests'`; the serialized stdio/Radicale methods are named above and the complete repository gate is `bash scripts/run-test-suite.sh`. Scripted providers and timers use `await using`; the MCP process, loopback OTLP collector, and Radicale fixture are disposed by their test owners; temporal rejection retains no Query Result Snapshot.

--- a/docs/performance-temporal-context-2026-08-23.md
+++ b/docs/performance-temporal-context-2026-08-23.md
@@ -1,7 +1,7 @@
 # Calendar Entity Temporal Evaluation Context observation
 
 Date: 2026-08-23
-Baseline revision: `05f4973`
+Baseline revision: `05f4973c8d4c1423da1c55cde4dbb0ee3c89b2f8`
 Implementation revision: `809cba3fc9bf6fad7eb50666935fec9eb498f5bf`
 Configuration: .NET 10 Release; deterministic scripted CalDAV port for zero-I/O and semantic work counts; real MCP stdio and digest-pinned Radicale 3.7.8 for the transport boundary
 

--- a/docs/requirement-to-evidence.md
+++ b/docs/requirement-to-evidence.md
@@ -95,6 +95,23 @@ no Depth-1 crawl or response-mismatch fallback. The dated
 records the code-derived sequential baseline, focused deterministic work
 counts, and the applicable real-server boundary.
 
+## Configured Temporal Evaluation Context
+
+| Requirement | Implementation evidence | Verification evidence |
+| --- | --- | --- |
+| `CAL-TIME-005` | `CalendarEntityQueryStartExecutor` resolves caller override, configured fallback, or typed `invalid_input` before constructing the CalDAV query transport. | `BoundedStartWithoutTemporalContextFailsBeforeAnyCalDavWork`, `CallerTemporalContextWinsAndIsFrozenAcrossContinuation`, and the raw stdio temporal witness |
+| `CAL-TIME-006` | Bounded Calendar Entity Starts require a context; unbounded Starts leave configured fallback unused and reject an explicit unused override. The same typed context is the closed contract for later Occurrence and To-do module cutovers. | `UnboundedStartLeavesConfiguredTemporalContextUnusedAndUnreported`, `UnboundedStartRejectsUnusedCallerTemporalOverrideBeforeAnyCalDavWork`, and strict MCP Start/Continue conversion tests |
+| `CAL-TIME-007` | `ValidateCalDavOptions` validates the deployment IANA identifier on startup and caller validation uses the same TZDB authority before I/O. No host-zone API participates in resolution. | `ValidateCalDavOptions_RejectsInvalidConfiguredEvaluationTimeZone`, `RunAsync_InvalidConfiguredEvaluationTimeZoneFailsStartupWithoutEchoingTheValue`, `InvalidCallerTemporalContextFailsBeforeAnyCalDavWork`, and `ExplicitTemporalContextProducesHostZoneIndependentItemsAndBytes` under `TZ=UTC` and `TZ=Pacific/Kiritimati` subprocesses |
+| `CAL-TIME-008` | `TemporalEvaluationContext` records only `timeZone` and caller/configuration source once per applicable page; `CalendarQuerySnapshot` freezes its authoritative wire bytes for Continue and exact page accounting. | `CallerTemporalContextWinsAndIsFrozenAcrossContinuation`, `RetainedSnapshotCountsTheExactContextWireBytesOnce`, the context-present 4 MiB page boundary, live catalog tests, and stdio schema/result evidence |
+| `CAL-TIME-009` | `CalendarTemporalResolver` evaluates UTC, IANA named-zone, resource-local VTIMEZONE, floating, and date-only forms without modifying `CalendarProperty` source slices or projected values. | `NamedIanaGapAndOverlapMatrixCoversEventAndTodoRecurringAndNonRecurring`, `ValidResourceLocalVTimeZoneIsAuthoritativeOverEvaluationContext`, floating gap/overlap tests, and source-form assertions |
+| `CAL-TIME-010` | `CalendarEntityTemporalMatcher` applies half-open positive spans, point inclusion, one civil-day implicit Event end, and civil-date To-do boundaries for recurring and non-recurring entities. | Event 23/25-hour, `RecurringDateOnlyTodoUsesCivilBoundariesAcrossTwentyThreeAndTwentyFiveHourDays`, To-do intervening-span, lone-DUE boundary, and half-open tests |
+| `CAL-TIME-011` | Unknown or conflicting resource-local zones return one non-retryable `temporal_unresolved` failure before page publication. | `UnknownResourceLocalZoneFailsAtomicallyWithoutRetainingASnapshot` and `ConflictingResourceLocalZonesFailAtomicallyWithoutRetainingASnapshot` |
+| `CAL-TIME-012` | Snapshot content freezes the context and cursor key context authenticates the configured zone with the credentials and other relevant configuration. | `CursorContextBindsConfiguredTemporalEvaluationContextWithoutDisclosingTheChange` and continuation replay tests |
+
+The dated [temporal before/after observation](performance-temporal-context-2026-08-23.md)
+records the zero-I/O admission change, focused temporal corpus, stdio/Radicale
+boundary, privacy assertions, and cleanup.
+
 ## Shared performance evidence
 
 | Requirement | Evidence |

--- a/scripts/run-test-suite.sh
+++ b/scripts/run-test-suite.sh
@@ -85,12 +85,12 @@ run_main_project \
   tests/DotnetAgents.CalDav.Core.Tests.Unit/DotnetAgents.CalDav.Core.Tests.Unit.csproj \
   main-core \
   main-core.trx \
-  1883
+  1925
 run_main_project \
   tests/DotnetAgents.CalDav.Mcp.Tests.Unit/DotnetAgents.CalDav.Mcp.Tests.Unit.csproj \
   main-mcp \
   main-mcp.trx \
-  958
+  960
 run_main_project \
   tests/DotnetAgents.CalDav.IntegrationTests/DotnetAgents.CalDav.IntegrationTests.csproj \
   main-integration \

--- a/scripts/run-test-suite.sh
+++ b/scripts/run-test-suite.sh
@@ -85,17 +85,17 @@ run_main_project \
   tests/DotnetAgents.CalDav.Core.Tests.Unit/DotnetAgents.CalDav.Core.Tests.Unit.csproj \
   main-core \
   main-core.trx \
-  1925
+  2081
 run_main_project \
   tests/DotnetAgents.CalDav.Mcp.Tests.Unit/DotnetAgents.CalDav.Mcp.Tests.Unit.csproj \
   main-mcp \
   main-mcp.trx \
-  960
+  964
 run_main_project \
   tests/DotnetAgents.CalDav.IntegrationTests/DotnetAgents.CalDav.IntegrationTests.csproj \
   main-integration \
   main-integration.trx \
-  99
+  100
 
 cobertura_reports=$("$script_directory/verify-test-artifacts.sh" "$artifacts_directory" main)
 coverage_report_directory="$artifacts_directory/coverage-report"

--- a/scripts/test-test-artifacts.sh
+++ b/scripts/test-test-artifacts.sh
@@ -29,8 +29,8 @@ seed_main_artifacts() {
     printf '<coverage />\n' > "$directory/$prefix.coverage.opencover.260821000000001.xml"
   done
 
-  write_successful_trx "$directory/main-core.trx" 1883
-  write_successful_trx "$directory/main-mcp.trx" 958
+  write_successful_trx "$directory/main-core.trx" 1925
+  write_successful_trx "$directory/main-mcp.trx" 960
   write_successful_trx "$directory/main-integration.trx" 99
 }
 
@@ -104,7 +104,7 @@ echo "PASS unknown root coverage reports are rejected"
 
 below_minimum="$fixture_root/below-minimum"
 seed_main_artifacts "$below_minimum"
-write_successful_trx "$below_minimum/main-core.trx" 1882
+write_successful_trx "$below_minimum/main-core.trx" 1924
 if "$verifier" "$below_minimum" main >/dev/null 2>&1; then
   echo "Expected a main test result below its discovery baseline to be rejected." >&2
   exit 1

--- a/scripts/test-test-artifacts.sh
+++ b/scripts/test-test-artifacts.sh
@@ -29,9 +29,9 @@ seed_main_artifacts() {
     printf '<coverage />\n' > "$directory/$prefix.coverage.opencover.260821000000001.xml"
   done
 
-  write_successful_trx "$directory/main-core.trx" 1925
-  write_successful_trx "$directory/main-mcp.trx" 960
-  write_successful_trx "$directory/main-integration.trx" 99
+  write_successful_trx "$directory/main-core.trx" 2081
+  write_successful_trx "$directory/main-mcp.trx" 964
+  write_successful_trx "$directory/main-integration.trx" 100
 }
 
 current_run="$fixture_root/current-run"
@@ -104,7 +104,7 @@ echo "PASS unknown root coverage reports are rejected"
 
 below_minimum="$fixture_root/below-minimum"
 seed_main_artifacts "$below_minimum"
-write_successful_trx "$below_minimum/main-core.trx" 1924
+write_successful_trx "$below_minimum/main-core.trx" 2080
 if "$verifier" "$below_minimum" main >/dev/null 2>&1; then
   echo "Expected a main test result below its discovery baseline to be rejected." >&2
   exit 1

--- a/scripts/verify-test-artifacts.sh
+++ b/scripts/verify-test-artifacts.sh
@@ -72,8 +72,8 @@ if [[ ${#root_trx[@]} -ne ${#expected_trx[@]} ]]; then
 fi
 
 declare -A expected_test_counts=(
-  [main-core.trx]=1883
-  [main-mcp.trx]=958
+  [main-core.trx]=1925
+  [main-mcp.trx]=960
   [main-integration.trx]=99
   [strict-preconditions.trx]=10
   [alternate-time-zone.trx]=10

--- a/scripts/verify-test-artifacts.sh
+++ b/scripts/verify-test-artifacts.sh
@@ -72,9 +72,9 @@ if [[ ${#root_trx[@]} -ne ${#expected_trx[@]} ]]; then
 fi
 
 declare -A expected_test_counts=(
-  [main-core.trx]=1925
-  [main-mcp.trx]=960
-  [main-integration.trx]=99
+  [main-core.trx]=2081
+  [main-mcp.trx]=964
+  [main-integration.trx]=100
   [strict-preconditions.trx]=10
   [alternate-time-zone.trx]=10
 )

--- a/src/DotnetAgents.CalDav.Core/Configuration/CalDavOptions.cs
+++ b/src/DotnetAgents.CalDav.Core/Configuration/CalDavOptions.cs
@@ -28,6 +28,9 @@ public sealed class CalDavOptions
     /// <summary>Display name of the default Calendar for Event operations.</summary>
     public string? DefaultEventCalendarName { get; set; }
 
+    /// <summary>Optional explicit IANA zone for temporal query evaluation.</summary>
+    public string? EvaluationTimeZone { get; set; }
+
     /// <summary>Optional timeout for HTTP requests. Defaults to 30 seconds.</summary>
     public TimeSpan RequestTimeout { get; set; } = TimeSpan.FromSeconds(30);
 
@@ -67,9 +70,17 @@ internal sealed class ValidateCalDavOptions : IValidateOptions<CalDavOptions>
         if (options.RequestTimeout <= TimeSpan.Zero)
             failures.Add("CalDav:RequestTimeout must be positive.");
 
+        ValidateEvaluationTimeZone(options, failures);
+
         return failures.Count > 0
             ? ValidateOptionsResult.Fail(failures)
             : ValidateOptionsResult.Success;
+    }
+
+    private static void ValidateEvaluationTimeZone(CalDavOptions options, ICollection<string> failures)
+    {
+        if (options.EvaluationTimeZone is not null && !IanaTimeZoneIds.IsValid(options.EvaluationTimeZone))
+            failures.Add("CalDav:EvaluationTimeZone must be an exact IANA time-zone identifier when configured.");
     }
 
     private static bool IsSafeCanonicalEndpoint(string original, Uri uri) =>
@@ -81,4 +92,11 @@ internal sealed class ValidateCalDavOptions : IValidateOptions<CalDavOptions>
         && !original.Contains("%5c", StringComparison.OrdinalIgnoreCase)
         && (string.Equals(original, uri.AbsoluteUri, StringComparison.Ordinal)
             || string.Equals(original + '/', uri.AbsoluteUri, StringComparison.Ordinal));
+}
+
+internal static class IanaTimeZoneIds
+{
+    internal static bool IsValid(string value) => value.Length > 0
+        && string.Equals(value, value.Trim(), StringComparison.Ordinal)
+        && NodaTime.DateTimeZoneProviders.Tzdb.GetZoneOrNull(value) is not null;
 }

--- a/src/DotnetAgents.CalDav.Core/Internal/CalendarEntityQueryPageCodec.cs
+++ b/src/DotnetAgents.CalDav.Core/Internal/CalendarEntityQueryPageCodec.cs
@@ -45,7 +45,7 @@ internal sealed class CalendarEntityQueryPageCodec
     {
         if (IsInvalidRequest(snapshot.Items.Length, position, pageSize))
             return CalendarQueryPagePlanAdmission.Failure(CalendarQueryFailures.InvalidInput());
-        var fixedBudget = MeasureFixedBudget(snapshot.DiagnosticsUtf8);
+        var fixedBudget = MeasureFixedBudget(snapshot.DiagnosticsUtf8, snapshot.TemporalEvaluationContextUtf8);
         _workCounter?.RecordAdmissionEnvelopeSerialization();
         if (fixedBudget.HumanReadableBytes > MaximumHumanReadableBytes)
             return CalendarQueryPagePlanAdmission.Failure(CalendarQueryFailures.PayloadTooLarge(
@@ -72,7 +72,12 @@ internal sealed class CalendarEntityQueryPageCodec
             var candidatePosition = position + candidateCount;
             var hasMore = candidatePosition < snapshot.Items.Length;
             var candidateCursor = hasMore
-                ? _cursorIssuer.Issue(ToolName, snapshot.Id, candidatePosition, snapshot.ExpiresAt)
+                ? _cursorIssuer.Issue(
+                    ToolName,
+                    snapshot.Id,
+                    candidatePosition,
+                    snapshot.ExpiresAt,
+                    snapshot.TemporalEvaluationContextUtf8)
                 : null;
             var candidateBytes = admittedBytes + stored.JsonByteCount;
             var measured = fixedCallToolResultBytes
@@ -119,6 +124,7 @@ internal sealed class CalendarEntityQueryPageCodec
             writer.WriteEndArray();
             writer.WritePropertyName("diagnostics");
             writer.WriteRawValue(snapshot.DiagnosticsUtf8.Span, skipInputValidation: true);
+            WriteTemporalContext(writer, snapshot.TemporalEvaluationContextUtf8);
             writer.WritePropertyName("pagination");
             writer.WriteStartObject();
             writer.WriteString("mode", "query_result_snapshot");
@@ -141,10 +147,14 @@ internal sealed class CalendarEntityQueryPageCodec
             plan.NextCursor,
             structuredContent,
             SuccessText,
-            plan.MeasuredCallToolResultBytes);
+            plan.MeasuredCallToolResultBytes,
+            TemporalEvaluationContext: CalendarTemporalEvaluationContextCodec.Decode(
+                snapshot.TemporalEvaluationContextUtf8));
     }
 
-    private static CalendarQueryFixedBudget MeasureFixedBudget(ReadOnlyMemory<byte> diagnosticsUtf8)
+    private static CalendarQueryFixedBudget MeasureFixedBudget(
+        ReadOnlyMemory<byte> diagnosticsUtf8,
+        ReadOnlyMemory<byte> temporalEvaluationContextUtf8)
     {
         var callToolResult = new ArrayBufferWriter<byte>();
         using (var writer = new Utf8JsonWriter(callToolResult))
@@ -158,7 +168,7 @@ internal sealed class CalendarEntityQueryPageCodec
             writer.WriteEndObject();
             writer.WriteEndArray();
             writer.WritePropertyName("structuredContent");
-            WriteEmptyStructuredContent(writer, diagnosticsUtf8);
+            WriteEmptyStructuredContent(writer, diagnosticsUtf8, temporalEvaluationContextUtf8);
             writer.WriteBoolean("isError", false);
             writer.WriteNull("_meta");
             writer.WriteNull("resultType");
@@ -179,7 +189,10 @@ internal sealed class CalendarEntityQueryPageCodec
         return new CalendarQueryFixedBudget(callToolResult.WrittenCount, human.WrittenCount);
     }
 
-    private static void WriteEmptyStructuredContent(Utf8JsonWriter writer, ReadOnlyMemory<byte> diagnosticsUtf8)
+    private static void WriteEmptyStructuredContent(
+        Utf8JsonWriter writer,
+        ReadOnlyMemory<byte> diagnosticsUtf8,
+        ReadOnlyMemory<byte> temporalEvaluationContextUtf8)
     {
         writer.WriteStartObject();
         writer.WriteString("outcome", "success");
@@ -188,12 +201,23 @@ internal sealed class CalendarEntityQueryPageCodec
         writer.WriteEndArray();
         writer.WritePropertyName("diagnostics");
         writer.WriteRawValue(diagnosticsUtf8.Span, skipInputValidation: true);
+        WriteTemporalContext(writer, temporalEvaluationContextUtf8);
         writer.WritePropertyName("pagination");
         writer.WriteStartObject();
         writer.WriteString("mode", "query_result_snapshot");
         writer.WriteNull("nextCursor");
         writer.WriteEndObject();
         writer.WriteEndObject();
+    }
+
+    private static void WriteTemporalContext(
+        Utf8JsonWriter writer,
+        ReadOnlyMemory<byte> temporalEvaluationContextUtf8)
+    {
+        if (temporalEvaluationContextUtf8.IsEmpty)
+            return;
+        writer.WritePropertyName("temporalEvaluationContext");
+        writer.WriteRawValue(temporalEvaluationContextUtf8.Span, skipInputValidation: true);
     }
 
     private static int CursorDelta(string? cursor) => cursor is null ? 0 : cursor.Length - 2;

--- a/src/DotnetAgents.CalDav.Core/Internal/CalendarQueryCursorCodec.cs
+++ b/src/DotnetAgents.CalDav.Core/Internal/CalendarQueryCursorCodec.cs
@@ -45,6 +45,7 @@ internal sealed class CalendarQueryCursorKey
         string CalendarScope,
         string DefaultEventCalendarName,
         string DefaultTodoCalendarName,
+        string EvaluationTimeZone,
         long RequestTimeoutTicks)
     {
         internal static CursorContext From(CalDavOptions options) => new(
@@ -57,6 +58,7 @@ internal sealed class CalendarQueryCursorKey
                 .Order(StringComparer.Ordinal)),
             options.DefaultEventCalendarName?.Trim() ?? string.Empty,
             options.DefaultTodoCalendarName?.Trim() ?? string.Empty,
+            options.EvaluationTimeZone ?? string.Empty,
             options.RequestTimeout.Ticks);
     }
 }
@@ -65,13 +67,22 @@ internal sealed class CalendarQueryCursorIssuer(CalendarQueryCursorKey key)
 {
     internal const int MaximumCursorCharacters = 2048;
 
-    internal string Issue(string tool, Guid snapshotId, int position, DateTimeOffset expiresAt) => Protect(new CalendarQueryCursor(
-        Version: 1,
+    internal string Issue(
+        string tool,
+        Guid snapshotId,
+        int position,
+        DateTimeOffset expiresAt,
+        ReadOnlyMemory<byte> temporalEvaluationContextUtf8 = default) => Protect(new CalendarQueryCursor(
+        Version: 2,
         Tool: tool,
         SnapshotId: snapshotId,
         Position: position,
         ExpiresAtUnixMilliseconds: expiresAt.ToUnixTimeMilliseconds(),
-        Context: key.Context));
+        Context: key.Context,
+        TemporalContextBinding: BindTemporalContext(temporalEvaluationContextUtf8.Span)));
+
+    private string BindTemporalContext(ReadOnlySpan<byte> value) =>
+        Convert.ToHexStringLower(HMACSHA256.HashData(key.NonceKey, value));
 
     private string Protect(CalendarQueryCursor cursor)
     {
@@ -116,6 +127,12 @@ internal sealed class CalendarQueryCursorAuthenticator(
         }
     }
 
+    internal bool MatchesTemporalContext(
+        CalendarQueryCursor cursor,
+        ReadOnlySpan<byte> temporalEvaluationContextUtf8) => FixedTimeEquals(
+        cursor.TemporalContextBinding,
+        Convert.ToHexStringLower(HMACSHA256.HashData(key.NonceKey, temporalEvaluationContextUtf8)));
+
     private CalendarQueryCursor? Decrypt(byte[] protectedBytes)
     {
         var nonce = protectedBytes.AsSpan(0, 12);
@@ -129,10 +146,11 @@ internal sealed class CalendarQueryCursorAuthenticator(
 
     private bool IsValid(CalendarQueryCursor? cursor, string expectedTool) => cursor is
         {
-            Version: 1,
+            Version: 2,
             SnapshotId: var snapshotId,
             Position: >= 1,
-            ExpiresAtUnixMilliseconds: > 0
+            ExpiresAtUnixMilliseconds: > 0,
+            TemporalContextBinding.Length: 64
         }
         && string.Equals(cursor.Tool, expectedTool, StringComparison.Ordinal)
         && snapshotId != Guid.Empty
@@ -169,7 +187,8 @@ internal sealed record CalendarQueryCursor(
     Guid SnapshotId,
     int Position,
     long ExpiresAtUnixMilliseconds,
-    string Context);
+    string Context,
+    string TemporalContextBinding);
 
 internal sealed record CalendarQueryCursorAuthentication(
     CalendarQueryCursorAuthenticationCode Code,

--- a/src/DotnetAgents.CalDav.Core/Internal/CalendarQuerySnapshotStore.cs
+++ b/src/DotnetAgents.CalDav.Core/Internal/CalendarQuerySnapshotStore.cs
@@ -196,7 +196,8 @@ internal sealed record CalendarQuerySnapshot(
     DateTimeOffset ExpiresAt,
     ImmutableArray<StoredCalendarEntityQueryItem> Items,
     ReadOnlyMemory<byte> DiagnosticsUtf8,
-    long RetainedBytes);
+    long RetainedBytes,
+    ReadOnlyMemory<byte> TemporalEvaluationContextUtf8 = default);
 
 internal sealed record StoredCalendarEntityQueryItem(ReadOnlyMemory<byte> JsonUtf8)
 {

--- a/src/DotnetAgents.CalDav.Core/Internal/CalendarTemporalEvaluationContextCodec.cs
+++ b/src/DotnetAgents.CalDav.Core/Internal/CalendarTemporalEvaluationContextCodec.cs
@@ -1,0 +1,40 @@
+using System.Buffers;
+using System.Text.Json;
+using DotnetAgents.CalDav.Core.Models;
+
+namespace DotnetAgents.CalDav.Core.Internal;
+
+internal static class CalendarTemporalEvaluationContextCodec
+{
+    internal static ReadOnlyMemory<byte> Encode(TemporalEvaluationContext? context)
+    {
+        if (context is null)
+            return ReadOnlyMemory<byte>.Empty;
+        var buffer = new ArrayBufferWriter<byte>();
+        using (var writer = new Utf8JsonWriter(buffer))
+        {
+            writer.WriteStartObject();
+            writer.WriteString("timeZone", context.TimeZone);
+            writer.WriteString("source", context.Source == TemporalEvaluationContextSource.Caller
+                ? "caller"
+                : "configuration");
+            writer.WriteEndObject();
+        }
+        return buffer.WrittenMemory.ToArray();
+    }
+
+    internal static TemporalEvaluationContext? Decode(ReadOnlyMemory<byte> encoded)
+    {
+        if (encoded.IsEmpty)
+            return null;
+        using var document = JsonDocument.Parse(encoded);
+        var root = document.RootElement;
+        var source = root.GetProperty("source").GetString() switch
+        {
+            "caller" => TemporalEvaluationContextSource.Caller,
+            "configuration" => TemporalEvaluationContextSource.Configuration,
+            _ => throw new InvalidOperationException("The retained Temporal Evaluation Context is invalid.")
+        };
+        return new TemporalEvaluationContext(root.GetProperty("timeZone").GetString()!, source);
+    }
+}

--- a/src/DotnetAgents.CalDav.Core/Internal/Ical/CalendarEntityTemporalMatcher.cs
+++ b/src/DotnetAgents.CalDav.Core/Internal/Ical/CalendarEntityTemporalMatcher.cs
@@ -35,6 +35,7 @@ internal static class CalendarEntityTemporalMatcher
         CalendarResourceSnapshot snapshot,
         DateTimeOffset? from,
         DateTimeOffset? to,
+        string? evaluationTimeZone = null,
         CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
@@ -48,7 +49,8 @@ internal static class CalendarEntityTemporalMatcher
         var resolver = new CalendarTemporalResolver(
             snapshot.CalendarProperties,
             snapshot.AuthoritativeUtf8.Span,
-            cancellationToken);
+            cancellationToken,
+            evaluationTimeZone);
         if (HasUnresolvedTemporalValue(entityProperties, resolver, cancellationToken))
             return new(CalendarEntityTemporalMatch.Unresolved);
         var masterProperties = entityProperties.Where(property => property.ComponentPath[1].Occurrence == 0).ToArray();
@@ -174,7 +176,18 @@ internal static class CalendarEntityTemporalMatcher
         var effectiveEnd = occurrence.Period.EffectiveEndTime;
         if (effectiveEnd is null)
         {
-            end = start;
+            if (occurrence.Period.StartTime.HasTime)
+            {
+                end = start;
+                return true;
+            }
+            var followingDate = resolver.ResolveFollowingCivilDate(occurrence.Period.StartTime);
+            if (followingDate.Value is null)
+            {
+                failure = ToFailure(followingDate);
+                return false;
+            }
+            end = followingDate.Value.Value;
             return true;
         }
         var resolvedEnd = resolver.Resolve(effectiveEnd);
@@ -216,14 +229,20 @@ internal static class CalendarEntityTemporalMatcher
         IReadOnlyList<CalendarProperty> properties,
         CalendarTemporalResolver resolver)
     {
-        var start = resolver.Resolve(GetProperty(properties, "DTSTART")).Value;
+        var startProperty = GetProperty(properties, "DTSTART");
+        var start = resolver.Resolve(startProperty).Value;
         if (start is null)
             return TimeSpan.Zero;
         var end = resolver.Resolve(GetProperty(properties, "DTEND") ?? GetProperty(properties, "DUE")).Value;
         if (end > start)
             return end.Value - start.Value;
         var duration = GetDuration(properties);
-        return duration > TimeSpan.Zero ? duration.Value : TimeSpan.Zero;
+        if (duration > TimeSpan.Zero)
+            return duration.Value;
+        var followingDate = startProperty is { ValueType: CalendarPropertyValueType.Date }
+            ? resolver.ResolveFollowingCivilDate(startProperty).Value
+            : null;
+        return followingDate > start ? followingDate.Value - start.Value : TimeSpan.Zero;
     }
 
     private static TimeSpan GetPeriodSpan(
@@ -289,6 +308,9 @@ internal static class CalendarEntityTemporalMatcher
             return ToFailure(resolvedEnd);
         var endInstant = resolvedEnd.Value
             ?? ApplyDuration(properties, start.Value.Value)
+            ?? (GetProperty(properties, "DTSTART") is { ValueType: CalendarPropertyValueType.Date } dateStart
+                ? resolver.ResolveFollowingCivilDate(dateStart).Value
+                : null)
             ?? start.Value.Value;
         return Overlaps(start.Value.Value, endInstant, from, to);
     }

--- a/src/DotnetAgents.CalDav.Core/Internal/Ical/CalendarTemporalResolver.cs
+++ b/src/DotnetAgents.CalDav.Core/Internal/Ical/CalendarTemporalResolver.cs
@@ -63,6 +63,30 @@ internal sealed class CalendarTemporalResolver
     public ResolvedCalendarInstant ResolveToken(CalendarProperty property, string raw) =>
         ResolveToken(raw, GetTimeZoneId(property));
 
+    public ResolvedCalendarInstant ResolveFollowingCivilDate(CalendarProperty property)
+    {
+        _cancellationToken.ThrowIfCancellationRequested();
+        if (property.ValueType != CalendarPropertyValueType.Date
+            || !DateTime.TryParseExact(
+                property.RawEncodedValue,
+                "yyyyMMdd",
+                CultureInfo.InvariantCulture,
+                DateTimeStyles.None,
+                out var date))
+        {
+            return new(null, true);
+        }
+        return ResolveInEvaluationZone(date.AddDays(1));
+    }
+
+    public ResolvedCalendarInstant ResolveFollowingCivilDate(CalDateTime value)
+    {
+        _cancellationToken.ThrowIfCancellationRequested();
+        return value.HasTime
+            ? new(null, true)
+            : ResolveInEvaluationZone(value.Value.Date.AddDays(1));
+    }
+
     public ResolvedCalendarInstant Resolve(CalDateTime value, bool generated = false)
     {
         _cancellationToken.ThrowIfCancellationRequested();

--- a/src/DotnetAgents.CalDav.Core/Models/CalendarEntityQuery.cs
+++ b/src/DotnetAgents.CalDav.Core/Models/CalendarEntityQuery.cs
@@ -27,7 +27,20 @@ public sealed record CalendarEntityQuery(
     CalendarEntityScope Scope,
     IReadOnlyList<CalendarEntityKind> EntityKinds,
     DateTimeOffset? From = null,
-    DateTimeOffset? To = null);
+    DateTimeOffset? To = null,
+    string? EvaluationTimeZone = null);
+
+/// <summary>Explicit context used to evaluate floating and date-only Temporal Values.</summary>
+public sealed record TemporalEvaluationContext(
+    string TimeZone,
+    TemporalEvaluationContextSource Source);
+
+/// <summary>Observable provenance of a Temporal Evaluation Context.</summary>
+public enum TemporalEvaluationContextSource
+{
+    Caller,
+    Configuration
+}
 
 /// <summary>Typed Calendar Entity query outcome.</summary>
 public sealed record CalendarEntityQueryResult(

--- a/src/DotnetAgents.CalDav.Core/Models/CalendarQueryReply.cs
+++ b/src/DotnetAgents.CalDav.Core/Models/CalendarQueryReply.cs
@@ -37,7 +37,8 @@ public sealed record QueryPage<T>(
     JsonElement StructuredContent,
     string HumanText,
     int MeasuredCallToolResultBytes,
-    string PaginationMode = "query_result_snapshot");
+    string PaginationMode = "query_result_snapshot",
+    TemporalEvaluationContext? TemporalEvaluationContext = null);
 
 /// <summary>One final projected Calendar Entity result retained without authoritative content.</summary>
 public sealed record CalendarEntityQueryItem(JsonElement Value);

--- a/src/DotnetAgents.CalDav.Core/Services/CalendarEntityQueryEngine.cs
+++ b/src/DotnetAgents.CalDav.Core/Services/CalendarEntityQueryEngine.cs
@@ -231,7 +231,7 @@ internal sealed class CalendarEntityQueryEngine
                 snapshot,
                 query.From,
                 query.To,
-                cancellationToken);
+                cancellationToken: cancellationToken);
             occurrenceCount += temporal.OccurrenceCount;
             if (temporal.Match == CalendarEntityTemporalMatch.LimitExhausted || occurrenceCount > MaximumQueryOccurrences)
                 return FilterResult.Failure(CalendarEntityQueryCode.LimitExhausted, occurrenceCount);

--- a/src/DotnetAgents.CalDav.Core/Services/CalendarQueryModule.cs
+++ b/src/DotnetAgents.CalDav.Core/Services/CalendarQueryModule.cs
@@ -72,13 +72,20 @@ internal sealed class CalendarEntityQueryStartExecutor
     {
         if (!IsValid(request))
             return Failure(CalendarQueryFailures.InvalidInput());
+        var temporal = ResolveTemporalContext(request.Query);
+        if (temporal.Error is not null)
+            return Failure(temporal.Error);
+        var selectedHrefFailure = PrevalidateSelectedHref(request.Query);
+        if (selectedHrefFailure is not null)
+            return Failure(selectedHrefFailure);
         var transport = _transportFactory();
         var startedAt = _timeProvider.GetUtcNow();
         using var deadline = new CancellationTokenSource(ExecutionTimeout, _timeProvider);
         using var linked = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, deadline.Token);
         try
         {
-            var completed = await CompleteQueryAsync(transport, request.Query, linked.Token).ConfigureAwait(false);
+            var completed = await CompleteQueryAsync(transport, request.Query, temporal.Context, linked.Token)
+                .ConfigureAwait(false);
             ThrowIfDeadlineExpired(startedAt, linked.Token);
             if (completed.Error is not null)
                 return Failure(completed.Error);
@@ -124,11 +131,9 @@ internal sealed class CalendarEntityQueryStartExecutor
     private async Task<CompletedCalendarEntityQuery> CompleteQueryAsync(
         ICalendarQueryTransport transport,
         CalendarEntityQuery query,
+        TemporalEvaluationContext? temporalContext,
         CancellationToken cancellationToken)
     {
-        var selectedHrefFailure = PrevalidateSelectedHref(query);
-        if (selectedHrefFailure is not null)
-            return CompletedCalendarEntityQuery.Failure(selectedHrefFailure);
         CalendarQueryDiscovery discovery;
         using (CalendarQueryTelemetry.StartPhase("discovery"))
             discovery = await transport.DiscoverAsync(cancellationToken).ConfigureAwait(false);
@@ -159,11 +164,11 @@ internal sealed class CalendarEntityQueryStartExecutor
             return CompletedCalendarEntityQuery.Failure(fetched.Error);
         FilterResult filtered;
         using (CalendarQueryTelemetry.StartPhase("evaluation"))
-            filtered = Filter(fetched.Snapshots, query, cancellationToken);
+            filtered = Filter(fetched.Snapshots, query, temporalContext, cancellationToken);
         if (filtered.Error is not null)
             return CompletedCalendarEntityQuery.Failure(filtered.Error);
         using (CalendarQueryTelemetry.StartPhase("serialization"))
-            return Project(filtered.Snapshots, fetched.Diagnostics, cancellationToken);
+            return Project(filtered.Snapshots, fetched.Diagnostics, temporalContext, cancellationToken);
     }
 
     private QueryReply<CalendarEntityQueryItem> PublishFirstPage(
@@ -177,7 +182,8 @@ internal sealed class CalendarEntityQueryStartExecutor
             firstPageAt.Add(SnapshotLifetime),
             completed.Items,
             completed.DiagnosticsUtf8,
-            completed.RetainedBytes);
+            completed.RetainedBytes,
+            completed.TemporalEvaluationContextUtf8);
         CalendarQueryPagePlanAdmission planned;
         using (CalendarQueryTelemetry.StartPhase("page_admission"))
         {
@@ -210,6 +216,7 @@ internal sealed class CalendarEntityQueryStartExecutor
     private static CompletedCalendarEntityQuery Project(
         IReadOnlyList<CalendarResourceSnapshot> snapshots,
         IReadOnlyList<QueryDiagnostic> diagnostics,
+        TemporalEvaluationContext? temporalContext,
         CancellationToken cancellationToken)
     {
         var countFailure = CalendarQuerySnapshotPolicy.Validate(snapshots.Count, 0);
@@ -229,14 +236,16 @@ internal sealed class CalendarEntityQueryStartExecutor
                 return CompletedCalendarEntityQuery.Failure(byteFailure);
         }
         var diagnosticsUtf8 = System.Text.Json.JsonSerializer.SerializeToUtf8Bytes(diagnostics);
-        var retainedBytes = itemBytes + diagnosticsUtf8.Length;
+        var temporalContextUtf8 = CalendarTemporalEvaluationContextCodec.Encode(temporalContext);
+        var retainedBytes = itemBytes + diagnosticsUtf8.Length + temporalContextUtf8.Length;
         var retainedFailure = CalendarQuerySnapshotPolicy.Validate(projected.Count, retainedBytes);
         if (retainedFailure is not null)
             return CompletedCalendarEntityQuery.Failure(retainedFailure);
         return CompletedCalendarEntityQuery.Success(
             projected.MoveToImmutable(),
             diagnosticsUtf8,
-            retainedBytes);
+            retainedBytes,
+            temporalContextUtf8);
     }
 
     private async Task<FetchResult> FetchSnapshotsAsync(
@@ -312,6 +321,7 @@ internal sealed class CalendarEntityQueryStartExecutor
     private static FilterResult Filter(
         IReadOnlyList<CalendarResourceSnapshot> snapshots,
         CalendarEntityQuery query,
+        TemporalEvaluationContext? temporalContext,
         CancellationToken cancellationToken)
     {
         var filtered = new List<CalendarResourceSnapshot>();
@@ -325,7 +335,12 @@ internal sealed class CalendarEntityQueryStartExecutor
                 continue;
             }
             CalendarQueryTelemetry.Add("caldav.query.evaluation_count");
-            var temporal = CalendarEntityTemporalMatcher.Matches(snapshot, query.From, query.To, cancellationToken);
+            var temporal = CalendarEntityTemporalMatcher.Matches(
+                snapshot,
+                query.From,
+                query.To,
+                temporalContext?.TimeZone,
+                cancellationToken);
             occurrenceCount += temporal.OccurrenceCount;
             var failure = TemporalFailure(temporal.Match, occurrenceCount);
             if (failure is not null)
@@ -587,6 +602,33 @@ internal sealed class CalendarEntityQueryStartExecutor
             _ => false
         };
 
+    private TemporalContextResolution ResolveTemporalContext(CalendarEntityQuery query)
+    {
+        var isBounded = query.From is not null;
+        if (!isBounded)
+        {
+            return query.EvaluationTimeZone is null
+                ? TemporalContextResolution.Success(null)
+                : TemporalContextResolution.Failure(CalendarQueryFailures.InvalidInput(
+                    "An unbounded Calendar Entity query cannot use evaluationTimeZone."));
+        }
+        if (query.EvaluationTimeZone is { } caller)
+        {
+            return IanaTimeZoneIds.IsValid(caller)
+                ? TemporalContextResolution.Success(new TemporalEvaluationContext(
+                    caller,
+                    TemporalEvaluationContextSource.Caller))
+                : TemporalContextResolution.Failure(CalendarQueryFailures.InvalidInput(
+                    "The Calendar Entity query evaluationTimeZone is invalid."));
+        }
+        return _options.EvaluationTimeZone is { } configured && IanaTimeZoneIds.IsValid(configured)
+            ? TemporalContextResolution.Success(new TemporalEvaluationContext(
+                configured,
+                TemporalEvaluationContextSource.Configuration))
+            : TemporalContextResolution.Failure(CalendarQueryFailures.InvalidInput(
+                "A bounded Calendar Entity query requires a Temporal Evaluation Context."));
+    }
+
     private static bool HasValidWindow(DateTimeOffset? from, DateTimeOffset? to) => from is null || to is null
         ? from is null && to is null
         : from.Value.Offset == TimeSpan.Zero
@@ -666,6 +708,15 @@ internal sealed class CalendarEntityQueryStartExecutor
         internal static FilterResult Failure(QueryFailure error) => new([], error);
     }
 
+    private sealed record TemporalContextResolution(
+        TemporalEvaluationContext? Context,
+        QueryFailure? Error)
+    {
+        internal static TemporalContextResolution Success(TemporalEvaluationContext? context) => new(context, null);
+
+        internal static TemporalContextResolution Failure(QueryFailure error) => new(null, error);
+    }
+
     private sealed class CalendarEntityQueryDeadlineException : Exception;
 }
 
@@ -706,10 +757,11 @@ internal sealed class CalendarEntityQueryContinueExecutor(
             : Failure(admitted.Error));
     }
 
-    private static bool MatchesSnapshot(CalendarQueryCursor cursor, CalendarQuerySnapshot? snapshot) => snapshot is not null
+    private bool MatchesSnapshot(CalendarQueryCursor cursor, CalendarQuerySnapshot? snapshot) => snapshot is not null
         && cursor.ExpiresAtUnixMilliseconds == snapshot.ExpiresAt.ToUnixTimeMilliseconds()
         && cursor.Position > 0
-        && cursor.Position < snapshot.Items.Length;
+        && cursor.Position < snapshot.Items.Length
+        && cursorAuthenticator.MatchesTemporalContext(cursor, snapshot.TemporalEvaluationContextUtf8.Span);
 
     private static QueryReply<CalendarEntityQueryItem>.Failure Failure(QueryFailure failure) => new(failure);
 }
@@ -718,14 +770,18 @@ internal sealed record CompletedCalendarEntityQuery(
     ImmutableArray<StoredCalendarEntityQueryItem> Items,
     ReadOnlyMemory<byte> DiagnosticsUtf8,
     long RetainedBytes,
+    ReadOnlyMemory<byte> TemporalEvaluationContextUtf8,
     QueryFailure? Error)
 {
     internal static CompletedCalendarEntityQuery Success(
         ImmutableArray<StoredCalendarEntityQueryItem> items,
         ReadOnlyMemory<byte> diagnosticsUtf8,
-        long retainedBytes) => new(items, diagnosticsUtf8, retainedBytes, null);
+        long retainedBytes,
+        ReadOnlyMemory<byte> temporalEvaluationContextUtf8) =>
+        new(items, diagnosticsUtf8, retainedBytes, temporalEvaluationContextUtf8, null);
 
-    internal static CompletedCalendarEntityQuery Failure(QueryFailure error) => new([], ReadOnlyMemory<byte>.Empty, 0, error);
+    internal static CompletedCalendarEntityQuery Failure(QueryFailure error) =>
+        new([], ReadOnlyMemory<byte>.Empty, 0, ReadOnlyMemory<byte>.Empty, error);
 }
 
 internal static class CalendarQueryFailures

--- a/src/DotnetAgents.CalDav.Mcp/.mcp/server.json
+++ b/src/DotnetAgents.CalDav.Mcp/.mcp/server.json
@@ -46,6 +46,11 @@
           "isRequired": false
         },
         {
+          "name": "CALDAV_EVALUATION_TIME_ZONE",
+          "description": "Explicit IANA time zone used as the configured Temporal Evaluation Context for bounded Calendar Entity Starts (optional; shared policy for later Occurrence and To-do query-module cutovers)",
+          "isRequired": false
+        },
+        {
           "name": "CALDAV_EXPOSE_EXACT_TOOLS",
           "description": "Set to true to expose protected exact Calendar Object Resource tools (optional)",
           "isRequired": false

--- a/src/DotnetAgents.CalDav.Mcp/Contracts/mcp-tool-catalog.json
+++ b/src/DotnetAgents.CalDav.Mcp/Contracts/mcp-tool-catalog.json
@@ -2359,6 +2359,11 @@
       "required": false
     },
     {
+      "name": "CALDAV_EVALUATION_TIME_ZONE",
+      "required": false,
+      "description": "Explicit IANA zone for bounded Calendar Entity Start Temporal Evaluation Context; shared policy for later Occurrence and To-do query-module cutovers"
+    },
+    {
       "name": "CALDAV_EXPOSE_EXACT_TOOLS",
       "required": false,
       "type": "boolean"
@@ -2433,7 +2438,7 @@
         "idempotentHint": true,
         "openWorldHint": true
       },
-      "description": "Start one bounded Calendar Entity query or continue its immutable Query Result Snapshot without repeating CalDAV or semantic work."
+      "description": "Start one Calendar Entity query or continue its immutable Query Result Snapshot. A bounded Start requires an explicit IANA Temporal Evaluation Context from evaluationTimeZone or validated configuration; Continue repeats the frozen context without CalDAV or semantic work."
     },
     {
       "name": "calendar_occurrences.query",
@@ -3331,6 +3336,12 @@
         "to": {
           "$ref": "#/$defs/utcTemporalValue"
         },
+        "evaluationTimeZone": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 255,
+          "description": "Caller IANA Temporal Evaluation Context override for a bounded Start"
+        },
         "cursor": {
           "type": "string",
           "minLength": 1,
@@ -3371,6 +3382,12 @@
             },
             "to": {
               "$ref": "#/$defs/utcTemporalValue"
+            },
+            "evaluationTimeZone": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 255,
+              "description": "Caller IANA Temporal Evaluation Context override for this bounded Start"
             },
             "pageSize": {
               "type": "integer",
@@ -4427,6 +4444,27 @@
           "type": "array",
           "items": {
             "$ref": "#/$defs/diagnostic"
+          }
+        },
+        "temporalEvaluationContext": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "timeZone",
+            "source"
+          ],
+          "properties": {
+            "timeZone": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 255
+            },
+            "source": {
+              "enum": [
+                "caller",
+                "configuration"
+              ]
+            }
           }
         },
         "pagination": {

--- a/src/DotnetAgents.CalDav.Mcp/Hosting/CalDavEnvironmentMapper.cs
+++ b/src/DotnetAgents.CalDav.Mcp/Hosting/CalDavEnvironmentMapper.cs
@@ -27,6 +27,7 @@ public static class CalDavEnvironmentMapper
             options.CalendarHrefs = getEnv("CALDAV_CALENDAR_HREFS");
             options.DefaultTodoCalendarName = getEnv("CALDAV_DEFAULT_TODO_CALENDAR_NAME");
             options.DefaultEventCalendarName = getEnv("CALDAV_DEFAULT_EVENT_CALENDAR_NAME");
+            options.EvaluationTimeZone = getEnv("CALDAV_EVALUATION_TIME_ZONE");
         };
     }
 }

--- a/src/DotnetAgents.CalDav.Mcp/Tools/CalendarEntityTools.cs
+++ b/src/DotnetAgents.CalDav.Mcp/Tools/CalendarEntityTools.cs
@@ -38,7 +38,7 @@ public sealed class CalendarEntityTools
         OpenWorld = true,
         UseStructuredContent = true,
         OutputSchemaType = typeof(CalendarEntityQuerySuccessResult)),
-     Description("Start one bounded Calendar Entity query or continue its immutable Query Result Snapshot without repeating CalDAV or semantic work.")]
+     Description("Start one Calendar Entity query or continue its immutable Query Result Snapshot. A bounded Start requires an explicit IANA Temporal Evaluation Context from evaluationTimeZone or validated configuration; Continue repeats the frozen context without CalDAV or semantic work.")]
     public Task<CallToolResult> QueryAsync(
         RequestContext<CallToolRequestParams> requestContext,
         CancellationToken cancellationToken) => QueryRawAsync(requestContext.Params?.Arguments, cancellationToken);
@@ -183,7 +183,7 @@ public sealed class CalendarEntityTools
     {
         scope = null;
         kinds = null;
-        if (arguments.Keys.Any(key => key is not ("scope" or "entityKinds" or "from" or "to" or "pageSize"))
+        if (arguments.Keys.Any(key => key is not ("scope" or "entityKinds" or "from" or "to" or "evaluationTimeZone" or "pageSize"))
             || !arguments.TryGetValue("scope", out var scopeElement)
             || !arguments.TryGetValue("entityKinds", out var kindsElement)
             || !CalendarQueryToolSupport.HasScopeShape(scopeElement)
@@ -205,10 +205,25 @@ public sealed class CalendarEntityTools
         query = null!;
         if (!CalendarQueryToolSupport.TryCreateScope(scope, out var domainScope)
             || !TryCreateKinds(kinds, out var domainKinds)
-            || !TryReadWindow(arguments, out var from, out var to))
+            || !TryReadWindow(arguments, out var from, out var to)
+            || !TryReadOptionalString(arguments, "evaluationTimeZone", out var evaluationTimeZone))
             return false;
-        query = new CalendarEntityQuery(domainScope, domainKinds, from, to);
+        query = new CalendarEntityQuery(domainScope, domainKinds, from, to, evaluationTimeZone);
         return true;
+    }
+
+    private static bool TryReadOptionalString(
+        IDictionary<string, JsonElement> arguments,
+        string name,
+        out string? value)
+    {
+        value = null;
+        if (!arguments.TryGetValue(name, out var element))
+            return true;
+        if (element.ValueKind != JsonValueKind.String)
+            return false;
+        value = element.GetString();
+        return value is not null;
     }
 
     private static bool TryCreateKinds(
@@ -375,7 +390,12 @@ public sealed record CalendarEntityQuerySuccessResult(
     [property: JsonPropertyName("outcome")] string Outcome,
     [property: JsonPropertyName("items")] IReadOnlyList<CalendarSnapshotResult> Items,
     [property: JsonPropertyName("diagnostics")] IReadOnlyList<CalendarDiagnosticResult> Diagnostics,
+    [property: JsonPropertyName("temporalEvaluationContext"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] CalendarTemporalEvaluationContextResult? TemporalEvaluationContext,
     [property: JsonPropertyName("pagination")] CalendarPagination Pagination);
+
+public sealed record CalendarTemporalEvaluationContextResult(
+    [property: JsonPropertyName("timeZone")] string TimeZone,
+    [property: JsonPropertyName("source")] string Source);
 
 public sealed record CalendarEntityQueryErrorResult(
     [property: JsonPropertyName("code")] string Code,

--- a/tests/DotnetAgents.CalDav.Core.Tests.Unit/Configuration/CalDavOptionsTests.cs
+++ b/tests/DotnetAgents.CalDav.Core.Tests.Unit/Configuration/CalDavOptionsTests.cs
@@ -159,4 +159,40 @@ public class CalDavOptionsTests
 
         result.Succeeded.ShouldBeTrue();
     }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("America/Sao_Paulo ")]
+    [InlineData("Eastern Standard Time")]
+    [InlineData("Private/Unknown")]
+    public void ValidateCalDavOptions_RejectsInvalidConfiguredEvaluationTimeZone(string evaluationTimeZone)
+    {
+        var result = new ValidateCalDavOptions().Validate(null, new CalDavOptions
+        {
+            BaseUrl = "https://caldav.example.com",
+            Username = "user",
+            Password = "pass",
+            EvaluationTimeZone = evaluationTimeZone
+        });
+
+        result.Failed.ShouldBeTrue();
+        result.Failures.ShouldContain(failure => failure.Contains("EvaluationTimeZone", StringComparison.Ordinal));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("UTC")]
+    [InlineData("America/Sao_Paulo")]
+    public void ValidateCalDavOptions_AcceptsAbsentOrIanaEvaluationTimeZone(string? evaluationTimeZone)
+    {
+        var result = new ValidateCalDavOptions().Validate(null, new CalDavOptions
+        {
+            BaseUrl = "https://caldav.example.com",
+            Username = "user",
+            Password = "pass",
+            EvaluationTimeZone = evaluationTimeZone
+        });
+
+        result.Succeeded.ShouldBeTrue();
+    }
 }

--- a/tests/DotnetAgents.CalDav.Core.Tests.Unit/Internal/CalendarEntityQueryPageCodecTests.cs
+++ b/tests/DotnetAgents.CalDav.Core.Tests.Unit/Internal/CalendarEntityQueryPageCodecTests.cs
@@ -17,17 +17,24 @@ public sealed class CalendarEntityQueryPageCodecTests
     public void ActualAccountantAdmitsExactlyFourMiBAndRejectsOneByteMore()
     {
         var codec = Codec();
-        var initial = Snapshot(Json("x"));
+        var temporalContext = CalendarTemporalEvaluationContextCodec.Encode(new TemporalEvaluationContext(
+            "America/Sao_Paulo",
+            TemporalEvaluationContextSource.Caller));
+        var initial = Snapshot(Json("x"), temporalContext);
         var initialPlan = codec.Plan(initial, 0, 1, CancellationToken.None).Value!;
         var padding = CalendarEntityQueryPageCodec.MaximumCallToolResultBytes
             - initialPlan.MeasuredCallToolResultBytes;
-        var exact = Snapshot(Json(new string('x', padding + 1)));
+        var exact = Snapshot(Json(new string('x', padding + 1)), temporalContext);
 
         var admitted = codec.Plan(exact, 0, 1, CancellationToken.None);
         admitted.Error.ShouldBeNull();
         admitted.Value!.MeasuredCallToolResultBytes.ShouldBe(
             CalendarEntityQueryPageCodec.MaximumCallToolResultBytes);
-        var above = Snapshot(Json(new string('x', padding + 2)));
+        var page = codec.Materialize(exact, admitted.Value);
+        page.TemporalEvaluationContext.ShouldBe(new TemporalEvaluationContext(
+            "America/Sao_Paulo",
+            TemporalEvaluationContextSource.Caller));
+        var above = Snapshot(Json(new string('x', padding + 2)), temporalContext);
         var refused = codec.Plan(above, 0, 1, CancellationToken.None);
         refused.Error!.Code.ShouldBe(QueryFailureCode.PayloadTooLarge);
     }
@@ -161,6 +168,14 @@ public sealed class CalendarEntityQueryPageCodecTests
         [new StoredCalendarEntityQueryItem(json)],
         "[]"u8.ToArray(),
         json.Length + 2);
+
+    private static CalendarQuerySnapshot Snapshot(byte[] json, ReadOnlyMemory<byte> temporalContext) => new(
+        Guid.NewGuid(),
+        Now.AddMinutes(10),
+        [new StoredCalendarEntityQueryItem(json)],
+        "[]"u8.ToArray(),
+        json.Length + 2 + temporalContext.Length,
+        temporalContext);
 
     private static byte[] Json<T>(T value) => JsonSerializer.SerializeToUtf8Bytes(value);
 }

--- a/tests/DotnetAgents.CalDav.Core.Tests.Unit/Internal/CalendarQueryCursorCodecTests.cs
+++ b/tests/DotnetAgents.CalDav.Core.Tests.Unit/Internal/CalendarQueryCursorCodecTests.cs
@@ -1,5 +1,6 @@
 using DotnetAgents.CalDav.Core.Configuration;
 using DotnetAgents.CalDav.Core.Internal;
+using DotnetAgents.CalDav.Core.Models;
 using Microsoft.Extensions.Options;
 using Shouldly;
 using Xunit;
@@ -150,6 +151,58 @@ public sealed class CalendarQueryCursorCodecTests
                 new FixedTimeProvider(Now))
             .Authenticate(cursor, CalendarEntityQueryPageCodec.ToolName).Code
             .ShouldBe(CalendarQueryCursorAuthenticationCode.Invalid);
+    }
+
+    [Fact]
+    public void CursorContextBindsConfiguredTemporalEvaluationContextWithoutDisclosingTheChange()
+    {
+        var baselineOptions = OptionsFor();
+        baselineOptions.Value.EvaluationTimeZone = "America/Sao_Paulo";
+        var baseline = new CalendarQueryCursorKey(baselineOptions, Key);
+        var cursor = new CalendarQueryCursorIssuer(baseline).Issue(
+            CalendarEntityQueryPageCodec.ToolName,
+            Guid.NewGuid(),
+            1,
+            Now.AddMinutes(10));
+        var changedOptions = OptionsFor();
+        changedOptions.Value.EvaluationTimeZone = "Europe/London";
+
+        var result = new CalendarQueryCursorAuthenticator(
+                new CalendarQueryCursorKey(changedOptions, Key),
+                new FixedTimeProvider(Now))
+            .Authenticate(cursor, CalendarEntityQueryPageCodec.ToolName);
+
+        result.Code.ShouldBe(CalendarQueryCursorAuthenticationCode.Invalid);
+        cursor.ShouldNotContain("America");
+        cursor.ShouldNotContain("Sao_Paulo");
+    }
+
+    [Fact]
+    public void CursorAuthenticatesTheExactEffectiveCallerContextBinding()
+    {
+        var key = new CalendarQueryCursorKey(OptionsFor(), Key);
+        var issuer = new CalendarQueryCursorIssuer(key);
+        var authenticator = new CalendarQueryCursorAuthenticator(key, new FixedTimeProvider(Now));
+        var contextA = CalendarTemporalEvaluationContextCodec.Encode(new TemporalEvaluationContext(
+            "America/Sao_Paulo",
+            TemporalEvaluationContextSource.Caller));
+        var contextB = CalendarTemporalEvaluationContextCodec.Encode(new TemporalEvaluationContext(
+            "Europe/London",
+            TemporalEvaluationContextSource.Caller));
+        var protectedCursor = issuer.Issue(
+            CalendarEntityQueryPageCodec.ToolName,
+            Guid.NewGuid(),
+            1,
+            Now.AddMinutes(10),
+            contextA);
+
+        var cursor = authenticator.Authenticate(protectedCursor, CalendarEntityQueryPageCodec.ToolName)
+            .Cursor.ShouldNotBeNull();
+
+        authenticator.MatchesTemporalContext(cursor, contextA.Span).ShouldBeTrue();
+        authenticator.MatchesTemporalContext(cursor, contextB.Span).ShouldBeFalse();
+        protectedCursor.ShouldNotContain("America");
+        protectedCursor.ShouldNotContain("London");
     }
 
     [Fact]

--- a/tests/DotnetAgents.CalDav.Core.Tests.Unit/Internal/CalendarTemporalEvaluationContextCodecTests.cs
+++ b/tests/DotnetAgents.CalDav.Core.Tests.Unit/Internal/CalendarTemporalEvaluationContextCodecTests.cs
@@ -1,0 +1,36 @@
+using DotnetAgents.CalDav.Core.Internal;
+using DotnetAgents.CalDav.Core.Models;
+using Shouldly;
+using Xunit;
+
+namespace DotnetAgents.CalDav.Core.Tests.Unit.Internal;
+
+public sealed class CalendarTemporalEvaluationContextCodecTests
+{
+    [Fact]
+    public void EncodedContextIsTheExactRetainedAndWireRepresentation()
+    {
+        var context = new TemporalEvaluationContext(
+            "America/Sao_Paulo",
+            TemporalEvaluationContextSource.Caller);
+
+        var encoded = CalendarTemporalEvaluationContextCodec.Encode(context);
+
+        System.Text.Encoding.UTF8.GetString(encoded.Span)
+            .ShouldBe("{\"timeZone\":\"America/Sao_Paulo\",\"source\":\"caller\"}");
+        CalendarTemporalEvaluationContextCodec.Decode(encoded).ShouldBe(context);
+    }
+
+    [Fact]
+    public void ContextBytesParticipateInTheExactSnapshotCapacityBoundary()
+    {
+        var encoded = CalendarTemporalEvaluationContextCodec.Encode(new TemporalEvaluationContext(
+            "America/Sao_Paulo",
+            TemporalEvaluationContextSource.Configuration));
+        var otherRetainedBytes = CalendarQuerySnapshotPolicy.MaximumBytes - encoded.Length;
+
+        CalendarQuerySnapshotPolicy.Validate(1, otherRetainedBytes + encoded.Length).ShouldBeNull();
+        CalendarQuerySnapshotPolicy.Validate(1, otherRetainedBytes + encoded.Length + 1)!.Code
+            .ShouldBe(QueryFailureCode.LimitExhausted);
+    }
+}

--- a/tests/DotnetAgents.CalDav.Core.Tests.Unit/Services/CalendarQueryModuleTests.cs
+++ b/tests/DotnetAgents.CalDav.Core.Tests.Unit/Services/CalendarQueryModuleTests.cs
@@ -21,6 +21,514 @@ public sealed class CalendarQueryModuleTests
     private static readonly DateTimeOffset Now = new(2026, 8, 23, 12, 0, 0, TimeSpan.Zero);
 
     [Fact]
+    public async Task BoundedStartWithoutTemporalContextFailsBeforeAnyCalDavWork()
+    {
+        const string calendarHref = "https://cal.example/calendars/work/";
+        var transport = new ScriptedCalendarQueryTransport([Calendar(calendarHref)], static () => []);
+        var transportConstructionCount = 0;
+        await using var provider = CreateProvider(
+            transport,
+            new MutableTimeProvider(Now),
+            services => services.AddTransient<ICalendarQueryTransport>(_ =>
+            {
+                transportConstructionCount++;
+                return transport;
+            }),
+            configureOptions: options => options.EvaluationTimeZone = null);
+
+        var failure = (await provider.GetRequiredService<ICalendarQueryModule>().QueryEntitiesAsync(
+            new CalendarEntityQueryRequest.Start(new CalendarEntityQuery(
+                CalendarEntityScope.All,
+                [CalendarEntityKind.Event],
+                Now,
+                Now.AddDays(1))),
+            CancellationToken.None)).ShouldBeOfType<QueryReply<CalendarEntityQueryItem>.Failure>();
+
+        failure.Error.Code.ShouldBe(QueryFailureCode.InvalidInput);
+        transportConstructionCount.ShouldBe(0);
+        transport.DiscoveryCount.ShouldBe(0);
+        transport.CandidateQueryCount.ShouldBe(0);
+        transport.MultigetCount.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task CallerTemporalContextWinsAndIsFrozenAcrossContinuation()
+    {
+        const string calendarHref = "https://cal.example/calendars/work/";
+        var hrefs = new[] { calendarHref + "a.ics", calendarHref + "b.ics" };
+        var transport = new ScriptedCalendarQueryTransport([Calendar(calendarHref)], () => hrefs);
+        await using var provider = CreateProvider(
+            transport,
+            new MutableTimeProvider(Now),
+            configureOptions: options => options.EvaluationTimeZone = "Europe/London");
+        var module = provider.GetRequiredService<ICalendarQueryModule>();
+        var query = new CalendarEntityQuery(
+            CalendarEntityScope.All,
+            [CalendarEntityKind.Event],
+            Now,
+            Now.AddDays(2),
+            "America/Sao_Paulo");
+
+        var first = (await module.QueryEntitiesAsync(
+            new CalendarEntityQueryRequest.Start(query, PageSize: 1),
+            CancellationToken.None)).ShouldBeOfType<QueryReply<CalendarEntityQueryItem>.Page>();
+        var continued = (await module.QueryEntitiesAsync(
+            new CalendarEntityQueryRequest.Continue(first.Value.NextCursor.ShouldNotBeNull()),
+            CancellationToken.None)).ShouldBeOfType<QueryReply<CalendarEntityQueryItem>.Page>();
+
+        first.Value.TemporalEvaluationContext.ShouldBe(
+            new TemporalEvaluationContext("America/Sao_Paulo", TemporalEvaluationContextSource.Caller));
+        continued.Value.TemporalEvaluationContext.ShouldBe(first.Value.TemporalEvaluationContext);
+        continued.Value.StructuredContent.GetProperty("temporalEvaluationContext")
+            .GetProperty("source").GetString().ShouldBe("caller");
+        transport.DiscoveryCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task ConfiguredTemporalContextIsReportedWithoutPerItemDuplication()
+    {
+        const string calendarHref = "https://cal.example/calendars/work/";
+        var transport = new ScriptedCalendarQueryTransport(
+            [Calendar(calendarHref)],
+            () => [calendarHref + "a.ics"]);
+        await using var provider = CreateProvider(
+            transport,
+            new MutableTimeProvider(Now),
+            configureOptions: options => options.EvaluationTimeZone = "Europe/London");
+
+        var page = (await provider.GetRequiredService<ICalendarQueryModule>().QueryEntitiesAsync(
+            new CalendarEntityQueryRequest.Start(new CalendarEntityQuery(
+                CalendarEntityScope.All,
+                [CalendarEntityKind.Event],
+                Now,
+                Now.AddDays(2))),
+            CancellationToken.None)).ShouldBeOfType<QueryReply<CalendarEntityQueryItem>.Page>();
+
+        page.Value.TemporalEvaluationContext.ShouldBe(new TemporalEvaluationContext(
+            "Europe/London",
+            TemporalEvaluationContextSource.Configuration));
+        page.Value.Items.ShouldHaveSingleItem().Value.GetRawText().ShouldNotContain("Europe/London");
+    }
+
+    [Fact]
+    public async Task UnboundedStartLeavesConfiguredTemporalContextUnusedAndUnreported()
+    {
+        const string calendarHref = "https://cal.example/calendars/work/";
+        var transport = new ScriptedCalendarQueryTransport(
+            [Calendar(calendarHref)],
+            () => [calendarHref + "a.ics"]);
+        await using var provider = CreateProvider(
+            transport,
+            new MutableTimeProvider(Now),
+            configureOptions: options => options.EvaluationTimeZone = "Europe/London");
+
+        var page = (await provider.GetRequiredService<ICalendarQueryModule>().QueryEntitiesAsync(
+            new CalendarEntityQueryRequest.Start(new CalendarEntityQuery(
+                CalendarEntityScope.All,
+                [CalendarEntityKind.Event])),
+            CancellationToken.None)).ShouldBeOfType<QueryReply<CalendarEntityQueryItem>.Page>();
+
+        page.Value.TemporalEvaluationContext.ShouldBeNull();
+        page.Value.StructuredContent.TryGetProperty("temporalEvaluationContext", out _).ShouldBeFalse();
+        transport.DiscoveryCount.ShouldBe(1);
+        transport.CandidateQueryCount.ShouldBe(1);
+        transport.MultigetCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task EffectiveTemporalContextNeverEntersQueryTelemetry()
+    {
+        const string calendarHref = "https://cal.example/calendars/work/";
+        const string privateZone = "America/Sao_Paulo";
+        var stopped = new List<Activity>();
+        using var listener = ListenToQuery(stopped);
+        using var source = new ActivitySource(CalendarQueryTelemetry.InstrumentationName, "0.1.0");
+        await using var provider = CreateProvider(
+            new ScriptedCalendarQueryTransport([Calendar(calendarHref)], () => [calendarHref + "a.ics"]),
+            new MutableTimeProvider(Now));
+
+        using (source.StartActivity("caldav.operation", ActivityKind.Internal))
+        {
+            (await provider.GetRequiredService<ICalendarQueryModule>().QueryEntitiesAsync(
+                new CalendarEntityQueryRequest.Start(new CalendarEntityQuery(
+                    CalendarEntityScope.All,
+                    [CalendarEntityKind.Event],
+                    Now,
+                    Now.AddDays(2),
+                    privateZone)),
+                CancellationToken.None)).ShouldBeOfType<QueryReply<CalendarEntityQueryItem>.Page>();
+        }
+
+        stopped.Single(activity => activity.OperationName == "caldav.operation").TagObjects
+            .Select(tag => tag.Value?.ToString() ?? string.Empty)
+            .ShouldAllBe(value => !value.Contains(privateZone, StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task UnboundedStartRejectsUnusedCallerTemporalOverrideBeforeAnyCalDavWork()
+    {
+        const string calendarHref = "https://cal.example/calendars/work/";
+        var transport = new ScriptedCalendarQueryTransport([Calendar(calendarHref)], static () => []);
+        await using var provider = CreateProvider(transport, new MutableTimeProvider(Now));
+
+        var failure = (await provider.GetRequiredService<ICalendarQueryModule>().QueryEntitiesAsync(
+            new CalendarEntityQueryRequest.Start(new CalendarEntityQuery(
+                CalendarEntityScope.All,
+                [CalendarEntityKind.Event],
+                EvaluationTimeZone: "UTC")),
+            CancellationToken.None)).ShouldBeOfType<QueryReply<CalendarEntityQueryItem>.Failure>();
+
+        failure.Error.Code.ShouldBe(QueryFailureCode.InvalidInput);
+        transport.DiscoveryCount.ShouldBe(0);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("America/New_York ")]
+    [InlineData("Eastern Standard Time")]
+    [InlineData("Private/Unknown")]
+    public async Task InvalidCallerTemporalContextFailsBeforeAnyCalDavWork(string evaluationTimeZone)
+    {
+        const string calendarHref = "https://cal.example/calendars/work/";
+        var transport = new ScriptedCalendarQueryTransport([Calendar(calendarHref)], static () => []);
+        await using var provider = CreateProvider(transport, new MutableTimeProvider(Now));
+
+        var failure = (await provider.GetRequiredService<ICalendarQueryModule>().QueryEntitiesAsync(
+            new CalendarEntityQueryRequest.Start(new CalendarEntityQuery(
+                CalendarEntityScope.All,
+                [CalendarEntityKind.Event],
+                Now,
+                Now.AddDays(1),
+                evaluationTimeZone)),
+            CancellationToken.None)).ShouldBeOfType<QueryReply<CalendarEntityQueryItem>.Failure>();
+
+        failure.Error.Code.ShouldBe(QueryFailureCode.InvalidInput);
+        transport.DiscoveryCount.ShouldBe(0);
+    }
+
+    [Theory]
+    [InlineData("20260308", "2026-03-09T03:30:00Z", "2026-03-09T03:45:00Z")]
+    [InlineData("20261101", "2026-11-02T04:30:00Z", "2026-11-02T04:45:00Z")]
+    public async Task DateOnlyEventWithoutEndOccupiesOneCompleteCivilDayAcrossDst(
+        string localDate,
+        string from,
+        string to)
+    {
+        const string calendarHref = "https://cal.example/calendars/work/";
+        const string resourceHref = calendarHref + "date.ics";
+        var transport = new ScriptedCalendarQueryTransport(
+            [Calendar(calendarHref)],
+            static () => [resourceHref],
+            reads: _ => [CalendarResourceRead.Success(resourceHref, "\"r1\"", Ics(
+                $"BEGIN:VEVENT\r\nUID:date\r\nDTSTAMP:20260823T120000Z\r\n"
+                + $"DTSTART;VALUE=DATE:{localDate}\r\nEND:VEVENT\r\n"))]);
+        await using var provider = CreateProvider(transport, new MutableTimeProvider(Now));
+
+        var page = (await provider.GetRequiredService<ICalendarQueryModule>().QueryEntitiesAsync(
+            new CalendarEntityQueryRequest.Start(new CalendarEntityQuery(
+                CalendarEntityScope.All,
+                [CalendarEntityKind.Event],
+                DateTimeOffset.Parse(from, System.Globalization.CultureInfo.InvariantCulture),
+                DateTimeOffset.Parse(to, System.Globalization.CultureInfo.InvariantCulture),
+                "America/New_York")),
+            CancellationToken.None)).ShouldBeOfType<QueryReply<CalendarEntityQueryItem>.Page>();
+
+        page.Value.Items.ShouldHaveSingleItem();
+        var start = page.Value.Items[0].Value.GetProperty("calendarProperties").EnumerateArray()
+            .Single(property => property.GetProperty("name").GetString() == "DTSTART");
+        start.GetProperty("valueType").GetString().ShouldBe("date");
+        start.GetProperty("rawEncodedValue").GetString().ShouldBe(localDate);
+    }
+
+    [Theory]
+    [InlineData("20260308", "2026-03-09T03:30:00Z", "2026-03-09T03:45:00Z")]
+    [InlineData("20261101", "2026-11-02T04:30:00Z", "2026-11-02T04:45:00Z")]
+    public async Task RecurringDateOnlyEventUsesOneCivilDayWhenOccurrenceHasNoExplicitEnd(
+        string localDate,
+        string from,
+        string to)
+    {
+        var page = await QueryTemporalResourceAsync(
+            $"BEGIN:VEVENT\r\nUID:event\r\nDTSTAMP:20260823T120000Z\r\n"
+            + $"DTSTART;VALUE=DATE:{localDate}\r\nRRULE:FREQ=DAILY;COUNT=2\r\nEND:VEVENT\r\n",
+            CalendarEntityKind.Event,
+            DateTimeOffset.Parse(from, System.Globalization.CultureInfo.InvariantCulture),
+            DateTimeOffset.Parse(to, System.Globalization.CultureInfo.InvariantCulture));
+
+        page.Value.Items.ShouldHaveSingleItem();
+    }
+
+    [Fact]
+    public async Task RetainedSnapshotCountsTheExactContextWireBytesOnce()
+    {
+        const string calendarHref = "https://cal.example/calendars/work/";
+        var transport = new ScriptedCalendarQueryTransport(
+            [Calendar(calendarHref)],
+            () => [calendarHref + "a.ics", calendarHref + "b.ics"]);
+        await using var provider = CreateProvider(transport, new MutableTimeProvider(Now));
+        var module = provider.GetRequiredService<ICalendarQueryModule>();
+
+        var first = (await module.QueryEntitiesAsync(
+            new CalendarEntityQueryRequest.Start(new CalendarEntityQuery(
+                CalendarEntityScope.All,
+                [CalendarEntityKind.Event],
+                Now,
+                Now.AddDays(2),
+                "America/Sao_Paulo"),
+                PageSize: 1),
+            CancellationToken.None)).ShouldBeOfType<QueryReply<CalendarEntityQueryItem>.Page>();
+        var second = (await module.QueryEntitiesAsync(
+            new CalendarEntityQueryRequest.Continue(first.Value.NextCursor.ShouldNotBeNull()),
+            CancellationToken.None)).ShouldBeOfType<QueryReply<CalendarEntityQueryItem>.Page>();
+        var itemBytes = first.Value.Items.Concat(second.Value.Items)
+            .Sum(item => Encoding.UTF8.GetByteCount(item.Value.GetRawText()));
+        var expectedContext = "{\"timeZone\":\"America/Sao_Paulo\",\"source\":\"caller\"}";
+
+        provider.GetRequiredService<CalendarQuerySnapshotStore>().RetainedBytes.ShouldBe(
+            itemBytes + "[]"u8.Length + Encoding.UTF8.GetByteCount(expectedContext));
+        first.Value.StructuredContent.GetProperty("temporalEvaluationContext").GetRawText()
+            .ShouldBe(expectedContext);
+        second.Value.StructuredContent.GetProperty("temporalEvaluationContext").GetRawText()
+            .ShouldBe(expectedContext);
+    }
+
+    [Theory]
+    [InlineData("20260308", "20260309", "2026-03-09T03:30:00Z", "2026-03-09T03:45:00Z")]
+    [InlineData("20261101", "20261102", "2026-11-02T04:30:00Z", "2026-11-02T04:45:00Z")]
+    public async Task DateOnlyTodoStartAndDueFormTheInterveningCivilSpan(
+        string startDate,
+        string dueDate,
+        string from,
+        string to)
+    {
+        var page = await QueryTemporalResourceAsync(
+            $"BEGIN:VTODO\r\nUID:todo\r\nDTSTAMP:20260823T120000Z\r\n"
+            + $"DTSTART;VALUE=DATE:{startDate}\r\nDUE;VALUE=DATE:{dueDate}\r\nEND:VTODO\r\n",
+            CalendarEntityKind.Todo,
+            DateTimeOffset.Parse(from, System.Globalization.CultureInfo.InvariantCulture),
+            DateTimeOffset.Parse(to, System.Globalization.CultureInfo.InvariantCulture));
+
+        page.Value.Items.ShouldHaveSingleItem();
+    }
+
+    [Theory]
+    [InlineData("2026-03-09T03:59:00Z", "2026-03-09T04:00:00Z", 0)]
+    [InlineData("2026-03-09T04:00:00Z", "2026-03-09T04:01:00Z", 1)]
+    public async Task LoneDateOnlyTodoDueIsAPointAtTheCivilDateBoundary(
+        string from,
+        string to,
+        int expectedItems)
+    {
+        var page = await QueryTemporalResourceAsync(
+            "BEGIN:VTODO\r\nUID:todo\r\nDTSTAMP:20260823T120000Z\r\n"
+            + "DUE;VALUE=DATE:20260309\r\nEND:VTODO\r\n",
+            CalendarEntityKind.Todo,
+            DateTimeOffset.Parse(from, System.Globalization.CultureInfo.InvariantCulture),
+            DateTimeOffset.Parse(to, System.Globalization.CultureInfo.InvariantCulture));
+
+        page.Value.Items.Count.ShouldBe(expectedItems);
+    }
+
+    [Theory]
+    [InlineData("20260308T023000", "2026-03-08T07:30:00Z", "2026-03-08T07:31:00Z")]
+    [InlineData("20261101T013000", "2026-11-01T05:30:00Z", "2026-11-01T05:31:00Z")]
+    public async Task FloatingGapAndOverlapUseTheEstablishedDeterministicOffset(
+        string localStart,
+        string from,
+        string to)
+    {
+        var page = await QueryTemporalResourceAsync(
+            $"BEGIN:VEVENT\r\nUID:event\r\nDTSTAMP:20260823T120000Z\r\n"
+            + $"DTSTART:{localStart}\r\nEND:VEVENT\r\n",
+            CalendarEntityKind.Event,
+            DateTimeOffset.Parse(from, System.Globalization.CultureInfo.InvariantCulture),
+            DateTimeOffset.Parse(to, System.Globalization.CultureInfo.InvariantCulture));
+
+        page.Value.Items.ShouldHaveSingleItem();
+    }
+
+    [Theory]
+    [InlineData(
+        CalendarEntityKind.Event,
+        "DTSTART;TZID=America/New_York:20260308T023000\r\n",
+        "2026-03-08T07:30:00Z",
+        "2026-03-08T07:31:00Z")]
+    [InlineData(
+        CalendarEntityKind.Event,
+        "DTSTART;TZID=America/New_York:20261101T013000\r\nRRULE:FREQ=DAILY;COUNT=2\r\n",
+        "2026-11-01T05:30:00Z",
+        "2026-11-01T05:31:00Z")]
+    [InlineData(
+        CalendarEntityKind.Todo,
+        "DUE;TZID=America/New_York:20261101T013000\r\n",
+        "2026-11-01T05:30:00Z",
+        "2026-11-01T05:31:00Z")]
+    [InlineData(
+        CalendarEntityKind.Todo,
+        "DTSTART;TZID=America/New_York:20260308T013000\r\n"
+        + "DUE;TZID=America/New_York:20260308T023000\r\nRRULE:FREQ=DAILY;COUNT=2\r\n",
+        "2026-03-08T06:30:00Z",
+        "2026-03-08T06:31:00Z")]
+    public async Task NamedIanaGapAndOverlapMatrixCoversEventAndTodoRecurringAndNonRecurring(
+        CalendarEntityKind kind,
+        string temporalLines,
+        string from,
+        string to)
+    {
+        var component = kind == CalendarEntityKind.Event ? "VEVENT" : "VTODO";
+        var page = await QueryTemporalResourceAsync(
+            $"BEGIN:{component}\r\nUID:matrix\r\nDTSTAMP:20260823T120000Z\r\n"
+            + temporalLines
+            + $"END:{component}\r\n",
+            kind,
+            DateTimeOffset.Parse(from, System.Globalization.CultureInfo.InvariantCulture),
+            DateTimeOffset.Parse(to, System.Globalization.CultureInfo.InvariantCulture));
+
+        page.Value.Items.ShouldHaveSingleItem();
+    }
+
+    [Fact]
+    public async Task ValidResourceLocalVTimeZoneIsAuthoritativeOverEvaluationContext()
+    {
+        var page = await QueryTemporalResourceAsync(
+            "BEGIN:VTIMEZONE\r\nTZID:Custom/Shift\r\nBEGIN:STANDARD\r\n"
+            + "DTSTART:19700101T000000\r\nTZOFFSETFROM:+0230\r\nTZOFFSETTO:+0230\r\n"
+            + "END:STANDARD\r\nEND:VTIMEZONE\r\n"
+            + "BEGIN:VEVENT\r\nUID:local-zone\r\nDTSTAMP:20260823T120000Z\r\n"
+            + "DTSTART;TZID=Custom/Shift:20260824T120000\r\nEND:VEVENT\r\n",
+            CalendarEntityKind.Event,
+            DateTimeOffset.Parse("2026-08-24T09:30:00Z", System.Globalization.CultureInfo.InvariantCulture),
+            DateTimeOffset.Parse("2026-08-24T09:31:00Z", System.Globalization.CultureInfo.InvariantCulture));
+
+        var item = page.Value.Items.ShouldHaveSingleItem().Value;
+        item.GetRawText().ShouldContain("Custom/Shift");
+    }
+
+    [Theory]
+    [InlineData("20260308", "20260309", "2026-03-09T03:30:00Z", "2026-03-09T03:45:00Z")]
+    [InlineData("20261101", "20261102", "2026-11-02T04:30:00Z", "2026-11-02T04:45:00Z")]
+    public async Task RecurringDateOnlyTodoUsesCivilBoundariesAcrossTwentyThreeAndTwentyFiveHourDays(
+        string startDate,
+        string dueDate,
+        string from,
+        string to)
+    {
+        var page = await QueryTemporalResourceAsync(
+            $"BEGIN:VTODO\r\nUID:todo-recurring-date\r\nDTSTAMP:20260823T120000Z\r\n"
+            + $"DTSTART;VALUE=DATE:{startDate}\r\nDUE;VALUE=DATE:{dueDate}\r\n"
+            + "RRULE:FREQ=DAILY;COUNT=2\r\nEND:VTODO\r\n",
+            CalendarEntityKind.Todo,
+            DateTimeOffset.Parse(from, System.Globalization.CultureInfo.InvariantCulture),
+            DateTimeOffset.Parse(to, System.Globalization.CultureInfo.InvariantCulture));
+
+        page.Value.Items.ShouldHaveSingleItem();
+    }
+
+    [Fact]
+    public async Task ExplicitTemporalContextProducesHostZoneIndependentItemsAndBytes()
+    {
+        const string outputEnvironmentName = "CALDAV_TEMPORAL_HOST_ORACLE_OUTPUT";
+        var oracleOutput = Environment.GetEnvironmentVariable(outputEnvironmentName);
+        if (oracleOutput is not null)
+        {
+            var page = await QueryTemporalResourceAsync(
+                "BEGIN:VEVENT\r\nUID:host-independent\r\nDTSTAMP:20260823T120000Z\r\n"
+                + "DTSTART:20260308T013000\r\nEND:VEVENT\r\n",
+                CalendarEntityKind.Event,
+                DateTimeOffset.Parse("2026-03-08T06:30:00Z", System.Globalization.CultureInfo.InvariantCulture),
+                DateTimeOffset.Parse("2026-03-08T06:31:00Z", System.Globalization.CultureInfo.InvariantCulture));
+            var evidence = System.Text.Json.JsonSerializer.Serialize(new
+            {
+                items = page.Value.Items.Select(item => item.Value.GetRawText()).ToArray(),
+                measuredCallToolResultBytes = page.Value.MeasuredCallToolResultBytes
+            });
+            await File.WriteAllTextAsync(oracleOutput, evidence, TestContext.Current.CancellationToken);
+            return;
+        }
+
+        var temporaryDirectory = Path.Combine(
+            Path.GetTempPath(),
+            $"caldav-temporal-host-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(temporaryDirectory);
+        try
+        {
+            var utc = await RunHostZoneOracleAsync("UTC", Path.Combine(temporaryDirectory, "utc.json"));
+            var kiritimati = await RunHostZoneOracleAsync(
+                "Pacific/Kiritimati",
+                Path.Combine(temporaryDirectory, "kiritimati.json"));
+
+            utc.ShouldBe(kiritimati);
+            using var evidence = System.Text.Json.JsonDocument.Parse(utc);
+            evidence.RootElement.GetProperty("items").GetArrayLength().ShouldBe(1);
+            evidence.RootElement.GetProperty("measuredCallToolResultBytes").GetInt32().ShouldBeGreaterThan(0);
+        }
+        finally
+        {
+            Directory.Delete(temporaryDirectory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task UnknownResourceLocalZoneFailsAtomicallyWithoutRetainingASnapshot()
+    {
+        const string calendarHref = "https://cal.example/calendars/work/";
+        const string resourceHref = calendarHref + "unknown.ics";
+        var transport = new ScriptedCalendarQueryTransport(
+            [Calendar(calendarHref)],
+            static () => [resourceHref],
+            reads: _ => [CalendarResourceRead.Success(resourceHref, "\"r1\"", Ics(
+                "BEGIN:VEVENT\r\nUID:event\r\nDTSTAMP:20260823T120000Z\r\n"
+                + "DTSTART;TZID=Private/Unknown:20260824T120000\r\nEND:VEVENT\r\n"))]);
+        await using var provider = CreateProvider(transport, new MutableTimeProvider(Now));
+
+        var failure = (await provider.GetRequiredService<ICalendarQueryModule>().QueryEntitiesAsync(
+            new CalendarEntityQueryRequest.Start(new CalendarEntityQuery(
+                CalendarEntityScope.All,
+                [CalendarEntityKind.Event],
+                Now,
+                Now.AddDays(2),
+                "America/New_York")),
+            CancellationToken.None)).ShouldBeOfType<QueryReply<CalendarEntityQueryItem>.Failure>();
+
+        failure.Error.Code.ShouldBe(QueryFailureCode.TemporalUnresolved);
+        failure.Error.Retryable.ShouldBeFalse();
+        provider.GetRequiredService<CalendarQuerySnapshotStore>().ActiveSnapshotCount.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task ConflictingResourceLocalZonesFailAtomicallyWithoutRetainingASnapshot()
+    {
+        const string calendarHref = "https://cal.example/calendars/work/";
+        const string resourceHref = calendarHref + "conflicting.ics";
+        var transport = new ScriptedCalendarQueryTransport(
+            [Calendar(calendarHref)],
+            static () => [resourceHref],
+            reads: _ => [CalendarResourceRead.Success(resourceHref, "\"r1\"", Ics(
+                "BEGIN:VTIMEZONE\r\nTZID:Private/Conflicting\r\n"
+                + "BEGIN:STANDARD\r\nDTSTART:19700101T000000\r\nTZOFFSETFROM:+0000\r\nTZOFFSETTO:+0000\r\n"
+                + "END:STANDARD\r\nEND:VTIMEZONE\r\n"
+                + "BEGIN:VTIMEZONE\r\nTZID:Private/Conflicting\r\n"
+                + "BEGIN:STANDARD\r\nDTSTART:19700101T000000\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0100\r\n"
+                + "END:STANDARD\r\nEND:VTIMEZONE\r\n"
+                + "BEGIN:VEVENT\r\nUID:event\r\nDTSTAMP:20260823T120000Z\r\n"
+                + "DTSTART;TZID=Private/Conflicting:20260824T120000\r\nEND:VEVENT\r\n"))]);
+        await using var provider = CreateProvider(transport, new MutableTimeProvider(Now));
+
+        var failure = (await provider.GetRequiredService<ICalendarQueryModule>().QueryEntitiesAsync(
+            new CalendarEntityQueryRequest.Start(new CalendarEntityQuery(
+                CalendarEntityScope.All,
+                [CalendarEntityKind.Event],
+                Now,
+                Now.AddDays(2),
+                "America/New_York")),
+            CancellationToken.None)).ShouldBeOfType<QueryReply<CalendarEntityQueryItem>.Failure>();
+
+        failure.Error.Code.ShouldBe(QueryFailureCode.TemporalUnresolved);
+        failure.Error.Retryable.ShouldBeFalse();
+        provider.GetRequiredService<CalendarQuerySnapshotStore>().ActiveSnapshotCount.ShouldBe(0);
+    }
+
+    [Fact]
     public async Task ContinueReadsTheImmutableResultWithoutRepeatingCalDavWork()
     {
         const string calendarHref = "https://cal.example/calendars/work/";
@@ -1081,7 +1589,7 @@ public sealed class CalendarQueryModuleTests
             "BEGIN:VEVENT\r\nUID:event-date\r\nDTSTAMP:20260823T120000Z\r\n"
             + "DTSTART;VALUE=DATE:20260824\r\nEND:VEVENT\r\n",
             CalendarEntityKind.Event,
-            -1];
+            1];
         yield return [
             "BEGIN:VEVENT\r\nUID:event-recur\r\nDTSTAMP:20260823T120000Z\r\n"
             + "DTSTART:20260823T120000Z\r\nRRULE:FREQ=DAILY;COUNT=3\r\n"
@@ -1212,6 +1720,7 @@ public sealed class CalendarQueryModuleTests
             options.BaseUrl = "https://cal.example";
             options.Username = "user";
             options.Password = "password";
+            options.EvaluationTimeZone = "UTC";
             configure?.Invoke(options);
         });
         services.AddSingleton(client);
@@ -1222,7 +1731,8 @@ public sealed class CalendarQueryModuleTests
     private static ServiceProvider CreateProvider(
         ICalendarQueryTransport transport,
         TimeProvider timeProvider,
-        Action<IServiceCollection>? configure = null)
+        Action<IServiceCollection>? configure = null,
+        Action<CalDavOptions>? configureOptions = null)
     {
         var services = new ServiceCollection();
         services.AddLogging();
@@ -1231,6 +1741,8 @@ public sealed class CalendarQueryModuleTests
             options.BaseUrl = "https://cal.example";
             options.Username = "user";
             options.Password = "password";
+            options.EvaluationTimeZone = "UTC";
+            configureOptions?.Invoke(options);
         });
         services.AddSingleton(Substitute.For<ICalendarClient>());
         services.AddSingleton(timeProvider);
@@ -1291,6 +1803,70 @@ public sealed class CalendarQueryModuleTests
         "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Query Module Tests//EN\r\n"
         + component
         + "END:VCALENDAR\r\n");
+
+    private static async Task<QueryReply<CalendarEntityQueryItem>.Page> QueryTemporalResourceAsync(
+        string component,
+        CalendarEntityKind kind,
+        DateTimeOffset from,
+        DateTimeOffset to)
+    {
+        const string calendarHref = "https://cal.example/calendars/work/";
+        const string resourceHref = calendarHref + "temporal.ics";
+        var calendar = Calendar(calendarHref) with
+        {
+            EventSupport = kind == CalendarEntityKind.Event
+                ? EntityKindSupport.Advertised
+                : EntityKindSupport.NotAdvertised,
+            TodoSupport = kind == CalendarEntityKind.Todo
+                ? EntityKindSupport.Advertised
+                : EntityKindSupport.NotAdvertised
+        };
+        var transport = new ScriptedCalendarQueryTransport(
+            [calendar],
+            static () => [resourceHref],
+            reads: _ => [CalendarResourceRead.Success(resourceHref, "\"r1\"", Ics(component))]);
+        await using var provider = CreateProvider(transport, new MutableTimeProvider(Now));
+        return (await provider.GetRequiredService<ICalendarQueryModule>().QueryEntitiesAsync(
+            new CalendarEntityQueryRequest.Start(new CalendarEntityQuery(
+                CalendarEntityScope.All,
+                [kind],
+                from,
+                to,
+                "America/New_York")),
+            CancellationToken.None)).ShouldBeOfType<QueryReply<CalendarEntityQueryItem>.Page>();
+    }
+
+    private static async Task<string> RunHostZoneOracleAsync(string hostTimeZone, string outputPath)
+    {
+        var assemblyPath = typeof(CalendarQueryModuleTests).Assembly.Location;
+        var executablePath = Path.Combine(
+            Path.GetDirectoryName(assemblyPath)!,
+            Path.GetFileNameWithoutExtension(assemblyPath));
+        var startInfo = new ProcessStartInfo(executablePath)
+        {
+            RedirectStandardError = true,
+            RedirectStandardOutput = true,
+            UseShellExecute = false
+        };
+        startInfo.ArgumentList.Add("--filter-method");
+        startInfo.ArgumentList.Add(
+            "DotnetAgents.CalDav.Core.Tests.Unit.Services.CalendarQueryModuleTests.ExplicitTemporalContextProducesHostZoneIndependentItemsAndBytes");
+        startInfo.ArgumentList.Add("--minimum-expected-tests");
+        startInfo.ArgumentList.Add("1");
+        startInfo.ArgumentList.Add("--no-progress");
+        startInfo.Environment["TZ"] = hostTimeZone;
+        startInfo.Environment["CALDAV_TEMPORAL_HOST_ORACLE_OUTPUT"] = outputPath;
+
+        using var process = Process.Start(startInfo)
+            ?? throw new InvalidOperationException("Could not start the temporal host-zone oracle.");
+        var standardOutput = process.StandardOutput.ReadToEndAsync(TestContext.Current.CancellationToken);
+        var standardError = process.StandardError.ReadToEndAsync(TestContext.Current.CancellationToken);
+        await process.WaitForExitAsync(TestContext.Current.CancellationToken);
+        var output = await standardOutput;
+        var error = await standardError;
+        process.ExitCode.ShouldBe(0, $"Host-zone oracle failed for {hostTimeZone}: {output}\n{error}");
+        return await File.ReadAllTextAsync(outputPath, TestContext.Current.CancellationToken);
+    }
 
     private static CalendarEntityQuery Query() =>
         new(CalendarEntityScope.All, [CalendarEntityKind.Event]);

--- a/tests/DotnetAgents.CalDav.IntegrationTests/CalendarMcpStdioIntegrationTests.cs
+++ b/tests/DotnetAgents.CalDav.IntegrationTests/CalendarMcpStdioIntegrationTests.cs
@@ -91,10 +91,13 @@ public sealed class CalendarMcpStdioIntegrationTests
     {
         const string content = "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Integration//EN\r\n"
             + "BEGIN:VTODO\r\nUID:entity-query-stdio-1\r\nDTSTAMP:20260817T120000Z\r\n"
-            + "SUMMARY:Entity query integration\r\nEND:VTODO\r\nEND:VCALENDAR\r\n";
+            + "SUMMARY:Entity query integration\r\nDUE;VALUE=DATE:20260817\r\nEND:VTODO\r\nEND:VCALENDAR\r\n";
         var href = await PutResourceAsync("entity-query-stdio-1.ics", content);
         var stderr = new ConcurrentQueue<string>();
-        await using var client = await CreateClientAsync(stderr, exposeExact: false);
+        await using var client = await CreateClientAsync(
+            stderr,
+            exposeExact: false,
+            evaluationTimeZone: "America/Sao_Paulo");
         var tools = await client.ListToolsAsync(new ListToolsRequestParams(), TestContext.Current.CancellationToken);
         var advertised = tools.Tools.Single(tool => tool.Name == "calendar_entities.query");
         var selectedScope = new Dictionary<string, object?>
@@ -113,6 +116,16 @@ public sealed class CalendarMcpStdioIntegrationTests
             {
                 ["scope"] = selectedScope,
                 ["entityKinds"] = new[] { "todo" },
+                ["from"] = new Dictionary<string, object?>
+                {
+                    ["kind"] = "utcDateTime",
+                    ["value"] = "2026-08-17T03:00:00Z"
+                },
+                ["to"] = new Dictionary<string, object?>
+                {
+                    ["kind"] = "utcDateTime",
+                    ["value"] = "2026-08-17T04:00:00Z"
+                },
                 ["pageSize"] = 1
             },
             cancellationToken: TestContext.Current.CancellationToken);
@@ -136,13 +149,20 @@ public sealed class CalendarMcpStdioIntegrationTests
         success.IsError.ShouldBe(false);
         var structured = success.StructuredContent!.Value;
         structured.EnumerateObject().Select(property => property.Name)
-            .ShouldBe(["outcome", "items", "diagnostics", "pagination"]);
+            .ShouldBe(["outcome", "items", "diagnostics", "temporalEvaluationContext", "pagination"]);
         structured.GetProperty("outcome").GetString().ShouldBe("success");
         structured.GetProperty("items").GetArrayLength().ShouldBe(1);
         structured.GetProperty("items")[0].GetProperty("resourceRevision").GetProperty("entityTag").GetString()
             .ShouldStartWith("\"");
         structured.GetProperty("pagination").GetProperty("mode").GetString().ShouldBe("query_result_snapshot");
         structured.GetProperty("diagnostics").ValueKind.ShouldBe(System.Text.Json.JsonValueKind.Array);
+        structured.GetProperty("temporalEvaluationContext").GetProperty("timeZone").GetString()
+            .ShouldBe("America/Sao_Paulo");
+        structured.GetProperty("temporalEvaluationContext").GetProperty("source").GetString()
+            .ShouldBe("configuration");
+        structured.GetProperty("items")[0].GetProperty("calendarProperties").EnumerateArray()
+            .Single(property => property.GetProperty("name").GetString() == "DUE")
+            .GetProperty("rawEncodedValue").GetString().ShouldBe("20260817");
         advertised.OutputSchema.ShouldNotBeNull();
         advertised.OutputSchema.Value.GetProperty("oneOf").GetArrayLength().ShouldBe(2);
         advertised.InputSchema.GetProperty("oneOf").GetArrayLength().ShouldBe(2);
@@ -1431,7 +1451,8 @@ public sealed class CalendarMcpStdioIntegrationTests
         string? baseUrl = null,
         string? calendarHrefs = null,
         bool confirmMutations = false,
-        string? password = null)
+        string? password = null,
+        string? evaluationTimeZone = null)
     {
         var environment = CreateEnvironment();
         if (baseUrl is not null)
@@ -1443,6 +1464,8 @@ public sealed class CalendarMcpStdioIntegrationTests
             environment["CALDAV_CALENDAR_HREFS"] = calendarHrefs;
         if (password is not null)
             environment["CALDAV_PASSWORD"] = password;
+        if (evaluationTimeZone is not null)
+            environment["CALDAV_EVALUATION_TIME_ZONE"] = evaluationTimeZone;
         environment["CALDAV_EXPOSE_EXACT_TOOLS"] = exposeExact ? "true" : "false";
         var transport = new StdioClientTransport(new StdioClientTransportOptions
         {

--- a/tests/DotnetAgents.CalDav.IntegrationTests/CalendarMcpStdioIntegrationTests.cs
+++ b/tests/DotnetAgents.CalDav.IntegrationTests/CalendarMcpStdioIntegrationTests.cs
@@ -89,103 +89,110 @@ public sealed class CalendarMcpStdioIntegrationTests
     [Fact]
     public async Task CalendarEntityQuery_ReturnsSchemaValidSnapshotsAndTypedFailureOverStdio()
     {
-        const string content = "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Integration//EN\r\n"
-            + "BEGIN:VTODO\r\nUID:entity-query-stdio-1\r\nDTSTAMP:20260817T120000Z\r\n"
-            + "SUMMARY:Entity query integration\r\nDUE;VALUE=DATE:20260817\r\nEND:VTODO\r\nEND:VCALENDAR\r\n";
-        var href = await PutResourceAsync("entity-query-stdio-1.ics", content);
-        var stderr = new ConcurrentQueue<string>();
-        await using var client = await CreateClientAsync(
-            stderr,
-            exposeExact: false,
-            evaluationTimeZone: "America/Sao_Paulo");
-        var tools = await client.ListToolsAsync(new ListToolsRequestParams(), TestContext.Current.CancellationToken);
-        var advertised = tools.Tools.Single(tool => tool.Name == "calendar_entities.query");
-        var selectedScope = new Dictionary<string, object?>
+        var suffix = Guid.NewGuid().ToString("N");
+        var content = "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Integration//EN\r\n"
+            + $"BEGIN:VTODO\r\nUID:entity-query-stdio-{suffix}\r\nDTSTAMP:20260817T120000Z\r\n"
+            + "SUMMARY:Entity query integration\r\nDUE;VALUE=DATE:20960817\r\nEND:VTODO\r\nEND:VCALENDAR\r\n";
+        var href = await PutResourceAsync($"entity-query-stdio-{suffix}.ics", content);
+        try
         {
-            ["mode"] = "selected",
-            ["calendar"] = new Dictionary<string, object?>
+            var stderr = new ConcurrentQueue<string>();
+            await using var client = await CreateClientAsync(
+                stderr,
+                exposeExact: false,
+                evaluationTimeZone: "America/Sao_Paulo");
+            var tools = await client.ListToolsAsync(new ListToolsRequestParams(), TestContext.Current.CancellationToken);
+            var advertised = tools.Tools.Single(tool => tool.Name == "calendar_entities.query");
+            var selectedScope = new Dictionary<string, object?>
             {
-                ["by"] = "href",
-                ["href"] = $"{_fixture.BaseUrl}{_fixture.TodoCalendarHref}"
-            }
-        };
+                ["mode"] = "selected",
+                ["calendar"] = new Dictionary<string, object?>
+                {
+                    ["by"] = "href",
+                    ["href"] = $"{_fixture.BaseUrl}{_fixture.TodoCalendarHref}"
+                }
+            };
 
-        var success = await client.CallToolAsync(
-            "calendar_entities.query",
-            new Dictionary<string, object?>
-            {
-                ["scope"] = selectedScope,
-                ["entityKinds"] = new[] { "todo" },
-                ["from"] = new Dictionary<string, object?>
+            var success = await client.CallToolAsync(
+                "calendar_entities.query",
+                new Dictionary<string, object?>
                 {
-                    ["kind"] = "utcDateTime",
-                    ["value"] = "2026-08-17T03:00:00Z"
-                },
-                ["to"] = new Dictionary<string, object?>
-                {
-                    ["kind"] = "utcDateTime",
-                    ["value"] = "2026-08-17T04:00:00Z"
-                },
-                ["pageSize"] = 1
-            },
-            cancellationToken: TestContext.Current.CancellationToken);
-        var failure = await client.CallToolAsync(
-            "calendar_entities.query",
-            new Dictionary<string, object?>
-            {
-                ["scope"] = new Dictionary<string, object?>
-                {
-                    ["mode"] = "selected",
-                    ["calendar"] = new Dictionary<string, object?>
+                    ["scope"] = selectedScope,
+                    ["entityKinds"] = new[] { "todo" },
+                    ["from"] = new Dictionary<string, object?>
                     {
-                        ["by"] = "name",
-                        ["name"] = "No such authorized calendar"
-                    }
+                        ["kind"] = "utcDateTime",
+                        ["value"] = "2096-08-17T03:00:00Z"
+                    },
+                    ["to"] = new Dictionary<string, object?>
+                    {
+                        ["kind"] = "utcDateTime",
+                        ["value"] = "2096-08-17T04:00:00Z"
+                    },
+                    ["pageSize"] = 1
                 },
-                ["entityKinds"] = new[] { "todo" }
-            },
-            cancellationToken: TestContext.Current.CancellationToken);
+                cancellationToken: TestContext.Current.CancellationToken);
+            var failure = await client.CallToolAsync(
+                "calendar_entities.query",
+                new Dictionary<string, object?>
+                {
+                    ["scope"] = new Dictionary<string, object?>
+                    {
+                        ["mode"] = "selected",
+                        ["calendar"] = new Dictionary<string, object?>
+                        {
+                            ["by"] = "name",
+                            ["name"] = "No such authorized calendar"
+                        }
+                    },
+                    ["entityKinds"] = new[] { "todo" }
+                },
+                cancellationToken: TestContext.Current.CancellationToken);
 
-        success.IsError.ShouldBe(false);
-        var structured = success.StructuredContent!.Value;
-        structured.EnumerateObject().Select(property => property.Name)
-            .ShouldBe(["outcome", "items", "diagnostics", "temporalEvaluationContext", "pagination"]);
-        structured.GetProperty("outcome").GetString().ShouldBe("success");
-        structured.GetProperty("items").GetArrayLength().ShouldBe(1);
-        structured.GetProperty("items")[0].GetProperty("resourceRevision").GetProperty("entityTag").GetString()
-            .ShouldStartWith("\"");
-        structured.GetProperty("pagination").GetProperty("mode").GetString().ShouldBe("query_result_snapshot");
-        structured.GetProperty("diagnostics").ValueKind.ShouldBe(System.Text.Json.JsonValueKind.Array);
-        structured.GetProperty("temporalEvaluationContext").GetProperty("timeZone").GetString()
-            .ShouldBe("America/Sao_Paulo");
-        structured.GetProperty("temporalEvaluationContext").GetProperty("source").GetString()
-            .ShouldBe("configuration");
-        structured.GetProperty("items")[0].GetProperty("calendarProperties").EnumerateArray()
-            .Single(property => property.GetProperty("name").GetString() == "DUE")
-            .GetProperty("rawEncodedValue").GetString().ShouldBe("20260817");
-        advertised.OutputSchema.ShouldNotBeNull();
-        advertised.OutputSchema.Value.GetProperty("oneOf").GetArrayLength().ShouldBe(2);
-        advertised.InputSchema.GetProperty("oneOf").GetArrayLength().ShouldBe(2);
-        failure.IsError.ShouldBe(true);
-        var error = failure.StructuredContent!.Value;
-        error.EnumerateObject().Select(property => property.Name)
-            .ShouldBe(["code", "category", "message", "retryable", "phase", "authorizedCandidates"]);
-        error.GetProperty("code").GetString().ShouldBe("not_found");
-        error.GetProperty("category").GetString().ShouldBe("selection");
-        error.GetProperty("message").GetString().ShouldNotBeNullOrWhiteSpace();
-        error.GetProperty("retryable").GetBoolean().ShouldBeFalse();
-        error.GetProperty("phase").GetString().ShouldBe("selectionDiscoveryCapability");
-        var candidate = error.GetProperty("authorizedCandidates").EnumerateArray().ShouldHaveSingleItem();
-        candidate.EnumerateObject().Select(property => property.Name)
-            .ShouldBe(["calendar", "displayName", "entityKinds"]);
-        candidate.GetProperty("calendar").GetProperty("href").GetString()
-            .ShouldBe($"{_fixture.BaseUrl}{_fixture.TodoCalendarHref}");
-        candidate.GetProperty("displayName").GetString().ShouldBe("Tasks");
-        candidate.GetProperty("entityKinds").EnumerateObject().Select(property => property.Name)
-            .ShouldBe(["event", "todo"]);
-        error.TryGetProperty("items", out _).ShouldBeFalse();
-        stderr.ShouldBeEmpty();
-        await DeleteResourceAsync(href);
+            success.IsError.ShouldBe(false, success.StructuredContent?.ToString());
+            var structured = success.StructuredContent!.Value;
+            structured.EnumerateObject().Select(property => property.Name)
+                .ShouldBe(["outcome", "items", "diagnostics", "temporalEvaluationContext", "pagination"]);
+            structured.GetProperty("outcome").GetString().ShouldBe("success");
+            structured.GetProperty("items").GetArrayLength().ShouldBe(1);
+            structured.GetProperty("items")[0].GetProperty("resourceRevision").GetProperty("entityTag").GetString()
+                .ShouldStartWith("\"");
+            structured.GetProperty("pagination").GetProperty("mode").GetString().ShouldBe("query_result_snapshot");
+            structured.GetProperty("diagnostics").ValueKind.ShouldBe(System.Text.Json.JsonValueKind.Array);
+            structured.GetProperty("temporalEvaluationContext").GetProperty("timeZone").GetString()
+                .ShouldBe("America/Sao_Paulo");
+            structured.GetProperty("temporalEvaluationContext").GetProperty("source").GetString()
+                .ShouldBe("configuration");
+            structured.GetProperty("items")[0].GetProperty("calendarProperties").EnumerateArray()
+                .Single(property => property.GetProperty("name").GetString() == "DUE")
+                .GetProperty("rawEncodedValue").GetString().ShouldBe("20960817");
+            advertised.OutputSchema.ShouldNotBeNull();
+            advertised.OutputSchema.Value.GetProperty("oneOf").GetArrayLength().ShouldBe(2);
+            advertised.InputSchema.GetProperty("oneOf").GetArrayLength().ShouldBe(2);
+            failure.IsError.ShouldBe(true);
+            var error = failure.StructuredContent!.Value;
+            error.EnumerateObject().Select(property => property.Name)
+                .ShouldBe(["code", "category", "message", "retryable", "phase", "authorizedCandidates"]);
+            error.GetProperty("code").GetString().ShouldBe("not_found");
+            error.GetProperty("category").GetString().ShouldBe("selection");
+            error.GetProperty("message").GetString().ShouldNotBeNullOrWhiteSpace();
+            error.GetProperty("retryable").GetBoolean().ShouldBeFalse();
+            error.GetProperty("phase").GetString().ShouldBe("selectionDiscoveryCapability");
+            var candidate = error.GetProperty("authorizedCandidates").EnumerateArray().ShouldHaveSingleItem();
+            candidate.EnumerateObject().Select(property => property.Name)
+                .ShouldBe(["calendar", "displayName", "entityKinds"]);
+            candidate.GetProperty("calendar").GetProperty("href").GetString()
+                .ShouldBe($"{_fixture.BaseUrl}{_fixture.TodoCalendarHref}");
+            candidate.GetProperty("displayName").GetString().ShouldBe("Tasks");
+            candidate.GetProperty("entityKinds").EnumerateObject().Select(property => property.Name)
+                .ShouldBe(["event", "todo"]);
+            error.TryGetProperty("items", out _).ShouldBeFalse();
+            stderr.ShouldBeEmpty();
+        }
+        finally
+        {
+            await DeleteResourceAsync(href);
+        }
     }
 
     [Fact]

--- a/tests/DotnetAgents.CalDav.IntegrationTests/OpenTelemetryStdioIntegrationTests.cs
+++ b/tests/DotnetAgents.CalDav.IntegrationTests/OpenTelemetryStdioIntegrationTests.cs
@@ -26,6 +26,7 @@ public sealed class OpenTelemetryStdioIntegrationTests
     [Fact]
     public async Task CalendarEntityStartContinue_ExportsSafeModulePhasesAndZeroContinuationWireWork()
     {
+        const string evaluationTimeZone = "America/Sao_Paulo";
         var suffix = Guid.NewGuid().ToString("N");
         var firstUid = $"private-query-first-{suffix}";
         var secondUid = $"private-query-second-{suffix}";
@@ -46,7 +47,8 @@ public sealed class OpenTelemetryStdioIntegrationTests
             await using (var client = await CreateClientAsync(
                              receiver.Endpoint,
                              stderr,
-                             calendarHrefs: $"{_fixture.BaseUrl}{_fixture.TodoCalendarHref}"))
+                             calendarHrefs: $"{_fixture.BaseUrl}{_fixture.TodoCalendarHref}",
+                             evaluationTimeZone: evaluationTimeZone))
             {
                 var start = await client.CallToolAsync(
                     "calendar_entities.query",
@@ -62,6 +64,16 @@ public sealed class OpenTelemetryStdioIntegrationTests
                             }
                         },
                         ["entityKinds"] = new[] { "todo" },
+                        ["from"] = new Dictionary<string, object?>
+                        {
+                            ["kind"] = "utcDateTime",
+                            ["value"] = "2026-08-24T03:00:00Z"
+                        },
+                        ["to"] = new Dictionary<string, object?>
+                        {
+                            ["kind"] = "utcDateTime",
+                            ["value"] = "2026-08-24T04:00:00Z"
+                        },
                         ["pageSize"] = 1
                     },
                     cancellationToken: TestContext.Current.CancellationToken);
@@ -69,6 +81,8 @@ public sealed class OpenTelemetryStdioIntegrationTests
                 var structured = start.StructuredContent!.Value;
                 structured.GetProperty("pagination").GetProperty("mode").GetString()
                     .ShouldBe("query_result_snapshot");
+                structured.GetProperty("temporalEvaluationContext").GetRawText()
+                    .ShouldBe("{\"timeZone\":\"America/Sao_Paulo\",\"source\":\"configuration\"}");
                 cursor = structured.GetProperty("pagination").GetProperty("nextCursor").GetString()
                     .ShouldNotBeNull();
 
@@ -79,6 +93,8 @@ public sealed class OpenTelemetryStdioIntegrationTests
                 continuation.IsError.ShouldBe(false, continuation.StructuredContent?.ToString());
                 continuation.StructuredContent!.Value.GetProperty("pagination").GetProperty("mode").GetString()
                     .ShouldBe("query_result_snapshot");
+                continuation.StructuredContent.Value.GetProperty("temporalEvaluationContext").GetRawText()
+                    .ShouldBe(structured.GetProperty("temporalEvaluationContext").GetRawText());
             }
 
             await receiver.WaitForPathsAsync(["/v1/traces"], TestContext.Current.CancellationToken);
@@ -129,6 +145,7 @@ public sealed class OpenTelemetryStdioIntegrationTests
                     "caldav.query.snapshot_lookup_count"
                 ]);
             OtlpProtobufReader.ContainsUtf8(receiver.Requests, cursor).ShouldBeFalse();
+            OtlpProtobufReader.ContainsUtf8(receiver.Requests, evaluationTimeZone).ShouldBeFalse();
             foreach (var privateValue in new[] { firstUid, secondUid, privateSummary, firstHref, secondHref })
                 OtlpProtobufReader.ContainsUtf8(receiver.Requests, privateValue).ShouldBeFalse();
             spans.ShouldAllBe(span => span.EventCount == 0);
@@ -1049,7 +1066,8 @@ public sealed class OpenTelemetryStdioIntegrationTests
         ConcurrentQueue<string> stderr,
         string? baseUrl = null,
         string? calendarHrefs = null,
-        string? defaultTodoCalendarName = null)
+        string? defaultTodoCalendarName = null,
+        string? evaluationTimeZone = null)
     {
         baseUrl ??= _fixture.BaseUrl;
         var eventCalendarHref = $"{baseUrl}{_fixture.EventCalendarHref}";
@@ -1068,6 +1086,7 @@ public sealed class OpenTelemetryStdioIntegrationTests
                 ["CALDAV_PASSWORD"] = "caldavtest123",
                 ["CALDAV_CALENDAR_HREFS"] = calendarHrefs,
                 ["CALDAV_DEFAULT_TODO_CALENDAR_NAME"] = defaultTodoCalendarName,
+                ["CALDAV_EVALUATION_TIME_ZONE"] = evaluationTimeZone,
                 ["OTEL_EXPORTER_OTLP_ENDPOINT"] = endpoint.GetLeftPart(UriPartial.Authority),
                 ["OTEL_EXPORTER_OTLP_PROTOCOL"] = "http/protobuf",
                 ["OTEL_EXPORTER_OTLP_HEADERS"] = "authorization=Bearer otlp-private-header",
@@ -1158,7 +1177,7 @@ public sealed class OpenTelemetryStdioIntegrationTests
     private static string SnapshotTodo(string uid, string summary) =>
         "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Query Snapshot Telemetry//EN\r\n"
         + $"BEGIN:VTODO\r\nUID:{uid}\r\nDTSTAMP:20260823T120000Z\r\n"
-        + $"SUMMARY:{summary}\r\nEND:VTODO\r\nEND:VCALENDAR\r\n";
+        + $"SUMMARY:{summary}\r\nDUE;VALUE=DATE:20260824\r\nEND:VTODO\r\nEND:VCALENDAR\r\n";
 
     private static string ExactEvent(string uid, string summary) =>
         "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Telemetry Exact Review//EN\r\n"

--- a/tests/DotnetAgents.CalDav.IntegrationTests/OpenTelemetryStdioIntegrationTests.cs
+++ b/tests/DotnetAgents.CalDav.IntegrationTests/OpenTelemetryStdioIntegrationTests.cs
@@ -1129,6 +1129,7 @@ public sealed class OpenTelemetryStdioIntegrationTests
             ["kind"] = "utcDateTime",
             ["value"] = "2026-08-18T11:00:00Z"
         },
+        ["evaluationTimeZone"] = "UTC",
         ["pageSize"] = 1
     };
 

--- a/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/CalDavEnvironmentMapperTests.cs
+++ b/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/CalDavEnvironmentMapperTests.cs
@@ -130,8 +130,21 @@ public class CalDavEnvironmentMapperTests
             "CALDAV_PASSWORD",
             "CALDAV_CALENDAR_HREFS",
             "CALDAV_DEFAULT_TODO_CALENDAR_NAME",
-            "CALDAV_DEFAULT_EVENT_CALENDAR_NAME"
+            "CALDAV_DEFAULT_EVENT_CALENDAR_NAME",
+            "CALDAV_EVALUATION_TIME_ZONE"
         ]);
+    }
+
+    [Fact]
+    public void MapFromEnvironment_MapsConfiguredTemporalEvaluationContextExactly()
+    {
+        var configure = CalDavEnvironmentMapper.MapFromEnvironment(name =>
+            name == "CALDAV_EVALUATION_TIME_ZONE" ? "America/Sao_Paulo" : null);
+        var options = new CalDavOptions();
+
+        configure(options);
+
+        options.EvaluationTimeZone.ShouldBe("America/Sao_Paulo");
     }
 
 }

--- a/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/CalDavHostBuilderTests.cs
+++ b/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/CalDavHostBuilderTests.cs
@@ -288,11 +288,15 @@ public class CalDavHostBuilderTests
         inputBranches.All(branch => !branch!["additionalProperties"]!.GetValue<bool>()).ShouldBeTrue();
         inputBranches[0]!["required"]!.AsArray().Select(item => item!.GetValue<string>())
             .ShouldBe(["scope", "entityKinds"]);
+        inputBranches[0]!["properties"]!.AsObject().ShouldContainKey("evaluationTimeZone");
         inputBranches[1]!["required"]!.AsArray().Select(item => item!.GetValue<string>())
             .ShouldBe(["cursor"]);
         inputBranches[1]!["properties"]!["cursor"]!["maxLength"]!.GetValue<int>().ShouldBe(2048);
         outputSchema["oneOf"]!.AsArray().Count.ShouldBe(2);
         outputSchema["$defs"]!.AsObject().ShouldContainKey("entityQuerySuccess");
+        var temporalContext = outputSchema["$defs"]!["entityQuerySuccess"]!["properties"]!["temporalEvaluationContext"]!;
+        temporalContext["properties"]!["source"]!["enum"]!.AsArray()
+            .Select(item => item!.GetValue<string>()).ShouldBe(["caller", "configuration"]);
         outputSchema["$defs"]!["entityQueryPagination"]!["properties"]!["mode"]!["const"]!
             .GetValue<string>().ShouldBe("query_result_snapshot");
         outputSchema["$defs"]!.AsObject().ShouldContainKey("entityQueryErrorOutcome");

--- a/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/CalDavMcpRunnerTests.cs
+++ b/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/CalDavMcpRunnerTests.cs
@@ -99,6 +99,25 @@ public class CalDavMcpRunnerTests
     }
 
     [Fact]
+    public async Task RunAsync_InvalidConfiguredEvaluationTimeZoneFailsStartupWithoutEchoingTheValue()
+    {
+        const string privateValue = "Private/Secret-Zone";
+        var output = new StringWriter();
+
+        var exitCode = await new CalDavMcpRunner(output).RunAsync(options =>
+        {
+            options.BaseUrl = "https://caldav.example.com";
+            options.Username = "user";
+            options.Password = "pass";
+            options.EvaluationTimeZone = privateValue;
+        }, TestContext.Current.CancellationToken);
+
+        exitCode.ShouldBe(1);
+        output.ToString().ShouldContain("EvaluationTimeZone");
+        output.ToString().ShouldNotContain(privateValue);
+    }
+
+    [Fact]
     public async Task RunAsync_MissingUsername_ReturnsExitCode1_WithUsernameInError()
     {
         var sw = new StringWriter();

--- a/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/CalendarEntityToolsTests.cs
+++ b/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/CalendarEntityToolsTests.cs
@@ -49,6 +49,7 @@ public sealed class CalendarEntityToolsTests
             ["entityKinds"] = JsonSerializer.SerializeToElement(new[] { "event", "todo" }),
             ["from"] = JsonSerializer.SerializeToElement(new { kind = "utcDateTime", value = "2026-08-23T12:00:00Z" }),
             ["to"] = JsonSerializer.SerializeToElement(new { kind = "utcDateTime", value = "2026-08-24T12:00:00Z" }),
+            ["evaluationTimeZone"] = JsonSerializer.SerializeToElement("America/Sao_Paulo"),
             ["pageSize"] = JsonSerializer.SerializeToElement(1)
         }, CancellationToken.None);
         var continuation = await tool.QueryRawAsync(new Dictionary<string, JsonElement>
@@ -64,6 +65,7 @@ public sealed class CalendarEntityToolsTests
         typedStart.Query.Scope.ShouldBe(CalendarEntityScope.All);
         typedStart.Query.EntityKinds.ShouldBe([CalendarEntityKind.Event, CalendarEntityKind.Todo]);
         typedStart.Query.From.ShouldBe(new DateTimeOffset(2026, 8, 23, 12, 0, 0, TimeSpan.Zero));
+        typedStart.Query.EvaluationTimeZone.ShouldBe("America/Sao_Paulo");
         observed[1].ShouldBe(new CalendarEntityQueryRequest.Continue("opaque", 200));
     }
 
@@ -101,6 +103,8 @@ public sealed class CalendarEntityToolsTests
                 ("from", new { kind = "utcDateTime", value = "2026-08-23T12:00:00+01:00" }),
                 ("to", new { kind = "utcDateTime", value = "2026-08-24T12:00:00Z" })),
             Arguments(("scope", new { mode = "all" }), ("entityKinds", new[] { "event" }), ("pageSize", 201))
+            ,Arguments(("scope", new { mode = "all" }), ("entityKinds", new[] { "event" }),
+                ("evaluationTimeZone", JsonSerializer.SerializeToElement<string?>(null)))
         };
         var module = Substitute.For<ICalendarQueryModule>();
         var tool = new CalendarEntityTools(module);
@@ -379,7 +383,7 @@ public sealed class CalendarEntityToolsTests
     }
 
     [Fact]
-    public async Task ActualSdkEnvelopeMatchesTheModuleAccountant()
+    public async Task ActualSdkEnvelopeMatchesTheModuleAccountantWithTemporalContext()
     {
         const string calendarHref = "https://cal.example/calendars/work/";
         var services = new ServiceCollection();
@@ -392,11 +396,17 @@ public sealed class CalendarEntityToolsTests
             options.Username = "user";
             options.Password = "password";
             options.CalendarHrefs = calendarHref;
+            options.EvaluationTimeZone = "Europe/London";
         });
         await using var provider = services.BuildServiceProvider();
         var page = (await provider.GetRequiredService<ICalendarQueryModule>().QueryEntitiesAsync(
             new CalendarEntityQueryRequest.Start(
-                new CalendarEntityQuery(CalendarEntityScope.All, [CalendarEntityKind.Event])),
+                new CalendarEntityQuery(
+                    CalendarEntityScope.All,
+                    [CalendarEntityKind.Event],
+                    new DateTimeOffset(2026, 8, 23, 0, 0, 0, TimeSpan.Zero),
+                    new DateTimeOffset(2026, 8, 25, 0, 0, 0, TimeSpan.Zero),
+                    "America/Sao_Paulo")),
             CancellationToken.None)).ShouldBeOfType<QueryReply<CalendarEntityQueryItem>.Page>();
         var module = Substitute.For<ICalendarQueryModule>();
         module.QueryEntitiesAsync(Arg.Any<CalendarEntityQueryRequest>(), Arg.Any<CancellationToken>())
@@ -407,6 +417,9 @@ public sealed class CalendarEntityToolsTests
             CancellationToken.None);
 
         CalendarEntityTools.MeasureResult(actual).ShouldBe(page.Value.MeasuredCallToolResultBytes);
+        actual.StructuredContent!.Value.GetProperty("items").GetArrayLength().ShouldBe(1);
+        actual.StructuredContent!.Value.GetProperty("temporalEvaluationContext")
+            .GetProperty("timeZone").GetString().ShouldBe("America/Sao_Paulo");
         actual.Content.OfType<TextContentBlock>().ShouldHaveSingleItem().Text.ShouldBe(page.Value.HumanText);
     }
 
@@ -424,6 +437,7 @@ public sealed class CalendarEntityToolsTests
                 outcome = "success",
                 items = new object[] { new { marker = 1 }, new { padding = new string('x', padding) } },
                 diagnostics = Array.Empty<object>(),
+                temporalEvaluationContext = new { timeZone = "America/Sao_Paulo", source = "caller" },
                 pagination = new { mode = "query_result_snapshot", nextCursor = "opaque-cursor" }
             }),
             Content = [new TextContentBlock { Text = "Calendar Entity query completed." }]

--- a/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/ContractCatalogTests.cs
+++ b/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/ContractCatalogTests.cs
@@ -138,6 +138,14 @@ public sealed class ContractCatalogTests
         var occurrenceInput = catalog["$defs"]!["occurrenceQueryInput"]!.AsObject();
         occurrenceInput["required"]!.ToJsonString().ShouldNotContain("evaluationTimeZone");
         occurrenceInput["properties"]!.AsObject().ShouldContainKey("evaluationTimeZone");
+        var entityQueryInput = catalog["$defs"]!["entityQueryInput"]!.AsObject();
+        entityQueryInput["oneOf"]![0]!["properties"]!.AsObject().ShouldContainKey("evaluationTimeZone");
+        entityQueryInput["oneOf"]![1]!["properties"]!.AsObject().ShouldNotContainKey("evaluationTimeZone");
+        var entityQuerySuccess = catalog["$defs"]!["entityQuerySuccess"]!.AsObject();
+        entityQuerySuccess["properties"]!.AsObject().ShouldContainKey("temporalEvaluationContext");
+        catalog["environment"]!.AsArray()
+            .Single(item => item!["name"]!.GetValue<string>() == "CALDAV_EVALUATION_TIME_ZONE")!
+            ["description"]!.GetValue<string>().ShouldContain("bounded Calendar Entity Start");
         var calendarListInput = catalog["$defs"]!["calendarScopeInput"]!.AsObject();
         calendarListInput["required"].ShouldBeNull();
         calendarListInput["properties"].ShouldBeNull();

--- a/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/McpMetadataTests.cs
+++ b/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/McpMetadataTests.cs
@@ -72,6 +72,7 @@ public class McpMetadataTests
             "CALDAV_CALENDAR_HREFS",
             "CALDAV_DEFAULT_TODO_CALENDAR_NAME",
             "CALDAV_DEFAULT_EVENT_CALENDAR_NAME",
+            "CALDAV_EVALUATION_TIME_ZONE",
             "CALDAV_EXPOSE_EXACT_TOOLS",
             "OTEL_EXPORTER_OTLP_ENDPOINT",
             "OTEL_EXPORTER_OTLP_PROTOCOL",
@@ -82,6 +83,10 @@ public class McpMetadataTests
         envVars.EnumerateArray()
             .Single(item => item.GetProperty("name").GetString() == "OTEL_EXPORTER_OTLP_HEADERS")
             .GetProperty("isSecret").GetBoolean().ShouldBeTrue();
+        envVars.EnumerateArray()
+            .Single(item => item.GetProperty("name").GetString() == "CALDAV_EVALUATION_TIME_ZONE")
+            .GetProperty("description").GetString().ShouldNotBeNull()
+            .ShouldContain("bounded Calendar Entity Starts");
         var description = root.GetProperty("description").GetString()!;
         description.ShouldContain("Calendars");
         description.ShouldContain("Events");


### PR DESCRIPTION
Closes #110
Part of #105.
Depends on #120.

Summary:
- Resolve caller or configured IANA Temporal Evaluation Context before query transport construction.
- Freeze the chosen context into snapshots and cursors while rejecting missing or invalid context with zero CalDAV work.

Validation:
- Release build: 0 warnings/errors
- Layer gate: Core 2,081; MCP 964; Integration 101; Radicale variants 10/10
- Coverage: 93.6% lines / 85.2% branches; isolated evidence verified; Slopwatch 0

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
