### PR TITLE
chore: prepare v0.2.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.3] - 2026-08-23
+
 ### Added
 
 - Added immutable ten-minute Query Result Snapshot pagination for `calendar_entities.query`, including authenticated replayable Continuation Cursors, variable page sizes, and typed `cursor_expired` and `busy` failures.
@@ -18,6 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added opt-in OTLP traces, MCP metrics, and trace-correlated safe logs for the stdio server, including CalDAV aggregate-phase and outbound HTTP attempt waterfalls.
 - Added automated loopback OTLP coverage for trace parentage, metrics, log correlation, redaction, disabled defaults, collector failure isolation, and stdin-EOF shutdown.
 - Added truthful Operation outcome and Mutation State telemetry, explicit expected-absence observations, and per-wire-attempt retry recovery evidence through the built MCP stdio server.
+
+### Fixed
+
+- Fixed final-package entry validation so larger archives cannot turn an existing entry into a false missing-entry failure under `pipefail`.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Add this MCP server to VS Code, Claude Desktop, Cursor, or any MCP client:
   "mcpServers": {
     "caldav-calendars": {
       "command": "dnx",
-      "args": ["--yes", "dotnet-agents-caldav@0.2.2"],
+      "args": ["--yes", "dotnet-agents-caldav@0.2.3"],
       "env": {
         "CALDAV_URL": "https://caldav.example.com",
         "CALDAV_USERNAME": "user",
@@ -68,7 +68,7 @@ Add this MCP server to VS Code, Claude Desktop, Cursor, or any MCP client:
 - `calendar_resources.move` — Move one reviewed resource with exact `If-Match`, `Overwrite: F`, server-authoritative UID collision truth, and bounded bilateral reconciliation; requires a verified interoperability profile.
 - `calendar_resources.delete` — Delete an entire resource from an explicitly supplied revision reference (href, UID, kind, and exact strong ETag) after MCP MRTR review and confirmation; success requires verified absence.
 
-The 0.2.2 default catalog contains exactly these 17 tools in the order shown. It has no legacy task aliases or compatibility mode.
+The 0.2.3 default catalog contains exactly these 17 tools in the order shown. It has no legacy task aliases or compatibility mode.
 
 ### Exact Calendar resource tools
 
@@ -105,12 +105,14 @@ Exported spans show the MCP request, `caldav.operation`, the applicable `discove
 
 ## Supported servers
 
-The verified interoperability profile is the official Radicale 3.7.8 image pinned in the [Radicale 3.7.8 profile](https://github.com/Jhonattan-Souza/dotnet-agents-caldav/blob/v0.2.2/contracts/0.2.2/radicale-3.7.8-profile.json). Set `CALDAV_INTEROPERABILITY_PROFILE=radicale-3.7.8` only for that runtime. Server-authoritative Semantic and Exact Move fail closed with `unsupported_capability` when the profile is omitted because atomic `If-Match`, `Overwrite: F`, and `CALDAV:no-uid-conflict` enforcement cannot be inferred from stored resources or generic DAV discovery. No collection-scan compatibility fallback is provided. Other CalDAV servers remain unverified profiles even when capability negotiation allows other operations.
+The verified interoperability profile is the official Radicale 3.7.8 image pinned in the [Radicale 3.7.8 profile](https://github.com/Jhonattan-Souza/dotnet-agents-caldav/blob/v0.2.3/contracts/0.2.3/radicale-3.7.8-profile.json). Set `CALDAV_INTEROPERABILITY_PROFILE=radicale-3.7.8` only for that runtime. Server-authoritative Semantic and Exact Move fail closed with `unsupported_capability` when the profile is omitted because atomic `If-Match`, `Overwrite: F`, and `CALDAV:no-uid-conflict` enforcement cannot be inferred from stored resources or generic DAV discovery. No collection-scan compatibility fallback is provided. Other CalDAV servers remain unverified profiles even when capability negotiation allows other operations.
 
-## Migrating from 0.2.1
+## Migrating from 0.2.2
 
-Version 0.2.2 changes Create collision handling while keeping tool names and
-input shapes stable. Read [Migrating from 0.2.1 to 0.2.2](https://github.com/Jhonattan-Souza/dotnet-agents-caldav/blob/v0.2.2/docs/migrating-0.2.1-to-0.2.2.md)
+Version 0.2.3 replaces query replay with immutable Query Result Snapshots,
+requires an explicit Temporal Evaluation Context for bounded query Starts, and
+makes Move server-authoritative under the verified profile. Read
+[Migrating from 0.2.2 to 0.2.3](https://github.com/Jhonattan-Souza/dotnet-agents-caldav/blob/v0.2.3/docs/migrating-0.2.2-to-0.2.3.md)
 before upgrading.
 
 ## Migrating from 0.1.x

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,27 @@
 # Release Notes
 
+## 0.2.3 — 2026-08-23
+
+Calendar Entity, Occurrence, and compact To-do queries now execute once into
+immutable ten-minute Query Result Snapshots. Continuation calls authenticate a
+cursor and read only retained projected bytes: they perform no CalDAV reads,
+parsing, filtering, or recurrence expansion. Bounded query Starts use an
+explicit caller or configured IANA Temporal Evaluation Context, and Direct GET
+compatibility activates only after verified `calendar-multiget`
+unavailability.
+
+Semantic and Exact Move now use one conditional server-authoritative MOVE with
+bounded bilateral reconciliation under the verified Radicale 3.7.8 profile.
+Destination enumeration and UID scans are removed, Exact Move uses a protected
+one-use execution plan across MRTR, and collision results remain deliberately
+non-disclosing. Discovery work is reused once per MCP tool call.
+
+The stdio server also adds opt-in privacy-allowlisted OTLP traces, metrics, and
+correlated logs with truthful Operation outcomes, Mutation State, and
+per-wire-attempt recovery evidence. Test execution has moved to Microsoft
+Testing Platform v2 and xUnit 4, with isolated coverage and complete-result
+gates. See [the 0.2.2 to 0.2.3 migration guide](docs/migrating-0.2.2-to-0.2.3.md).
+
 ## 0.2.2 — 2026-08-21
 
 Event, To-do, and opt-in Exact Create now delegate collision authority to the

--- a/contracts/0.2.3/compatibility-matrix.md
+++ b/contracts/0.2.3/compatibility-matrix.md
@@ -1,0 +1,25 @@
+# Compatibility matrix: query, Move, and telemetry contract 0.2.3
+
+| Surface | 0.2.2 | 0.2.3 |
+| --- | --- | --- |
+| `calendar_entities.query` pagination | Query-bound cursor re-executes the query | Start creates a ten-minute Query Result Snapshot; Continue performs no CalDAV or semantic work |
+| `calendar_occurrences.query` pagination | Cursor-bound query replay | Start creates one immutable snapshot; Continue reads projected snapshot bytes only |
+| `todos.query` pagination | Query-bound cursor replay | Start evaluates one VTODO-only corpus once; Continue reads the immutable snapshot |
+| Query request shape | Query fields plus an optional cursor | Strict Start-or-Continue union; Continue accepts only the Continuation Cursor and page size |
+| Continuation expiry | Query cursor policy | Fixed snapshot expiry ten minutes after Start; replay never extends it |
+| Bounded Calendar Entity time zone | Implicit host context possible | Explicit caller or configured IANA Temporal Evaluation Context required before I/O |
+| Occurrence and To-do time zone | Caller query context | Explicit caller or configured IANA Temporal Evaluation Context required for every Start |
+| Successful query retrieval | `calendar-multiget` batches | 50-resource multiget batches with zero GETs; malformed or incomplete batches fail atomically |
+| Direct GET compatibility | No closed activation and work contract | Activates only after HTTP 405, HTTP 501, or explicit DAV unsupported evidence; bounded four-wide waves |
+| Semantic Move | Client-side destination and UID discovery | One conditional server-authoritative MOVE plus bounded bilateral reconciliation |
+| Exact Move MRTR | Repeated preflight work around confirmation | Fresh review plus one internal one-use execution plan; no third preflight or UID scan |
+| Move interoperability | Generic capability behavior | Fail closed unless the verified Radicale 3.7.8 profile is configured |
+| Destination collision disclosure | May derive collision details from scans | `destination_conflict` only for exact occupancy; other conflicts remain non-disclosing |
+| Discovery lifetime | Repeated discovery consumers inside one call | One immutable authorization-bound discovery result reused per MCP tool call |
+| Telemetry | MCP SDK defaults without product OTLP pipeline | Opt-in allowlisted OTLP traces, metrics, and correlated logs with bounded export |
+| Default semantic catalog | 17 tools | 17 tools; no legacy aliases or compatibility paths |
+| Opt-in exact catalog | 4 additional tools | 4 additional tools |
+
+The 0.2.3 wire schemas remain closed. Query input and continuation contracts
+are deliberately breaking; pending 0.2.2 cursors and MRTR request states must
+be discarded during upgrade. Historical contract directories remain immutable.

--- a/contracts/0.2.3/mcp-authority-manifest.json
+++ b/contracts/0.2.3/mcp-authority-manifest.json
@@ -1,0 +1,26 @@
+{
+  "contractVersion": "0.2.3",
+  "verifiedAt": "2026-08-23",
+  "protocol": {
+    "revision": "2026-07-28",
+    "stableTag": "2026-07-28",
+    "commit": "5f5440bb26a62e2cf3440b92da5a667efa03b267",
+    "sourceDocuments": [
+      { "category": "specification", "url": "https://github.com/modelcontextprotocol/modelcontextprotocol/tree/5f5440bb26a62e2cf3440b92da5a667efa03b267/docs/specification/2026-07-28" },
+      { "category": "changelog", "url": "https://github.com/modelcontextprotocol/modelcontextprotocol/blob/5f5440bb26a62e2cf3440b92da5a667efa03b267/docs/specification/2026-07-28/changelog.mdx" },
+      { "category": "discovery", "url": "https://github.com/modelcontextprotocol/modelcontextprotocol/blob/5f5440bb26a62e2cf3440b92da5a667efa03b267/docs/specification/2026-07-28/server/discover.mdx" },
+      { "category": "tools", "url": "https://github.com/modelcontextprotocol/modelcontextprotocol/blob/5f5440bb26a62e2cf3440b92da5a667efa03b267/docs/specification/2026-07-28/server/tools.mdx" },
+      { "category": "multiRoundTripRequests", "url": "https://github.com/modelcontextprotocol/modelcontextprotocol/blob/5f5440bb26a62e2cf3440b92da5a667efa03b267/docs/specification/2026-07-28/basic/patterns/mrtr.mdx" },
+      { "category": "stdio", "url": "https://github.com/modelcontextprotocol/modelcontextprotocol/blob/5f5440bb26a62e2cf3440b92da5a667efa03b267/docs/specification/2026-07-28/basic/transports/stdio.mdx" }
+    ]
+  },
+  "sdk": {
+    "package": "ModelContextProtocol",
+    "version": "2.2.0",
+    "release": "https://github.com/modelcontextprotocol/csharp-sdk/releases/tag/v2.2.0"
+  },
+  "authorityPolicy": {
+    "acceptedSources": ["stableSpecification", "stableChangelog", "officialFeatureDocumentation", "officialCSharpSdk"],
+    "excludedSources": ["draftSpecification", "deprecatedSamples", "thirdPartyExamples"]
+  }
+}

--- a/contracts/0.2.3/mcp-server.schema.json
+++ b/contracts/0.2.3/mcp-server.schema.json
@@ -1,0 +1,574 @@
+{
+  "$comment": "This file is auto-generated from docs/reference/api/openapi.yaml. Do not edit manually. Run 'make generate-schema' to update.",
+  "$id": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "$ref": "#/definitions/ServerDetail",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "Argument": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/PositionalArgument"
+        },
+        {
+          "$ref": "#/definitions/NamedArgument"
+        }
+      ],
+      "description": "Warning: Arguments construct command-line parameters that may contain user-provided input. This creates potential command injection risks if clients execute commands in a shell environment. For example, a malicious argument value like ';rm -rf ~/Development' could execute dangerous commands. Clients should prefer non-shell execution methods (e.g., posix_spawn) when possible to eliminate injection risks entirely. Where not possible, clients should obtain consent from users or agents to run the resolved command before execution."
+    },
+    "Icon": {
+      "description": "An optionally-sized icon that can be displayed in a user interface.",
+      "properties": {
+        "mimeType": {
+          "description": "Optional MIME type override if the source MIME type is missing or generic. Must be one of: image/png, image/jpeg, image/jpg, image/svg+xml, image/webp.",
+          "enum": [
+            "image/png",
+            "image/jpeg",
+            "image/jpg",
+            "image/svg+xml",
+            "image/webp"
+          ],
+          "example": "image/png",
+          "type": "string"
+        },
+        "sizes": {
+          "description": "Optional array of strings that specify sizes at which the icon can be used. Each string should be in WxH format (e.g., '48x48', '96x96') or 'any' for scalable formats like SVG. If not provided, the client should assume that the icon can be used at any size.",
+          "examples": [
+            [
+              "48x48",
+              "96x96"
+            ],
+            [
+              "any"
+            ]
+          ],
+          "items": {
+            "pattern": "^(\\d+x\\d+|any)$",
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "src": {
+          "description": "A standard URI pointing to an icon resource. Must be an HTTPS URL. Consumers SHOULD take steps to ensure URLs serving icons are from the same domain as the server or a trusted domain. Consumers SHOULD take appropriate precautions when consuming SVGs as they can contain executable JavaScript.",
+          "example": "https://example.com/icon.png",
+          "format": "uri",
+          "maxLength": 255,
+          "type": "string"
+        },
+        "theme": {
+          "description": "Optional specifier for the theme this icon is designed for. 'light' indicates the icon is designed to be used with a light background, and 'dark' indicates the icon is designed to be used with a dark background. If not provided, the client should assume the icon can be used with any theme.",
+          "enum": [
+            "light",
+            "dark"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "src"
+      ],
+      "type": "object"
+    },
+    "Input": {
+      "properties": {
+        "choices": {
+          "description": "A list of possible values for the input. If provided, the user must select one of these values.",
+          "example": [],
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "default": {
+          "description": "The default value for the input.  This should be a valid value for the input.  If you want to provide input examples or guidance, use the `placeholder` field instead.",
+          "type": "string"
+        },
+        "description": {
+          "description": "A description of the input, which clients can use to provide context to the user.",
+          "type": "string"
+        },
+        "format": {
+          "default": "string",
+          "description": "Specifies the input format. Supported values include `filepath`, which should be interpreted as a file on the user's filesystem.\n\nWhen the input is converted to a string, booleans should be represented by the strings \"true\" and \"false\", and numbers should be represented as decimal values.",
+          "enum": [
+            "string",
+            "number",
+            "boolean",
+            "filepath"
+          ],
+          "type": "string"
+        },
+        "isRequired": {
+          "default": false,
+          "type": "boolean"
+        },
+        "isSecret": {
+          "default": false,
+          "description": "Indicates whether the input is a secret value (e.g., password, token). If true, clients should handle the value securely.",
+          "type": "boolean"
+        },
+        "placeholder": {
+          "description": "A placeholder for the input to be displaying during configuration. This is used to provide examples or guidance about the expected form or content of the input.",
+          "type": "string"
+        },
+        "value": {
+          "description": "The value for the input. If this is not set, the user may be prompted to provide a value. If a value is set, it should not be configurable by end users.\n\nIdentifiers wrapped in `{curly_braces}` will be replaced with the corresponding properties from the input `variables` map. If an identifier in braces is not found in `variables`, or if `variables` is not provided, the `{curly_braces}` substring should remain unchanged.\n",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "InputWithVariables": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/Input"
+        },
+        {
+          "properties": {
+            "variables": {
+              "additionalProperties": {
+                "$ref": "#/definitions/Input"
+              },
+              "description": "A map of variable names to their values. Keys in the input `value` that are wrapped in `{curly_braces}` will be replaced with the corresponding variable values.",
+              "type": "object"
+            }
+          },
+          "type": "object"
+        }
+      ]
+    },
+    "KeyValueInput": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/InputWithVariables"
+        },
+        {
+          "properties": {
+            "name": {
+              "description": "Name of the header or environment variable.",
+              "example": "SOME_VARIABLE",
+              "type": "string"
+            }
+          },
+          "required": [
+            "name"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "LocalTransport": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/StdioTransport"
+        },
+        {
+          "$ref": "#/definitions/StreamableHttpTransport"
+        },
+        {
+          "$ref": "#/definitions/SseTransport"
+        }
+      ],
+      "description": "Transport protocol configuration for local/package context"
+    },
+    "NamedArgument": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/InputWithVariables"
+        },
+        {
+          "properties": {
+            "isRepeated": {
+              "default": false,
+              "description": "Whether the argument can be repeated multiple times.",
+              "type": "boolean"
+            },
+            "name": {
+              "description": "The flag name, including any leading dashes.",
+              "example": "--port",
+              "type": "string"
+            },
+            "type": {
+              "enum": [
+                "named"
+              ],
+              "example": "named",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "name"
+          ],
+          "type": "object"
+        }
+      ],
+      "description": "A command-line `--flag={value}`."
+    },
+    "Package": {
+      "properties": {
+        "environmentVariables": {
+          "description": "A mapping of environment variables to be set when running the package.",
+          "items": {
+            "$ref": "#/definitions/KeyValueInput"
+          },
+          "type": "array"
+        },
+        "fileSha256": {
+          "description": "SHA-256 hash of the package file for integrity verification. Required for MCPB packages and optional for other package types. Authors are responsible for generating correct SHA-256 hashes when creating server.json. If present, MCP clients must validate the downloaded file matches the hash before running packages to ensure file integrity.",
+          "example": "fe333e598595000ae021bd27117db32ec69af6987f507ba7a63c90638ff633ce",
+          "pattern": "^[a-f0-9]{64}$",
+          "type": "string"
+        },
+        "identifier": {
+          "description": "Package identifier - either a package name (for registries) or URL (for direct downloads)",
+          "examples": [
+            "@modelcontextprotocol/server-brave-search",
+            "https://github.com/example/releases/download/v1.0.0/package.mcpb"
+          ],
+          "type": "string"
+        },
+        "packageArguments": {
+          "description": "A list of arguments to be passed to the package's binary.",
+          "items": {
+            "$ref": "#/definitions/Argument"
+          },
+          "type": "array"
+        },
+        "registryBaseUrl": {
+          "description": "Base URL of the package registry",
+          "examples": [
+            "https://registry.npmjs.org",
+            "https://pypi.org",
+            "https://docker.io",
+            "https://api.nuget.org/v3/index.json",
+            "https://github.com",
+            "https://gitlab.com"
+          ],
+          "format": "uri",
+          "type": "string"
+        },
+        "registryType": {
+          "description": "Registry type indicating how to download packages (e.g., 'npm', 'pypi', 'oci', 'nuget', 'mcpb')",
+          "examples": [
+            "npm",
+            "pypi",
+            "oci",
+            "nuget",
+            "mcpb"
+          ],
+          "type": "string"
+        },
+        "runtimeArguments": {
+          "description": "A list of arguments to be passed to the package's runtime command (such as docker or npx). The `runtimeHint` field should be provided when `runtimeArguments` are present.",
+          "items": {
+            "$ref": "#/definitions/Argument"
+          },
+          "type": "array"
+        },
+        "runtimeHint": {
+          "description": "A hint to help clients determine the appropriate runtime for the package. This field should be provided when `runtimeArguments` are present.",
+          "examples": [
+            "npx",
+            "uvx",
+            "docker",
+            "dnx"
+          ],
+          "type": "string"
+        },
+        "transport": {
+          "$ref": "#/definitions/LocalTransport",
+          "description": "Transport protocol configuration for the package"
+        },
+        "version": {
+          "description": "Package version. Must be a specific version. Version ranges are rejected (e.g., '^1.2.3', '~1.2.3', '\u003e=1.2.3', '1.x', '1.*').",
+          "example": "1.0.2",
+          "minLength": 1,
+          "not": {
+            "const": "latest"
+          },
+          "type": "string"
+        }
+      },
+      "required": [
+        "registryType",
+        "identifier",
+        "transport"
+      ],
+      "type": "object"
+    },
+    "PositionalArgument": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/InputWithVariables"
+        },
+        {
+          "anyOf": [
+            {
+              "required": [
+                "valueHint"
+              ]
+            },
+            {
+              "required": [
+                "value"
+              ]
+            }
+          ],
+          "properties": {
+            "isRepeated": {
+              "default": false,
+              "description": "Whether the argument can be repeated multiple times in the command line.",
+              "type": "boolean"
+            },
+            "type": {
+              "enum": [
+                "positional"
+              ],
+              "example": "positional",
+              "type": "string"
+            },
+            "valueHint": {
+              "description": "An identifier for the positional argument. It is not part of the command line. It may be used by client configuration as a label identifying the argument. It is also used to identify the value in transport URL variable substitution.",
+              "example": "file_path",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "type": "object"
+        }
+      ],
+      "description": "A positional input is a value inserted verbatim into the command line."
+    },
+    "RemoteTransport": {
+      "allOf": [
+        {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StreamableHttpTransport"
+            },
+            {
+              "$ref": "#/definitions/SseTransport"
+            }
+          ]
+        },
+        {
+          "properties": {
+            "variables": {
+              "additionalProperties": {
+                "$ref": "#/definitions/Input"
+              },
+              "description": "Configuration variables that can be referenced in URL template {curly_braces}. The key is the variable name, and the value defines the variable properties.",
+              "type": "object"
+            }
+          },
+          "type": "object"
+        }
+      ],
+      "description": "Transport protocol configuration for remote context - extends StreamableHttpTransport or SseTransport with variables"
+    },
+    "Repository": {
+      "description": "Repository metadata for the MCP server source code. Enables users and security experts to inspect the code, improving transparency.",
+      "properties": {
+        "id": {
+          "description": "Repository identifier from the hosting service (e.g., GitHub repo ID). Owned and determined by the source forge. Should remain stable across repository renames and may be used to detect repository resurrection attacks - if a repository is deleted and recreated, the ID should change. For GitHub, use: gh api repos/\u003cowner\u003e/\u003crepo\u003e --jq '.id'",
+          "example": "b94b5f7e-c7c6-d760-2c78-a5e9b8a5b8c9",
+          "type": "string"
+        },
+        "source": {
+          "description": "Repository hosting service identifier. Used by registries to determine validation and API access methods.",
+          "example": "github",
+          "type": "string"
+        },
+        "subfolder": {
+          "description": "Optional relative path from repository root to the server location within a monorepo or nested package structure. Must be a clean relative path.",
+          "example": "src/everything",
+          "type": "string"
+        },
+        "url": {
+          "description": "Repository URL for browsing source code. Should support both web browsing and git clone operations.",
+          "example": "https://github.com/modelcontextprotocol/servers",
+          "format": "uri",
+          "type": "string"
+        }
+      },
+      "required": [
+        "url",
+        "source"
+      ],
+      "type": "object"
+    },
+    "ServerDetail": {
+      "description": "Schema for a static representation of an MCP server. Used in various contexts related to discovery, installation, and configuration.",
+      "properties": {
+        "$schema": {
+          "description": "JSON Schema URI for this server.json format",
+          "example": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+          "format": "uri",
+          "type": "string"
+        },
+        "_meta": {
+          "description": "Extension metadata using reverse DNS namespacing for vendor-specific data",
+          "properties": {
+            "io.modelcontextprotocol.registry/publisher-provided": {
+              "additionalProperties": true,
+              "description": "Publisher-provided metadata for downstream registries",
+              "example": {
+                "buildInfo": {
+                  "commit": "abc123def456",
+                  "pipelineId": "build-789",
+                  "timestamp": "2023-12-01T10:30:00Z"
+                },
+                "tool": "publisher-cli",
+                "version": "1.2.3"
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "description": {
+          "description": "Clear human-readable explanation of server functionality. Should focus on capabilities, not implementation details.",
+          "example": "MCP server providing weather data and forecasts via OpenWeatherMap API",
+          "maxLength": 100,
+          "minLength": 1,
+          "type": "string"
+        },
+        "icons": {
+          "description": "Optional set of sized icons that the client can display in a user interface. Clients that support rendering icons MUST support at least the following MIME types: image/png and image/jpeg (safe, universal compatibility). Clients SHOULD also support: image/svg+xml (scalable but requires security precautions) and image/webp (modern, efficient format).",
+          "items": {
+            "$ref": "#/definitions/Icon"
+          },
+          "type": "array"
+        },
+        "name": {
+          "description": "Server name in reverse-DNS format. Must contain exactly one forward slash separating namespace from server name.",
+          "example": "io.github.user/weather",
+          "maxLength": 200,
+          "minLength": 3,
+          "pattern": "^[a-zA-Z0-9.-]+/[a-zA-Z0-9._-]+$",
+          "type": "string"
+        },
+        "packages": {
+          "items": {
+            "$ref": "#/definitions/Package"
+          },
+          "type": "array"
+        },
+        "remotes": {
+          "items": {
+            "$ref": "#/definitions/RemoteTransport"
+          },
+          "type": "array"
+        },
+        "repository": {
+          "$ref": "#/definitions/Repository",
+          "description": "Optional repository metadata for the MCP server source code. Recommended for transparency and security inspection."
+        },
+        "title": {
+          "description": "Optional human-readable title or display name for the MCP server. MCP subregistries or clients MAY choose to use this for display purposes.",
+          "example": "Weather API",
+          "maxLength": 100,
+          "minLength": 1,
+          "type": "string"
+        },
+        "version": {
+          "description": "Version string for this server. SHOULD follow semantic versioning (e.g., '1.0.2', '2.1.0-alpha'). Equivalent of Implementation.version in MCP specification. Non-semantic versions are allowed but may not sort predictably. Version ranges are rejected (e.g., '^1.2.3', '~1.2.3', '\u003e=1.2.3', '1.x', '1.*').",
+          "example": "1.0.2",
+          "maxLength": 255,
+          "type": "string"
+        },
+        "websiteUrl": {
+          "description": "Optional URL to the server's homepage, documentation, or project website. This provides a central link for users to learn more about the server. Particularly useful when the server has custom installation instructions or setup requirements.",
+          "example": "https://modelcontextprotocol.io/examples",
+          "format": "uri",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "description",
+        "version"
+      ],
+      "type": "object"
+    },
+    "SseTransport": {
+      "properties": {
+        "headers": {
+          "description": "HTTP headers to include",
+          "items": {
+            "$ref": "#/definitions/KeyValueInput"
+          },
+          "type": "array"
+        },
+        "type": {
+          "description": "Transport type",
+          "enum": [
+            "sse"
+          ],
+          "example": "sse",
+          "type": "string"
+        },
+        "url": {
+          "description": "Server-Sent Events endpoint URL template. Variables in {curly_braces} are resolved based on context: In Package context, they reference argument valueHints, argument names, or environment variable names from the parent Package. In Remote context, they reference variables from the transport's 'variables' object. After variable substitution, this should produce a valid URI.",
+          "example": "https://mcp-fs.example.com/sse",
+          "pattern": "^https?://[^\\s]+$",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "url"
+      ],
+      "type": "object"
+    },
+    "StdioTransport": {
+      "properties": {
+        "type": {
+          "description": "Transport type",
+          "enum": [
+            "stdio"
+          ],
+          "example": "stdio",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object"
+    },
+    "StreamableHttpTransport": {
+      "properties": {
+        "headers": {
+          "description": "HTTP headers to include",
+          "items": {
+            "$ref": "#/definitions/KeyValueInput"
+          },
+          "type": "array"
+        },
+        "type": {
+          "description": "Transport type",
+          "enum": [
+            "streamable-http"
+          ],
+          "example": "streamable-http",
+          "type": "string"
+        },
+        "url": {
+          "description": "URL template for the streamable-http transport. Variables in {curly_braces} are resolved based on context: In Package context, they reference argument valueHints, argument names, or environment variable names from the parent Package. In Remote context, they reference variables from the transport's 'variables' object. After variable substitution, this should produce a valid URI.",
+          "example": "https://api.example.com/mcp",
+          "pattern": "^https?://[^\\s]+$",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "url"
+      ],
+      "type": "object"
+    }
+  },
+  "title": "server.json defining a Model Context Protocol (MCP) server"
+}

--- a/contracts/0.2.3/mcp-tool-catalog.json
+++ b/contracts/0.2.3/mcp-tool-catalog.json
@@ -1,0 +1,9388 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "protocolRevision": "2026-07-28",
+  "createSemantics": {
+    "authoritativeOperation": "conditional_put",
+    "preflightEnumeration": false,
+    "hrefConflictCode": "destination_conflict",
+    "uidConflictCode": "conflict",
+    "rejectedMutationState": "not_committed",
+    "generatedUidMaximumAttempts": 3,
+    "exactReviewBindingFields": [
+      "destinationHref",
+      "entityUid",
+      "entityKind",
+      "intentDigest",
+      "policyVersion"
+    ]
+  },
+  "transport": {
+    "discover": "server/discover",
+    "stateless": true,
+    "tasksExtension": false,
+    "listChangedNotifications": false
+  },
+  "outcomeContract": {
+    "structuredContent": "authoritative",
+    "textContent": "concise compatible summary",
+    "expectedFailure": {
+      "isError": true,
+      "schemas": [
+        "#/$defs/errorOutcome",
+        "#/$defs/mutationErrorOutcome"
+      ]
+    },
+    "nonMutatingSuccesses": [
+      "no_change",
+      "confirmation_declined"
+    ]
+  },
+  "mrtrWireContract": {
+    "toolsCallParams": {
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "name",
+            "_meta"
+          ],
+          "properties": {
+            "name": {
+              "const": "calendars.list"
+            },
+            "arguments": {
+              "$ref": "#/$defs/calendarScopeInput"
+            },
+            "requestState": {
+              "type": "string",
+              "minLength": 1
+            },
+            "inputResponses": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/$defs/mrtrInputResponse"
+              }
+            },
+            "_meta": {
+              "type": "object",
+              "required": [
+                "io.modelcontextprotocol/protocolVersion",
+                "io.modelcontextprotocol/clientCapabilities"
+              ],
+              "properties": {
+                "progressToken": {
+                  "type": "number"
+                },
+                "io.modelcontextprotocol/protocolVersion": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "io.modelcontextprotocol/clientCapabilities": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "properties": {
+                    "elicitation": {
+                      "type": "object",
+                      "additionalProperties": true,
+                      "properties": {
+                        "form": {
+                          "type": "object",
+                          "additionalProperties": true
+                        },
+                        "url": {
+                          "type": "object",
+                          "additionalProperties": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "io.modelcontextprotocol/clientInfo": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": [
+                    "name",
+                    "version"
+                  ],
+                  "properties": {
+                    "name": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "version": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "title": {
+                      "type": "string"
+                    },
+                    "description": {
+                      "type": "string"
+                    },
+                    "websiteUrl": {
+                      "type": "string",
+                      "format": "uri"
+                    },
+                    "icons": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    }
+                  }
+                },
+                "io.modelcontextprotocol/logLevel": {
+                  "enum": [
+                    "debug",
+                    "info",
+                    "notice",
+                    "warning",
+                    "error",
+                    "critical",
+                    "alert",
+                    "emergency"
+                  ]
+                }
+              },
+              "additionalProperties": true
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "name",
+            "_meta",
+            "arguments"
+          ],
+          "properties": {
+            "name": {
+              "const": "calendar_entities.query"
+            },
+            "arguments": {
+              "$ref": "#/$defs/entityQueryInput"
+            },
+            "requestState": {
+              "type": "string",
+              "minLength": 1
+            },
+            "inputResponses": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/$defs/mrtrInputResponse"
+              }
+            },
+            "_meta": {
+              "type": "object",
+              "required": [
+                "io.modelcontextprotocol/protocolVersion",
+                "io.modelcontextprotocol/clientCapabilities"
+              ],
+              "properties": {
+                "progressToken": {
+                  "type": "number"
+                },
+                "io.modelcontextprotocol/protocolVersion": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "io.modelcontextprotocol/clientCapabilities": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "properties": {
+                    "elicitation": {
+                      "type": "object",
+                      "additionalProperties": true,
+                      "properties": {
+                        "form": {
+                          "type": "object",
+                          "additionalProperties": true
+                        },
+                        "url": {
+                          "type": "object",
+                          "additionalProperties": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "io.modelcontextprotocol/clientInfo": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": [
+                    "name",
+                    "version"
+                  ],
+                  "properties": {
+                    "name": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "version": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "title": {
+                      "type": "string"
+                    },
+                    "description": {
+                      "type": "string"
+                    },
+                    "websiteUrl": {
+                      "type": "string",
+                      "format": "uri"
+                    },
+                    "icons": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    }
+                  }
+                },
+                "io.modelcontextprotocol/logLevel": {
+                  "enum": [
+                    "debug",
+                    "info",
+                    "notice",
+                    "warning",
+                    "error",
+                    "critical",
+                    "alert",
+                    "emergency"
+                  ]
+                }
+              },
+              "additionalProperties": true
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "name",
+            "_meta",
+            "arguments"
+          ],
+          "properties": {
+            "name": {
+              "const": "calendar_occurrences.query"
+            },
+            "arguments": {
+              "$ref": "#/$defs/occurrenceQueryInput"
+            },
+            "requestState": {
+              "type": "string",
+              "minLength": 1
+            },
+            "inputResponses": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/$defs/mrtrInputResponse"
+              }
+            },
+            "_meta": {
+              "type": "object",
+              "required": [
+                "io.modelcontextprotocol/protocolVersion",
+                "io.modelcontextprotocol/clientCapabilities"
+              ],
+              "properties": {
+                "progressToken": {
+                  "type": "number"
+                },
+                "io.modelcontextprotocol/protocolVersion": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "io.modelcontextprotocol/clientCapabilities": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "properties": {
+                    "elicitation": {
+                      "type": "object",
+                      "additionalProperties": true,
+                      "properties": {
+                        "form": {
+                          "type": "object",
+                          "additionalProperties": true
+                        },
+                        "url": {
+                          "type": "object",
+                          "additionalProperties": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "io.modelcontextprotocol/clientInfo": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": [
+                    "name",
+                    "version"
+                  ],
+                  "properties": {
+                    "name": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "version": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "title": {
+                      "type": "string"
+                    },
+                    "description": {
+                      "type": "string"
+                    },
+                    "websiteUrl": {
+                      "type": "string",
+                      "format": "uri"
+                    },
+                    "icons": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    }
+                  }
+                },
+                "io.modelcontextprotocol/logLevel": {
+                  "enum": [
+                    "debug",
+                    "info",
+                    "notice",
+                    "warning",
+                    "error",
+                    "critical",
+                    "alert",
+                    "emergency"
+                  ]
+                }
+              },
+              "additionalProperties": true
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "name",
+            "_meta",
+            "arguments"
+          ],
+          "properties": {
+            "name": {
+              "const": "todos.query"
+            },
+            "arguments": {
+              "$ref": "#/$defs/todoQueryInput"
+            },
+            "requestState": {
+              "type": "string",
+              "minLength": 1
+            },
+            "inputResponses": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/$defs/mrtrInputResponse"
+              }
+            },
+            "_meta": {
+              "type": "object",
+              "required": [
+                "io.modelcontextprotocol/protocolVersion",
+                "io.modelcontextprotocol/clientCapabilities"
+              ],
+              "additionalProperties": true
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "name",
+            "_meta",
+            "arguments"
+          ],
+          "properties": {
+            "name": {
+              "const": "calendar_resources.get"
+            },
+            "arguments": {
+              "$ref": "#/$defs/resourceAddressInput"
+            },
+            "requestState": {
+              "type": "string",
+              "minLength": 1
+            },
+            "inputResponses": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/$defs/mrtrInputResponse"
+              }
+            },
+            "_meta": {
+              "type": "object",
+              "required": [
+                "io.modelcontextprotocol/protocolVersion",
+                "io.modelcontextprotocol/clientCapabilities"
+              ],
+              "properties": {
+                "progressToken": {
+                  "type": "number"
+                },
+                "io.modelcontextprotocol/protocolVersion": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "io.modelcontextprotocol/clientCapabilities": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "properties": {
+                    "elicitation": {
+                      "type": "object",
+                      "additionalProperties": true,
+                      "properties": {
+                        "form": {
+                          "type": "object",
+                          "additionalProperties": true
+                        },
+                        "url": {
+                          "type": "object",
+                          "additionalProperties": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "io.modelcontextprotocol/clientInfo": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": [
+                    "name",
+                    "version"
+                  ],
+                  "properties": {
+                    "name": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "version": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "title": {
+                      "type": "string"
+                    },
+                    "description": {
+                      "type": "string"
+                    },
+                    "websiteUrl": {
+                      "type": "string",
+                      "format": "uri"
+                    },
+                    "icons": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    }
+                  }
+                },
+                "io.modelcontextprotocol/logLevel": {
+                  "enum": [
+                    "debug",
+                    "info",
+                    "notice",
+                    "warning",
+                    "error",
+                    "critical",
+                    "alert",
+                    "emergency"
+                  ]
+                }
+              },
+              "additionalProperties": true
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "name",
+            "_meta",
+            "arguments"
+          ],
+          "properties": {
+            "name": {
+              "const": "events.create"
+            },
+            "arguments": {
+              "$ref": "#/$defs/eventCreateInput"
+            },
+            "requestState": {
+              "type": "string",
+              "minLength": 1
+            },
+            "inputResponses": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/$defs/mrtrInputResponse"
+              }
+            },
+            "_meta": {
+              "type": "object",
+              "required": [
+                "io.modelcontextprotocol/protocolVersion",
+                "io.modelcontextprotocol/clientCapabilities"
+              ],
+              "properties": {
+                "progressToken": {
+                  "type": "number"
+                },
+                "io.modelcontextprotocol/protocolVersion": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "io.modelcontextprotocol/clientCapabilities": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "properties": {
+                    "elicitation": {
+                      "type": "object",
+                      "additionalProperties": true,
+                      "properties": {
+                        "form": {
+                          "type": "object",
+                          "additionalProperties": true
+                        },
+                        "url": {
+                          "type": "object",
+                          "additionalProperties": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "io.modelcontextprotocol/clientInfo": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": [
+                    "name",
+                    "version"
+                  ],
+                  "properties": {
+                    "name": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "version": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "title": {
+                      "type": "string"
+                    },
+                    "description": {
+                      "type": "string"
+                    },
+                    "websiteUrl": {
+                      "type": "string",
+                      "format": "uri"
+                    },
+                    "icons": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    }
+                  }
+                },
+                "io.modelcontextprotocol/logLevel": {
+                  "enum": [
+                    "debug",
+                    "info",
+                    "notice",
+                    "warning",
+                    "error",
+                    "critical",
+                    "alert",
+                    "emergency"
+                  ]
+                }
+              },
+              "additionalProperties": true
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "name",
+            "_meta",
+            "arguments"
+          ],
+          "properties": {
+            "name": {
+              "const": "events.patch"
+            },
+            "arguments": {
+              "$ref": "#/$defs/eventPatchInput"
+            },
+            "requestState": {
+              "type": "string",
+              "minLength": 1
+            },
+            "inputResponses": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/$defs/mrtrInputResponse"
+              }
+            },
+            "_meta": {
+              "type": "object",
+              "required": [
+                "io.modelcontextprotocol/protocolVersion",
+                "io.modelcontextprotocol/clientCapabilities"
+              ],
+              "properties": {
+                "progressToken": {
+                  "type": "number"
+                },
+                "io.modelcontextprotocol/protocolVersion": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "io.modelcontextprotocol/clientCapabilities": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "properties": {
+                    "elicitation": {
+                      "type": "object",
+                      "additionalProperties": true,
+                      "properties": {
+                        "form": {
+                          "type": "object",
+                          "additionalProperties": true
+                        },
+                        "url": {
+                          "type": "object",
+                          "additionalProperties": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "io.modelcontextprotocol/clientInfo": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": [
+                    "name",
+                    "version"
+                  ],
+                  "properties": {
+                    "name": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "version": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "title": {
+                      "type": "string"
+                    },
+                    "description": {
+                      "type": "string"
+                    },
+                    "websiteUrl": {
+                      "type": "string",
+                      "format": "uri"
+                    },
+                    "icons": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    }
+                  }
+                },
+                "io.modelcontextprotocol/logLevel": {
+                  "enum": [
+                    "debug",
+                    "info",
+                    "notice",
+                    "warning",
+                    "error",
+                    "critical",
+                    "alert",
+                    "emergency"
+                  ]
+                }
+              },
+              "additionalProperties": true
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "name",
+            "_meta",
+            "arguments"
+          ],
+          "properties": {
+            "name": {
+              "const": "todos.create"
+            },
+            "arguments": {
+              "$ref": "#/$defs/todoCreateInput"
+            },
+            "requestState": {
+              "type": "string",
+              "minLength": 1
+            },
+            "inputResponses": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/$defs/mrtrInputResponse"
+              }
+            },
+            "_meta": {
+              "type": "object",
+              "required": [
+                "io.modelcontextprotocol/protocolVersion",
+                "io.modelcontextprotocol/clientCapabilities"
+              ],
+              "properties": {
+                "progressToken": {
+                  "type": "number"
+                },
+                "io.modelcontextprotocol/protocolVersion": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "io.modelcontextprotocol/clientCapabilities": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "properties": {
+                    "elicitation": {
+                      "type": "object",
+                      "additionalProperties": true,
+                      "properties": {
+                        "form": {
+                          "type": "object",
+                          "additionalProperties": true
+                        },
+                        "url": {
+                          "type": "object",
+                          "additionalProperties": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "io.modelcontextprotocol/clientInfo": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": [
+                    "name",
+                    "version"
+                  ],
+                  "properties": {
+                    "name": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "version": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "title": {
+                      "type": "string"
+                    },
+                    "description": {
+                      "type": "string"
+                    },
+                    "websiteUrl": {
+                      "type": "string",
+                      "format": "uri"
+                    },
+                    "icons": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    }
+                  }
+                },
+                "io.modelcontextprotocol/logLevel": {
+                  "enum": [
+                    "debug",
+                    "info",
+                    "notice",
+                    "warning",
+                    "error",
+                    "critical",
+                    "alert",
+                    "emergency"
+                  ]
+                }
+              },
+              "additionalProperties": true
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "name",
+            "_meta",
+            "arguments"
+          ],
+          "properties": {
+            "name": {
+              "const": "todos.patch"
+            },
+            "arguments": {
+              "$ref": "#/$defs/todoPatchInput"
+            },
+            "requestState": {
+              "type": "string",
+              "minLength": 1
+            },
+            "inputResponses": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/$defs/mrtrInputResponse"
+              }
+            },
+            "_meta": {
+              "type": "object",
+              "required": [
+                "io.modelcontextprotocol/protocolVersion",
+                "io.modelcontextprotocol/clientCapabilities"
+              ],
+              "properties": {
+                "progressToken": {
+                  "type": "number"
+                },
+                "io.modelcontextprotocol/protocolVersion": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "io.modelcontextprotocol/clientCapabilities": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "properties": {
+                    "elicitation": {
+                      "type": "object",
+                      "additionalProperties": true,
+                      "properties": {
+                        "form": {
+                          "type": "object",
+                          "additionalProperties": true
+                        },
+                        "url": {
+                          "type": "object",
+                          "additionalProperties": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "io.modelcontextprotocol/clientInfo": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": [
+                    "name",
+                    "version"
+                  ],
+                  "properties": {
+                    "name": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "version": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "title": {
+                      "type": "string"
+                    },
+                    "description": {
+                      "type": "string"
+                    },
+                    "websiteUrl": {
+                      "type": "string",
+                      "format": "uri"
+                    },
+                    "icons": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    }
+                  }
+                },
+                "io.modelcontextprotocol/logLevel": {
+                  "enum": [
+                    "debug",
+                    "info",
+                    "notice",
+                    "warning",
+                    "error",
+                    "critical",
+                    "alert",
+                    "emergency"
+                  ]
+                }
+              },
+              "additionalProperties": true
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "name",
+            "_meta",
+            "arguments"
+          ],
+          "properties": {
+            "name": {
+              "const": "todos.complete"
+            },
+            "arguments": {
+              "$ref": "#/$defs/completionInput"
+            },
+            "requestState": {
+              "type": "string",
+              "minLength": 1
+            },
+            "inputResponses": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/$defs/mrtrInputResponse"
+              }
+            },
+            "_meta": {
+              "type": "object",
+              "required": [
+                "io.modelcontextprotocol/protocolVersion",
+                "io.modelcontextprotocol/clientCapabilities"
+              ],
+              "properties": {
+                "progressToken": {
+                  "type": "number"
+                },
+                "io.modelcontextprotocol/protocolVersion": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "io.modelcontextprotocol/clientCapabilities": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "properties": {
+                    "elicitation": {
+                      "type": "object",
+                      "additionalProperties": true,
+                      "properties": {
+                        "form": {
+                          "type": "object",
+                          "additionalProperties": true
+                        },
+                        "url": {
+                          "type": "object",
+                          "additionalProperties": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "io.modelcontextprotocol/clientInfo": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": [
+                    "name",
+                    "version"
+                  ],
+                  "properties": {
+                    "name": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "version": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "title": {
+                      "type": "string"
+                    },
+                    "description": {
+                      "type": "string"
+                    },
+                    "websiteUrl": {
+                      "type": "string",
+                      "format": "uri"
+                    },
+                    "icons": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    }
+                  }
+                },
+                "io.modelcontextprotocol/logLevel": {
+                  "enum": [
+                    "debug",
+                    "info",
+                    "notice",
+                    "warning",
+                    "error",
+                    "critical",
+                    "alert",
+                    "emergency"
+                  ]
+                }
+              },
+              "additionalProperties": true
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "name",
+            "_meta",
+            "arguments"
+          ],
+          "properties": {
+            "name": {
+              "const": "calendar_occurrences.add"
+            },
+            "arguments": {
+              "$ref": "#/$defs/occurrenceMutationInput"
+            },
+            "requestState": {
+              "type": "string",
+              "minLength": 1
+            },
+            "inputResponses": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/$defs/mrtrInputResponse"
+              }
+            },
+            "_meta": {
+              "type": "object",
+              "required": [
+                "io.modelcontextprotocol/protocolVersion",
+                "io.modelcontextprotocol/clientCapabilities"
+              ],
+              "properties": {
+                "progressToken": {
+                  "type": "number"
+                },
+                "io.modelcontextprotocol/protocolVersion": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "io.modelcontextprotocol/clientCapabilities": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "properties": {
+                    "elicitation": {
+                      "type": "object",
+                      "additionalProperties": true,
+                      "properties": {
+                        "form": {
+                          "type": "object",
+                          "additionalProperties": true
+                        },
+                        "url": {
+                          "type": "object",
+                          "additionalProperties": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "io.modelcontextprotocol/clientInfo": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": [
+                    "name",
+                    "version"
+                  ],
+                  "properties": {
+                    "name": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "version": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "title": {
+                      "type": "string"
+                    },
+                    "description": {
+                      "type": "string"
+                    },
+                    "websiteUrl": {
+                      "type": "string",
+                      "format": "uri"
+                    },
+                    "icons": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    }
+                  }
+                },
+                "io.modelcontextprotocol/logLevel": {
+                  "enum": [
+                    "debug",
+                    "info",
+                    "notice",
+                    "warning",
+                    "error",
+                    "critical",
+                    "alert",
+                    "emergency"
+                  ]
+                }
+              },
+              "additionalProperties": true
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "name",
+            "_meta",
+            "arguments"
+          ],
+          "properties": {
+            "name": {
+              "const": "calendar_occurrences.exclude"
+            },
+            "arguments": {
+              "$ref": "#/$defs/occurrenceMutationInput"
+            },
+            "requestState": {
+              "type": "string",
+              "minLength": 1
+            },
+            "inputResponses": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/$defs/mrtrInputResponse"
+              }
+            },
+            "_meta": {
+              "type": "object",
+              "required": [
+                "io.modelcontextprotocol/protocolVersion",
+                "io.modelcontextprotocol/clientCapabilities"
+              ],
+              "properties": {
+                "progressToken": {
+                  "type": "number"
+                },
+                "io.modelcontextprotocol/protocolVersion": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "io.modelcontextprotocol/clientCapabilities": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "properties": {
+                    "elicitation": {
+                      "type": "object",
+                      "additionalProperties": true,
+                      "properties": {
+                        "form": {
+                          "type": "object",
+                          "additionalProperties": true
+                        },
+                        "url": {
+                          "type": "object",
+                          "additionalProperties": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "io.modelcontextprotocol/clientInfo": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": [
+                    "name",
+                    "version"
+                  ],
+                  "properties": {
+                    "name": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "version": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "title": {
+                      "type": "string"
+                    },
+                    "description": {
+                      "type": "string"
+                    },
+                    "websiteUrl": {
+                      "type": "string",
+                      "format": "uri"
+                    },
+                    "icons": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    }
+                  }
+                },
+                "io.modelcontextprotocol/logLevel": {
+                  "enum": [
+                    "debug",
+                    "info",
+                    "notice",
+                    "warning",
+                    "error",
+                    "critical",
+                    "alert",
+                    "emergency"
+                  ]
+                }
+              },
+              "additionalProperties": true
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "name",
+            "_meta",
+            "arguments"
+          ],
+          "properties": {
+            "name": {
+              "const": "calendar_occurrences.restore_exclusion"
+            },
+            "arguments": {
+              "$ref": "#/$defs/occurrenceMutationInput"
+            },
+            "requestState": {
+              "type": "string",
+              "minLength": 1
+            },
+            "inputResponses": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/$defs/mrtrInputResponse"
+              }
+            },
+            "_meta": {
+              "type": "object",
+              "required": [
+                "io.modelcontextprotocol/protocolVersion",
+                "io.modelcontextprotocol/clientCapabilities"
+              ],
+              "properties": {
+                "progressToken": {
+                  "type": "number"
+                },
+                "io.modelcontextprotocol/protocolVersion": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "io.modelcontextprotocol/clientCapabilities": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "properties": {
+                    "elicitation": {
+                      "type": "object",
+                      "additionalProperties": true,
+                      "properties": {
+                        "form": {
+                          "type": "object",
+                          "additionalProperties": true
+                        },
+                        "url": {
+                          "type": "object",
+                          "additionalProperties": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "io.modelcontextprotocol/clientInfo": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": [
+                    "name",
+                    "version"
+                  ],
+                  "properties": {
+                    "name": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "version": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "title": {
+                      "type": "string"
+                    },
+                    "description": {
+                      "type": "string"
+                    },
+                    "websiteUrl": {
+                      "type": "string",
+                      "format": "uri"
+                    },
+                    "icons": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    }
+                  }
+                },
+                "io.modelcontextprotocol/logLevel": {
+                  "enum": [
+                    "debug",
+                    "info",
+                    "notice",
+                    "warning",
+                    "error",
+                    "critical",
+                    "alert",
+                    "emergency"
+                  ]
+                }
+              },
+              "additionalProperties": true
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "name",
+            "_meta",
+            "arguments"
+          ],
+          "properties": {
+            "name": {
+              "const": "calendar_occurrences.cancel"
+            },
+            "arguments": {
+              "$ref": "#/$defs/occurrenceMutationInput"
+            },
+            "requestState": {
+              "type": "string",
+              "minLength": 1
+            },
+            "inputResponses": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/$defs/mrtrInputResponse"
+              }
+            },
+            "_meta": {
+              "type": "object",
+              "required": [
+                "io.modelcontextprotocol/protocolVersion",
+                "io.modelcontextprotocol/clientCapabilities"
+              ],
+              "properties": {
+                "progressToken": {
+                  "type": "number"
+                },
+                "io.modelcontextprotocol/protocolVersion": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "io.modelcontextprotocol/clientCapabilities": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "properties": {
+                    "elicitation": {
+                      "type": "object",
+                      "additionalProperties": true,
+                      "properties": {
+                        "form": {
+                          "type": "object",
+                          "additionalProperties": true
+                        },
+                        "url": {
+                          "type": "object",
+                          "additionalProperties": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "io.modelcontextprotocol/clientInfo": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": [
+                    "name",
+                    "version"
+                  ],
+                  "properties": {
+                    "name": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "version": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "title": {
+                      "type": "string"
+                    },
+                    "description": {
+                      "type": "string"
+                    },
+                    "websiteUrl": {
+                      "type": "string",
+                      "format": "uri"
+                    },
+                    "icons": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    }
+                  }
+                },
+                "io.modelcontextprotocol/logLevel": {
+                  "enum": [
+                    "debug",
+                    "info",
+                    "notice",
+                    "warning",
+                    "error",
+                    "critical",
+                    "alert",
+                    "emergency"
+                  ]
+                }
+              },
+              "additionalProperties": true
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "name",
+            "_meta",
+            "arguments"
+          ],
+          "properties": {
+            "name": {
+              "const": "calendar_occurrences.restore_cancellation"
+            },
+            "arguments": {
+              "$ref": "#/$defs/occurrenceMutationInput"
+            },
+            "requestState": {
+              "type": "string",
+              "minLength": 1
+            },
+            "inputResponses": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/$defs/mrtrInputResponse"
+              }
+            },
+            "_meta": {
+              "type": "object",
+              "required": [
+                "io.modelcontextprotocol/protocolVersion",
+                "io.modelcontextprotocol/clientCapabilities"
+              ],
+              "properties": {
+                "progressToken": {
+                  "type": "number"
+                },
+                "io.modelcontextprotocol/protocolVersion": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "io.modelcontextprotocol/clientCapabilities": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "properties": {
+                    "elicitation": {
+                      "type": "object",
+                      "additionalProperties": true,
+                      "properties": {
+                        "form": {
+                          "type": "object",
+                          "additionalProperties": true
+                        },
+                        "url": {
+                          "type": "object",
+                          "additionalProperties": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "io.modelcontextprotocol/clientInfo": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": [
+                    "name",
+                    "version"
+                  ],
+                  "properties": {
+                    "name": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "version": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "title": {
+                      "type": "string"
+                    },
+                    "description": {
+                      "type": "string"
+                    },
+                    "websiteUrl": {
+                      "type": "string",
+                      "format": "uri"
+                    },
+                    "icons": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    }
+                  }
+                },
+                "io.modelcontextprotocol/logLevel": {
+                  "enum": [
+                    "debug",
+                    "info",
+                    "notice",
+                    "warning",
+                    "error",
+                    "critical",
+                    "alert",
+                    "emergency"
+                  ]
+                }
+              },
+              "additionalProperties": true
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "name",
+            "_meta",
+            "arguments"
+          ],
+          "properties": {
+            "name": {
+              "const": "calendar_resources.move"
+            },
+            "arguments": {
+              "$ref": "#/$defs/semanticMoveInput"
+            },
+            "requestState": {
+              "type": "string",
+              "minLength": 1
+            },
+            "inputResponses": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/$defs/mrtrInputResponse"
+              }
+            },
+            "_meta": {
+              "type": "object",
+              "required": [
+                "io.modelcontextprotocol/protocolVersion",
+                "io.modelcontextprotocol/clientCapabilities"
+              ],
+              "properties": {
+                "progressToken": {
+                  "type": "number"
+                },
+                "io.modelcontextprotocol/protocolVersion": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "io.modelcontextprotocol/clientCapabilities": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "properties": {
+                    "elicitation": {
+                      "type": "object",
+                      "additionalProperties": true,
+                      "properties": {
+                        "form": {
+                          "type": "object",
+                          "additionalProperties": true
+                        },
+                        "url": {
+                          "type": "object",
+                          "additionalProperties": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "io.modelcontextprotocol/clientInfo": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": [
+                    "name",
+                    "version"
+                  ],
+                  "properties": {
+                    "name": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "version": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "title": {
+                      "type": "string"
+                    },
+                    "description": {
+                      "type": "string"
+                    },
+                    "websiteUrl": {
+                      "type": "string",
+                      "format": "uri"
+                    },
+                    "icons": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    }
+                  }
+                },
+                "io.modelcontextprotocol/logLevel": {
+                  "enum": [
+                    "debug",
+                    "info",
+                    "notice",
+                    "warning",
+                    "error",
+                    "critical",
+                    "alert",
+                    "emergency"
+                  ]
+                }
+              },
+              "additionalProperties": true
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "name",
+            "_meta",
+            "arguments"
+          ],
+          "properties": {
+            "name": {
+              "const": "calendar_resources.delete"
+            },
+            "arguments": {
+              "$ref": "#/$defs/deleteInput"
+            },
+            "requestState": {
+              "type": "string",
+              "minLength": 1
+            },
+            "inputResponses": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/$defs/mrtrInputResponse"
+              }
+            },
+            "_meta": {
+              "type": "object",
+              "required": [
+                "io.modelcontextprotocol/protocolVersion",
+                "io.modelcontextprotocol/clientCapabilities"
+              ],
+              "properties": {
+                "progressToken": {
+                  "type": "number"
+                },
+                "io.modelcontextprotocol/protocolVersion": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "io.modelcontextprotocol/clientCapabilities": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "properties": {
+                    "elicitation": {
+                      "type": "object",
+                      "additionalProperties": true,
+                      "properties": {
+                        "form": {
+                          "type": "object",
+                          "additionalProperties": true
+                        },
+                        "url": {
+                          "type": "object",
+                          "additionalProperties": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "io.modelcontextprotocol/clientInfo": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": [
+                    "name",
+                    "version"
+                  ],
+                  "properties": {
+                    "name": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "version": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "title": {
+                      "type": "string"
+                    },
+                    "description": {
+                      "type": "string"
+                    },
+                    "websiteUrl": {
+                      "type": "string",
+                      "format": "uri"
+                    },
+                    "icons": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    }
+                  }
+                },
+                "io.modelcontextprotocol/logLevel": {
+                  "enum": [
+                    "debug",
+                    "info",
+                    "notice",
+                    "warning",
+                    "error",
+                    "critical",
+                    "alert",
+                    "emergency"
+                  ]
+                }
+              },
+              "additionalProperties": true
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "name",
+            "_meta",
+            "arguments"
+          ],
+          "properties": {
+            "name": {
+              "const": "calendar_resources.exact_get"
+            },
+            "arguments": {
+              "$ref": "#/$defs/resourceAddressInput"
+            },
+            "requestState": {
+              "type": "string",
+              "minLength": 1
+            },
+            "inputResponses": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/$defs/mrtrInputResponse"
+              }
+            },
+            "_meta": {
+              "type": "object",
+              "required": [
+                "io.modelcontextprotocol/protocolVersion",
+                "io.modelcontextprotocol/clientCapabilities"
+              ],
+              "properties": {
+                "progressToken": {
+                  "type": "number"
+                },
+                "io.modelcontextprotocol/protocolVersion": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "io.modelcontextprotocol/clientCapabilities": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "properties": {
+                    "elicitation": {
+                      "type": "object",
+                      "additionalProperties": true,
+                      "properties": {
+                        "form": {
+                          "type": "object",
+                          "additionalProperties": true
+                        },
+                        "url": {
+                          "type": "object",
+                          "additionalProperties": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "io.modelcontextprotocol/clientInfo": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": [
+                    "name",
+                    "version"
+                  ],
+                  "properties": {
+                    "name": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "version": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "title": {
+                      "type": "string"
+                    },
+                    "description": {
+                      "type": "string"
+                    },
+                    "websiteUrl": {
+                      "type": "string",
+                      "format": "uri"
+                    },
+                    "icons": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    }
+                  }
+                },
+                "io.modelcontextprotocol/logLevel": {
+                  "enum": [
+                    "debug",
+                    "info",
+                    "notice",
+                    "warning",
+                    "error",
+                    "critical",
+                    "alert",
+                    "emergency"
+                  ]
+                }
+              },
+              "additionalProperties": true
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "name",
+            "_meta",
+            "arguments"
+          ],
+          "properties": {
+            "name": {
+              "const": "calendar_resources.exact_create"
+            },
+            "arguments": {
+              "$ref": "#/$defs/exactCreateInput"
+            },
+            "requestState": {
+              "type": "string",
+              "minLength": 1
+            },
+            "inputResponses": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/$defs/mrtrInputResponse"
+              }
+            },
+            "_meta": {
+              "type": "object",
+              "required": [
+                "io.modelcontextprotocol/protocolVersion",
+                "io.modelcontextprotocol/clientCapabilities"
+              ],
+              "properties": {
+                "progressToken": {
+                  "type": "number"
+                },
+                "io.modelcontextprotocol/protocolVersion": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "io.modelcontextprotocol/clientCapabilities": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "properties": {
+                    "elicitation": {
+                      "type": "object",
+                      "additionalProperties": true,
+                      "properties": {
+                        "form": {
+                          "type": "object",
+                          "additionalProperties": true
+                        },
+                        "url": {
+                          "type": "object",
+                          "additionalProperties": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "io.modelcontextprotocol/clientInfo": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": [
+                    "name",
+                    "version"
+                  ],
+                  "properties": {
+                    "name": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "version": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "title": {
+                      "type": "string"
+                    },
+                    "description": {
+                      "type": "string"
+                    },
+                    "websiteUrl": {
+                      "type": "string",
+                      "format": "uri"
+                    },
+                    "icons": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    }
+                  }
+                },
+                "io.modelcontextprotocol/logLevel": {
+                  "enum": [
+                    "debug",
+                    "info",
+                    "notice",
+                    "warning",
+                    "error",
+                    "critical",
+                    "alert",
+                    "emergency"
+                  ]
+                }
+              },
+              "additionalProperties": true
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "name",
+            "_meta",
+            "arguments"
+          ],
+          "properties": {
+            "name": {
+              "const": "calendar_resources.exact_replace"
+            },
+            "arguments": {
+              "$ref": "#/$defs/exactReplaceInput"
+            },
+            "requestState": {
+              "type": "string",
+              "minLength": 1
+            },
+            "inputResponses": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/$defs/mrtrInputResponse"
+              }
+            },
+            "_meta": {
+              "type": "object",
+              "required": [
+                "io.modelcontextprotocol/protocolVersion",
+                "io.modelcontextprotocol/clientCapabilities"
+              ],
+              "properties": {
+                "progressToken": {
+                  "type": "number"
+                },
+                "io.modelcontextprotocol/protocolVersion": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "io.modelcontextprotocol/clientCapabilities": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "properties": {
+                    "elicitation": {
+                      "type": "object",
+                      "additionalProperties": true,
+                      "properties": {
+                        "form": {
+                          "type": "object",
+                          "additionalProperties": true
+                        },
+                        "url": {
+                          "type": "object",
+                          "additionalProperties": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "io.modelcontextprotocol/clientInfo": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": [
+                    "name",
+                    "version"
+                  ],
+                  "properties": {
+                    "name": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "version": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "title": {
+                      "type": "string"
+                    },
+                    "description": {
+                      "type": "string"
+                    },
+                    "websiteUrl": {
+                      "type": "string",
+                      "format": "uri"
+                    },
+                    "icons": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    }
+                  }
+                },
+                "io.modelcontextprotocol/logLevel": {
+                  "enum": [
+                    "debug",
+                    "info",
+                    "notice",
+                    "warning",
+                    "error",
+                    "critical",
+                    "alert",
+                    "emergency"
+                  ]
+                }
+              },
+              "additionalProperties": true
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "name",
+            "_meta",
+            "arguments"
+          ],
+          "properties": {
+            "name": {
+              "const": "calendar_resources.exact_move"
+            },
+            "arguments": {
+              "$ref": "#/$defs/exactMoveInput"
+            },
+            "requestState": {
+              "type": "string",
+              "minLength": 1
+            },
+            "inputResponses": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/$defs/mrtrInputResponse"
+              }
+            },
+            "_meta": {
+              "type": "object",
+              "required": [
+                "io.modelcontextprotocol/protocolVersion",
+                "io.modelcontextprotocol/clientCapabilities"
+              ],
+              "properties": {
+                "progressToken": {
+                  "type": "number"
+                },
+                "io.modelcontextprotocol/protocolVersion": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "io.modelcontextprotocol/clientCapabilities": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "properties": {
+                    "elicitation": {
+                      "type": "object",
+                      "additionalProperties": true,
+                      "properties": {
+                        "form": {
+                          "type": "object",
+                          "additionalProperties": true
+                        },
+                        "url": {
+                          "type": "object",
+                          "additionalProperties": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "io.modelcontextprotocol/clientInfo": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": [
+                    "name",
+                    "version"
+                  ],
+                  "properties": {
+                    "name": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "version": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "title": {
+                      "type": "string"
+                    },
+                    "description": {
+                      "type": "string"
+                    },
+                    "websiteUrl": {
+                      "type": "string",
+                      "format": "uri"
+                    },
+                    "icons": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    }
+                  }
+                },
+                "io.modelcontextprotocol/logLevel": {
+                  "enum": [
+                    "debug",
+                    "info",
+                    "notice",
+                    "warning",
+                    "error",
+                    "critical",
+                    "alert",
+                    "emergency"
+                  ]
+                }
+              },
+              "additionalProperties": true
+            }
+          }
+        }
+      ]
+    },
+    "outerResult": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "resultType"
+      ],
+      "properties": {
+        "resultType": {
+          "const": "input_required"
+        },
+        "requestState": {
+          "type": "string",
+          "minLength": 1
+        },
+        "inputRequests": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/mrtrInputRequest"
+          }
+        }
+      },
+      "anyOf": [
+        {
+          "required": [
+            "inputRequests"
+          ]
+        },
+        {
+          "required": [
+            "requestState"
+          ]
+        }
+      ]
+    }
+  },
+  "environment": [
+    {
+      "name": "CALDAV_URL",
+      "required": true
+    },
+    {
+      "name": "CALDAV_USERNAME",
+      "required": true
+    },
+    {
+      "name": "CALDAV_PASSWORD",
+      "required": true,
+      "secret": true
+    },
+    {
+      "name": "CALDAV_CALENDAR_HREFS",
+      "required": false,
+      "description": "Exact canonical-href allowlist"
+    },
+    {
+      "name": "CALDAV_DEFAULT_TODO_CALENDAR_NAME",
+      "required": false
+    },
+    {
+      "name": "CALDAV_DEFAULT_EVENT_CALENDAR_NAME",
+      "required": false
+    },
+    {
+      "name": "CALDAV_EVALUATION_TIME_ZONE",
+      "required": false,
+      "description": "Explicit IANA zone for bounded Calendar Entity Starts and every Occurrence or To-do Start under the configured Temporal Evaluation Context"
+    },
+    {
+      "name": "CALDAV_INTEROPERABILITY_PROFILE",
+      "required": false,
+      "description": "Verified server profile; radicale-3.7.8 enables server-authoritative MOVE"
+    },
+    {
+      "name": "CALDAV_EXPOSE_EXACT_TOOLS",
+      "required": false,
+      "type": "boolean"
+    }
+  ],
+  "retiredEnvironment": [
+    "CALDAV_TASK_LISTS",
+    "CALDAV_DEFAULT_TASK_LIST",
+    "CALDAV_EXPOSE_ADVANCED_TOOLS"
+  ],
+  "discoveryOrder": [
+    "calendars.list",
+    "calendar_entities.query",
+    "calendar_occurrences.query",
+    "todos.query",
+    "calendar_resources.get",
+    "events.create",
+    "events.patch",
+    "todos.create",
+    "todos.patch",
+    "todos.complete",
+    "calendar_occurrences.add",
+    "calendar_occurrences.exclude",
+    "calendar_occurrences.restore_exclusion",
+    "calendar_occurrences.cancel",
+    "calendar_occurrences.restore_cancellation",
+    "calendar_resources.move",
+    "calendar_resources.delete"
+  ],
+  "exactTools": [
+    "calendar_resources.exact_get",
+    "calendar_resources.exact_create",
+    "calendar_resources.exact_replace",
+    "calendar_resources.exact_move"
+  ],
+  "tools": [
+    {
+      "name": "calendars.list",
+      "cache": {
+        "ttlMs": 30000,
+        "cacheScope": "private"
+      },
+      "inputSchema": {
+        "$ref": "#/$defs/calendarScopeInput"
+      },
+      "outputSchema": {
+        "$ref": "#/$defs/calendarListOutcome"
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      },
+      "description": "List every configured Calendar with independent Event and To-do capability evidence."
+    },
+    {
+      "name": "calendar_entities.query",
+      "cache": {
+        "ttlMs": 5000,
+        "cacheScope": "private"
+      },
+      "inputSchema": {
+        "$ref": "#/$defs/entityQueryInput"
+      },
+      "outputSchema": {
+        "$ref": "#/$defs/entityQueryOutcome"
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      },
+      "description": "Start one Calendar Entity query or continue its immutable Query Result Snapshot. A bounded Start requires an explicit IANA Temporal Evaluation Context from evaluationTimeZone or validated configuration; Continue repeats the frozen context without CalDAV or semantic work."
+    },
+    {
+      "name": "calendar_occurrences.query",
+      "cache": {
+        "ttlMs": 5000,
+        "cacheScope": "private"
+      },
+      "inputSchema": {
+        "$ref": "#/$defs/occurrenceQueryInput"
+      },
+      "outputSchema": {
+        "$ref": "#/$defs/occurrenceQueryOutcome"
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      },
+      "description": "Start one bounded Occurrence query or continue its immutable Query Result Snapshot. Start evaluates recurrence once under an explicit IANA Temporal Evaluation Context from evaluationTimeZone or validated configuration; Continue accepts only cursor and optional pageSize and performs no CalDAV or semantic work."
+    },
+    {
+      "name": "todos.query",
+      "cache": {
+        "ttlMs": 5000,
+        "cacheScope": "private"
+      },
+      "inputSchema": {
+        "$ref": "#/$defs/todoQueryInput"
+      },
+      "outputSchema": {
+        "$ref": "#/$defs/todoQueryOutcome"
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      },
+      "description": "Start one compact To-do query or continue its immutable Query Result Snapshot. A Start resolves an explicit IANA Temporal Evaluation Context before CalDAV work and uses one VTODO-only authoritative corpus; Continue repeats the frozen page context without CalDAV or semantic work."
+    },
+    {
+      "name": "calendar_resources.get",
+      "cache": {
+        "ttlMs": 0,
+        "cacheScope": "private"
+      },
+      "inputSchema": {
+        "$ref": "#/$defs/resourceAddressInput"
+      },
+      "outputSchema": {
+        "$ref": "#/$defs/resourceOutcome"
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      },
+      "description": "Read one semantic Calendar Object Resource by an explicitly confirmed absolute href."
+    },
+    {
+      "name": "events.create",
+      "cache": {
+        "ttlMs": 0,
+        "cacheScope": "private"
+      },
+      "inputSchema": {
+        "$ref": "#/$defs/eventCreateInput"
+      },
+      "outputSchema": {
+        "$ref": "#/$defs/snapshotMutationOutcome"
+      },
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      },
+      "description": "Create one typed Event in the default or explicitly selected Calendar."
+    },
+    {
+      "name": "events.patch",
+      "cache": {
+        "ttlMs": 0,
+        "cacheScope": "private"
+      },
+      "inputSchema": {
+        "$ref": "#/$defs/eventPatchInput"
+      },
+      "outputSchema": {
+        "$ref": "#/$defs/snapshotMutationOutcome"
+      },
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": true
+      },
+      "description": "Apply a revision-bound semantic patch to one Event resource at an explicitly supplied absolute snapshot href."
+    },
+    {
+      "name": "todos.create",
+      "cache": {
+        "ttlMs": 0,
+        "cacheScope": "private"
+      },
+      "inputSchema": {
+        "$ref": "#/$defs/todoCreateInput"
+      },
+      "outputSchema": {
+        "$ref": "#/$defs/snapshotMutationOutcome"
+      },
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      },
+      "description": "Create one typed To-do in the default or explicitly selected Calendar."
+    },
+    {
+      "name": "todos.patch",
+      "cache": {
+        "ttlMs": 0,
+        "cacheScope": "private"
+      },
+      "inputSchema": {
+        "$ref": "#/$defs/todoPatchInput"
+      },
+      "outputSchema": {
+        "$ref": "#/$defs/snapshotMutationOutcome"
+      },
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": true
+      },
+      "description": "Apply a revision-bound semantic patch to one To-do resource at an explicitly supplied absolute snapshot href; completion is reserved for todos.complete."
+    },
+    {
+      "name": "todos.complete",
+      "cache": {
+        "ttlMs": 0,
+        "cacheScope": "private"
+      },
+      "inputSchema": {
+        "$ref": "#/$defs/completionInput"
+      },
+      "outputSchema": {
+        "$ref": "#/$defs/snapshotMutationOutcome"
+      },
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      },
+      "description": "Record completion for one revision-bound To-do or identified To-do occurrence at an explicitly supplied absolute snapshot href."
+    },
+    {
+      "name": "calendar_occurrences.add",
+      "cache": {
+        "ttlMs": 0,
+        "cacheScope": "private"
+      },
+      "inputSchema": {
+        "$ref": "#/$defs/occurrenceMutationInput"
+      },
+      "outputSchema": {
+        "$ref": "#/$defs/snapshotMutationOutcome"
+      },
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      },
+      "description": "Add one explicit recurrence identity through recurrence data."
+    },
+    {
+      "name": "calendar_occurrences.exclude",
+      "cache": {
+        "ttlMs": 0,
+        "cacheScope": "private"
+      },
+      "inputSchema": {
+        "$ref": "#/$defs/occurrenceMutationInput"
+      },
+      "outputSchema": {
+        "$ref": "#/$defs/snapshotMutationOutcome"
+      },
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": true
+      },
+      "description": "Add one explicit exclusion to a revision-bound recurrence set."
+    },
+    {
+      "name": "calendar_occurrences.restore_exclusion",
+      "cache": {
+        "ttlMs": 0,
+        "cacheScope": "private"
+      },
+      "inputSchema": {
+        "$ref": "#/$defs/occurrenceMutationInput"
+      },
+      "outputSchema": {
+        "$ref": "#/$defs/snapshotMutationOutcome"
+      },
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      },
+      "description": "Remove only one explicit recurrence exclusion."
+    },
+    {
+      "name": "calendar_occurrences.cancel",
+      "cache": {
+        "ttlMs": 0,
+        "cacheScope": "private"
+      },
+      "inputSchema": {
+        "$ref": "#/$defs/occurrenceMutationInput"
+      },
+      "outputSchema": {
+        "$ref": "#/$defs/snapshotMutationOutcome"
+      },
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": true
+      },
+      "description": "Create or update one cancelled recurrence override."
+    },
+    {
+      "name": "calendar_occurrences.restore_cancellation",
+      "cache": {
+        "ttlMs": 0,
+        "cacheScope": "private"
+      },
+      "inputSchema": {
+        "$ref": "#/$defs/occurrenceMutationInput"
+      },
+      "outputSchema": {
+        "$ref": "#/$defs/snapshotMutationOutcome"
+      },
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      },
+      "description": "Restore only one cancelled recurrence override."
+    },
+    {
+      "name": "calendar_resources.move",
+      "cache": {
+        "ttlMs": 0,
+        "cacheScope": "private"
+      },
+      "inputSchema": {
+        "$ref": "#/$defs/semanticMoveInput"
+      },
+      "outputSchema": {
+        "$ref": "#/$defs/snapshotMutationOutcome"
+      },
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": true
+      },
+      "description": "Move one revision-bound semantic resource with server-authoritative preconditions and bounded bilateral reconciliation; requires a verified interoperability profile."
+    },
+    {
+      "name": "calendar_resources.delete",
+      "cache": {
+        "ttlMs": 0,
+        "cacheScope": "private"
+      },
+      "inputSchema": {
+        "$ref": "#/$defs/deleteInput"
+      },
+      "outputSchema": {
+        "$ref": "#/$defs/deleteMutationOutcome"
+      },
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": true
+      },
+      "description": "Confirm and delete one revision-bound Calendar Object Resource."
+    },
+    {
+      "name": "calendar_resources.exact_get",
+      "cache": {
+        "ttlMs": 0,
+        "cacheScope": "private"
+      },
+      "optIn": true,
+      "inputSchema": {
+        "$ref": "#/$defs/resourceAddressInput"
+      },
+      "outputSchema": {
+        "$ref": "#/$defs/exactGetOutcome"
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      },
+      "description": "Read one confirmed absolute href through a protected MCP resource link."
+    },
+    {
+      "name": "calendar_resources.exact_create",
+      "cache": {
+        "ttlMs": 0,
+        "cacheScope": "private"
+      },
+      "optIn": true,
+      "inputSchema": {
+        "$ref": "#/$defs/exactCreateInput"
+      },
+      "outputSchema": {
+        "$ref": "#/$defs/exactSnapshotMutationOutcome"
+      },
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      },
+      "description": "Create a complete caller-authored Calendar Object Resource at an explicitly provided absolute destination resource href."
+    },
+    {
+      "name": "calendar_resources.exact_replace",
+      "cache": {
+        "ttlMs": 0,
+        "cacheScope": "private"
+      },
+      "optIn": true,
+      "inputSchema": {
+        "$ref": "#/$defs/exactReplaceInput"
+      },
+      "outputSchema": {
+        "$ref": "#/$defs/exactSnapshotMutationOutcome"
+      },
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": true
+      },
+      "description": "Confirm and replace one revision-bound resource at its explicitly provided absolute href with a complete caller-authored Calendar Object Resource."
+    },
+    {
+      "name": "calendar_resources.exact_move",
+      "cache": {
+        "ttlMs": 0,
+        "cacheScope": "private"
+      },
+      "optIn": true,
+      "inputSchema": {
+        "$ref": "#/$defs/exactMoveInput"
+      },
+      "outputSchema": {
+        "$ref": "#/$defs/exactSnapshotMutationOutcome"
+      },
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": true
+      },
+      "description": "Review, confirm, and atomically move one strong-revision-bound complete resource to an explicitly provided absolute destination href with constant work and authoritative-byte verification."
+    }
+  ],
+  "$defs": {
+    "calendarReference": {
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "by",
+            "name"
+          ],
+          "properties": {
+            "by": {
+              "const": "name"
+            },
+            "name": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "by",
+            "href"
+          ],
+          "properties": {
+            "by": {
+              "const": "href"
+            },
+            "href": {
+              "type": "string",
+              "format": "uri"
+            }
+          }
+        }
+      ]
+    },
+    "calendarScope": {
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "mode"
+          ],
+          "properties": {
+            "mode": {
+              "const": "default"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "mode",
+            "calendar"
+          ],
+          "properties": {
+            "mode": {
+              "const": "selected"
+            },
+            "calendar": {
+              "$ref": "#/$defs/calendarReference"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "mode"
+          ],
+          "properties": {
+            "mode": {
+              "const": "all"
+            }
+          }
+        }
+      ]
+    },
+    "todoScope": {
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "mode",
+            "calendar"
+          ],
+          "properties": {
+            "mode": {
+              "const": "selected"
+            },
+            "calendar": {
+              "$ref": "#/$defs/calendarReference"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "mode"
+          ],
+          "properties": {
+            "mode": {
+              "const": "all"
+            }
+          }
+        }
+      ]
+    },
+    "calendarDestination": {
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "mode"
+          ],
+          "properties": {
+            "mode": {
+              "const": "default"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "mode",
+            "calendar"
+          ],
+          "properties": {
+            "mode": {
+              "const": "selected"
+            },
+            "calendar": {
+              "$ref": "#/$defs/calendarReference"
+            }
+          }
+        }
+      ]
+    },
+    "revisionReference": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "href",
+        "entityUid",
+        "entityKind",
+        "entityTag"
+      ],
+      "properties": {
+        "href": {
+          "type": "string",
+          "format": "uri"
+        },
+        "entityUid": {
+          "type": "string",
+          "minLength": 1
+        },
+        "entityKind": {
+          "enum": [
+            "event",
+            "todo"
+          ]
+        },
+        "entityTag": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "eventRevisionReference": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "href",
+        "entityUid",
+        "entityKind",
+        "entityTag"
+      ],
+      "properties": {
+        "href": {
+          "type": "string",
+          "format": "uri"
+        },
+        "entityUid": {
+          "type": "string",
+          "minLength": 1
+        },
+        "entityKind": {
+          "const": "event"
+        },
+        "entityTag": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "todoRevisionReference": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "href",
+        "entityUid",
+        "entityKind",
+        "entityTag"
+      ],
+      "properties": {
+        "href": {
+          "type": "string",
+          "format": "uri"
+        },
+        "entityUid": {
+          "type": "string",
+          "minLength": 1
+        },
+        "entityKind": {
+          "const": "todo"
+        },
+        "entityTag": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "temporalValue": {
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "kind",
+            "value"
+          ],
+          "properties": {
+            "kind": {
+              "const": "date"
+            },
+            "value": {
+              "type": "string",
+              "pattern": "^\\d{4}-(?:0[1-9]|1[0-2])-(?:0[1-9]|[12]\\d|3[01])$"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "kind",
+            "value"
+          ],
+          "properties": {
+            "kind": {
+              "const": "floatingDateTime"
+            },
+            "value": {
+              "type": "string",
+              "pattern": "^\\d{4}-(?:0[1-9]|1[0-2])-(?:0[1-9]|[12]\\d|3[01])T(?:[01]\\d|2[0-3]):[0-5]\\d:[0-5]\\d(?:\\.\\d+)?$"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "kind",
+            "value"
+          ],
+          "properties": {
+            "kind": {
+              "const": "utcDateTime"
+            },
+            "value": {
+              "type": "string",
+              "pattern": "^\\d{4}-(?:0[1-9]|1[0-2])-(?:0[1-9]|[12]\\d|3[01])T(?:[01]\\d|2[0-3]):[0-5]\\d:[0-5]\\d(?:\\.\\d+)?Z$"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "kind",
+            "value",
+            "timeZoneId"
+          ],
+          "properties": {
+            "kind": {
+              "const": "zonedDateTime"
+            },
+            "value": {
+              "type": "string",
+              "pattern": "^\\d{4}-(?:0[1-9]|1[0-2])-(?:0[1-9]|[12]\\d|3[01])T(?:[01]\\d|2[0-3]):[0-5]\\d:[0-5]\\d(?:\\.\\d+)?$"
+            },
+            "timeZoneId": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        }
+      ]
+    },
+    "utcTemporalValue": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "value"
+      ],
+      "properties": {
+        "kind": {
+          "const": "utcDateTime"
+        },
+        "value": {
+          "type": "string",
+          "pattern": "^\\d{4}-(?:0[1-9]|1[0-2])-(?:0[1-9]|[12]\\d|3[01])T(?:[01]\\d|2[0-3]):[0-5]\\d:[0-5]\\d(?:\\.\\d+)?Z$"
+        }
+      }
+    },
+    "effectiveTemporalValue": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/temporalValue"
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["source", "evaluatedUtc"],
+          "properties": {
+            "source": {"$ref": "#/$defs/temporalValue"},
+            "evaluatedUtc": {"$ref": "#/$defs/utcTemporalValue"}
+          }
+        }
+      ]
+    },
+    "utcTemporalProperty": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "value",
+        "parameters"
+      ],
+      "properties": {
+        "value": {
+          "$ref": "#/$defs/utcTemporalValue"
+        },
+        "parameters": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/icalParameter"
+          }
+        }
+      }
+    },
+    "geoProperty": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "value",
+        "parameters"
+      ],
+      "properties": {
+        "value": {
+          "$ref": "#/$defs/geo"
+        },
+        "parameters": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/icalParameter"
+          }
+        }
+      }
+    },
+    "nonNegativeIntegerProperty": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "value",
+        "parameters"
+      ],
+      "properties": {
+        "value": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "parameters": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/icalParameter"
+          }
+        }
+      }
+    },
+    "positiveIntegerProperty": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "value",
+        "parameters"
+      ],
+      "properties": {
+        "value": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "parameters": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/icalParameter"
+          }
+        }
+      }
+    },
+    "priorityProperty": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "value",
+        "parameters"
+      ],
+      "properties": {
+        "value": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 9
+        },
+        "parameters": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/icalParameter"
+          }
+        }
+      }
+    },
+    "textListProperty": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "value",
+        "parameters"
+      ],
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "parameters": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/icalParameter"
+          }
+        }
+      }
+    },
+    "durationProperty": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "value",
+        "parameters"
+      ],
+      "properties": {
+        "value": {
+          "type": "string",
+          "minLength": 1
+        },
+        "parameters": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/icalParameter"
+          }
+        }
+      }
+    },
+    "calendarScopeInput": {
+      "type": "object",
+      "additionalProperties": false
+    },
+    "entityQueryInput": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "scope": {
+          "$ref": "#/$defs/todoScope"
+        },
+        "entityKinds": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 2,
+          "uniqueItems": true,
+          "items": {
+            "enum": [
+              "event",
+              "todo"
+            ]
+          }
+        },
+        "from": {
+          "$ref": "#/$defs/utcTemporalValue"
+        },
+        "to": {
+          "$ref": "#/$defs/utcTemporalValue"
+        },
+        "evaluationTimeZone": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 255,
+          "description": "Caller IANA Temporal Evaluation Context override for a bounded Start"
+        },
+        "cursor": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 2048
+        },
+        "pageSize": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 200
+        }
+      },
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "scope",
+            "entityKinds"
+          ],
+          "properties": {
+            "scope": {
+              "$ref": "#/$defs/todoScope"
+            },
+            "entityKinds": {
+              "type": "array",
+              "minItems": 1,
+              "maxItems": 2,
+              "uniqueItems": true,
+              "items": {
+                "enum": [
+                  "event",
+                  "todo"
+                ]
+              }
+            },
+            "from": {
+              "$ref": "#/$defs/utcTemporalValue"
+            },
+            "to": {
+              "$ref": "#/$defs/utcTemporalValue"
+            },
+            "evaluationTimeZone": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 255,
+              "description": "Caller IANA Temporal Evaluation Context override for this bounded Start"
+            },
+            "pageSize": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 200
+            }
+          },
+          "allOf": [
+            {
+              "if": {
+                "required": [
+                  "from"
+                ]
+              },
+              "then": {
+                "required": [
+                  "to"
+                ]
+              }
+            },
+            {
+              "if": {
+                "required": [
+                  "to"
+                ]
+              },
+              "then": {
+                "required": [
+                  "from"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "cursor"
+          ],
+          "properties": {
+            "cursor": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 2048
+            },
+            "pageSize": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 200
+            }
+          }
+        }
+      ]
+    },
+    "todoQueryInput": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "scope": {
+          "$ref": "#/$defs/todoScope"
+        },
+        "completionStates": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "enum": [
+              "open",
+              "completed",
+              "cancelled",
+              "indeterminate"
+            ]
+          }
+        },
+        "from": {
+          "$ref": "#/$defs/utcTemporalValue"
+        },
+        "to": {
+          "$ref": "#/$defs/utcTemporalValue"
+        },
+        "evaluationTimeZone": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 255
+        },
+        "dueFrom": {
+          "$ref": "#/$defs/utcTemporalValue"
+        },
+        "dueTo": {
+          "$ref": "#/$defs/utcTemporalValue"
+        },
+        "projection": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "enum": [
+              "summary",
+              "status",
+              "completedAt",
+              "percentComplete",
+              "due",
+              "priority",
+              "categories",
+              "start",
+              "description",
+              "recurrence"
+            ]
+          }
+        },
+        "pageSize": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 200
+        },
+        "cursor": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 2048
+        }
+      },
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "scope"
+          ],
+          "properties": {
+            "scope": {
+              "$ref": "#/$defs/todoScope"
+            },
+            "completionStates": {
+              "type": "array",
+              "minItems": 1,
+              "uniqueItems": true,
+              "items": {
+                "enum": [
+                  "open",
+                  "completed",
+                  "cancelled",
+                  "indeterminate"
+                ]
+              }
+            },
+            "from": {
+              "$ref": "#/$defs/utcTemporalValue"
+            },
+            "to": {
+              "$ref": "#/$defs/utcTemporalValue"
+            },
+            "evaluationTimeZone": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 255
+            },
+            "dueFrom": {
+              "$ref": "#/$defs/utcTemporalValue"
+            },
+            "dueTo": {
+              "$ref": "#/$defs/utcTemporalValue"
+            },
+            "projection": {
+              "type": "array",
+              "minItems": 1,
+              "uniqueItems": true,
+              "items": {
+                "enum": [
+                  "summary",
+                  "status",
+                  "completedAt",
+                  "percentComplete",
+                  "due",
+                  "priority",
+                  "categories",
+                  "start",
+                  "description",
+                  "recurrence"
+                ]
+              }
+            },
+            "pageSize": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 200
+            }
+          },
+          "allOf": [
+            {
+              "if": {
+                "required": [
+                  "from"
+                ]
+              },
+              "then": {
+                "required": [
+                  "to"
+                ]
+              }
+            },
+            {
+              "if": {
+                "required": [
+                  "to"
+                ]
+              },
+              "then": {
+                "required": [
+                  "from"
+                ]
+              }
+            },
+            {
+              "if": {
+                "required": [
+                  "dueFrom"
+                ]
+              },
+              "then": {
+                "required": [
+                  "dueTo"
+                ]
+              }
+            },
+            {
+              "if": {
+                "required": [
+                  "dueTo"
+                ]
+              },
+              "then": {
+                "required": [
+                  "dueFrom"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "cursor"
+          ],
+          "properties": {
+            "cursor": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 2048
+            },
+            "pageSize": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 200
+            }
+          }
+        }
+      ]
+    },
+    "todoQueryItem": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "resultKind",
+        "completionState",
+        "completionTarget",
+        "diagnostics"
+      ],
+      "properties": {
+        "resultKind": {
+          "enum": [
+            "entity",
+            "occurrence",
+            "unresolved"
+          ]
+        },
+        "uid": {
+          "type": "string",
+          "minLength": 1
+        },
+        "completionState": {
+          "enum": [
+            "open",
+            "completed",
+            "cancelled",
+            "indeterminate"
+          ]
+        },
+        "summary": {
+          "type": "string"
+        },
+        "status": {
+          "$ref": "#/$defs/openEnumValue"
+        },
+        "completedAt": {
+          "$ref": "#/$defs/temporalValue"
+        },
+        "percentComplete": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 100
+        },
+        "due": {
+          "$ref": "#/$defs/effectiveTemporalValue"
+        },
+        "priority": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 9
+        },
+        "categories": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "start": {
+          "$ref": "#/$defs/effectiveTemporalValue"
+        },
+        "description": {
+          "type": "string"
+        },
+        "recurrence": {
+          "$ref": "#/$defs/recurrenceSet"
+        },
+        "completionTarget": {
+          "$ref": "#/$defs/todoCompletionTarget"
+        },
+        "diagnostics": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/diagnostic"
+          }
+        }
+      }
+    },
+    "todoCompletionTarget": {
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["kind", "entityRevision"],
+          "properties": {
+            "kind": {"const": "direct"},
+            "entityRevision": {"$ref": "#/$defs/todoRevisionReference"},
+            "recurrenceIdentity": {"$ref": "#/$defs/todoRecurrenceIdentity"}
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["kind", "entityRevision"],
+          "properties": {
+            "kind": {"const": "occurrence_required"},
+            "entityRevision": {"$ref": "#/$defs/todoRevisionReference"}
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["kind", "resourceRevision"],
+          "properties": {
+            "kind": {"const": "unavailable"},
+            "resourceRevision": {"$ref": "#/$defs/resourceRevision"}
+          }
+        }
+      ]
+    },
+    "todoQuerySuccess": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "outcome",
+        "items",
+        "diagnostics",
+        "excludedIndeterminateCount",
+        "temporalEvaluationContext",
+        "pagination"
+      ],
+      "properties": {
+        "outcome": {
+          "const": "success"
+        },
+        "items": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/todoQueryItem"
+          }
+        },
+        "diagnostics": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/diagnostic"
+          }
+        },
+        "excludedIndeterminateCount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "temporalEvaluationContext": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "timeZone",
+            "source"
+          ],
+          "properties": {
+            "timeZone": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 255
+            },
+            "source": {
+              "enum": [
+                "caller",
+                "configuration"
+              ]
+            }
+          }
+        },
+        "pagination": {
+          "$ref": "#/$defs/entityQueryPagination"
+        }
+      }
+    },
+    "todoQueryOutcome": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/todoQuerySuccess"
+        },
+        {
+          "$ref": "#/$defs/errorOutcome"
+        }
+      ]
+    },
+    "occurrenceQueryInput": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "scope": {
+          "$ref": "#/$defs/calendarScope"
+        },
+        "from": {
+          "$ref": "#/$defs/utcTemporalValue"
+        },
+        "to": {
+          "$ref": "#/$defs/utcTemporalValue"
+        },
+        "evaluationTimeZone": {
+          "type": "string",
+          "minLength": 1
+        },
+        "pageSize": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 200
+        },
+        "cursor": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 2048
+        }
+      },
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "scope",
+            "from",
+            "to"
+          ],
+          "properties": {
+            "scope": {
+              "$ref": "#/$defs/calendarScope"
+            },
+            "from": {
+              "$ref": "#/$defs/utcTemporalValue"
+            },
+            "to": {
+              "$ref": "#/$defs/utcTemporalValue"
+            },
+            "evaluationTimeZone": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 255
+            },
+            "pageSize": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 200
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "cursor"
+          ],
+          "properties": {
+            "cursor": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 2048
+            },
+            "pageSize": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 200
+            }
+          }
+        }
+      ]
+    },
+    "resourceAddressInput": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "href"
+      ],
+      "properties": {
+        "href": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "openEnumValue": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "rawValue"
+      ],
+      "properties": {
+        "kind": {
+          "type": "string",
+          "minLength": 1
+        },
+        "rawValue": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "openEnumProperty": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["value", "parameters"],
+      "properties": {
+        "value": { "$ref": "#/$defs/openEnumValue" },
+        "parameters": { "type": "array", "items": { "$ref": "#/$defs/icalParameter" } }
+      }
+    },
+    "effectiveOpenEnumValue": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "effectiveValue"
+      ],
+      "properties": {
+        "explicitValue": {
+          "$ref": "#/$defs/openEnumValue"
+        },
+        "effectiveValue": {
+          "$ref": "#/$defs/openEnumValue"
+        }
+      }
+    },
+    "effectiveBooleanValue": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "effectiveValue"
+      ],
+      "properties": {
+        "explicitValue": {
+          "type": "boolean"
+        },
+        "effectiveValue": {
+          "type": "boolean"
+        }
+      }
+    },
+    "eventFields": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [],
+      "properties": {
+        "summary": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "start": {
+          "$ref": "#/$defs/temporalValue"
+        },
+        "end": {
+          "$ref": "#/$defs/temporalValue"
+        },
+        "duration": {
+          "type": "string"
+        },
+        "location": {
+          "type": "string"
+        },
+        "geo": {
+          "$ref": "#/$defs/geo"
+        },
+        "status": {
+          "$ref": "#/$defs/openEnumValue"
+        },
+        "transparency": {
+          "$ref": "#/$defs/openEnumValue"
+        },
+        "classification": {
+          "$ref": "#/$defs/openEnumValue"
+        },
+        "priority": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 9
+        },
+        "categories": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "recurrenceSet": {
+          "$ref": "#/$defs/recurrenceSet"
+        },
+        "structuredData": {
+          "$ref": "#/$defs/structuredData"
+        }
+      }
+    },
+    "todoFields": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [],
+      "properties": {
+        "summary": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "start": {
+          "$ref": "#/$defs/temporalValue"
+        },
+        "due": {
+          "$ref": "#/$defs/temporalValue"
+        },
+        "duration": {
+          "type": "string"
+        },
+        "status": {
+          "$ref": "#/$defs/openEnumValue"
+        },
+        "classification": {
+          "$ref": "#/$defs/openEnumValue"
+        },
+        "priority": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 9
+        },
+        "percentComplete": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 100
+        },
+        "categories": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "recurrenceSet": {
+          "$ref": "#/$defs/recurrenceSet"
+        },
+        "structuredData": {
+          "$ref": "#/$defs/structuredData"
+        }
+      }
+    },
+    "eventOverrideFields": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/eventFields"
+        },
+        {
+          "not": {
+            "required": [
+              "recurrenceSet"
+            ]
+          }
+        }
+      ]
+    },
+    "todoOverrideFields": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/todoFields"
+        },
+        {
+          "not": {
+            "required": [
+              "recurrenceSet"
+            ]
+          }
+        }
+      ]
+    },
+    "eventInputFields": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "summary": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "start": {
+          "$ref": "#/$defs/temporalValue"
+        },
+        "end": {
+          "$ref": "#/$defs/temporalValue"
+        },
+        "duration": {
+          "type": "string"
+        },
+        "location": {
+          "type": "string"
+        },
+        "geo": {
+          "$ref": "#/$defs/geo"
+        },
+        "status": {
+          "type": "string"
+        },
+        "transparency": {
+          "type": "string"
+        },
+        "classification": {
+          "type": "string"
+        },
+        "priority": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 9
+        },
+        "categories": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "recurrenceSet": {
+          "$ref": "#/$defs/eventRecurrenceSetInput"
+        },
+        "structuredData": {
+          "$ref": "#/$defs/structuredDataInput"
+        }
+      }
+    },
+    "todoInputFields": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "summary": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "start": {
+          "$ref": "#/$defs/temporalValue"
+        },
+        "due": {
+          "$ref": "#/$defs/temporalValue"
+        },
+        "duration": {
+          "type": "string"
+        },
+        "status": {
+          "type": "string"
+        },
+        "priority": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 9
+        },
+        "categories": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "recurrenceSet": {
+          "$ref": "#/$defs/todoRecurrenceSetInput"
+        },
+        "structuredData": {
+          "$ref": "#/$defs/structuredDataInput"
+        }
+      }
+    },
+    "eventOverrideInputFields": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/eventInputFields"
+        },
+        {
+          "not": {
+            "required": [
+              "recurrenceSet"
+            ]
+          }
+        }
+      ]
+    },
+    "todoOverrideInputFields": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/todoInputFields"
+        },
+        {
+          "not": {
+            "required": [
+              "recurrenceSet"
+            ]
+          }
+        }
+      ]
+    },
+    "eventRecurrenceOverrideInput": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "recurrenceIdentity",
+        "status",
+        "fields"
+      ],
+      "properties": {
+        "recurrenceIdentity": {
+          "$ref": "#/$defs/recurrenceIdentity"
+        },
+        "range": {
+          "enum": [
+            "this-and-future"
+          ]
+        },
+        "status": {
+          "enum": [
+            "active",
+            "cancelled"
+          ]
+        },
+        "fields": {
+          "$ref": "#/$defs/eventOverrideInputFields"
+        }
+      }
+    },
+    "todoRecurrenceOverrideInput": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "recurrenceIdentity",
+        "status",
+        "fields"
+      ],
+      "properties": {
+        "recurrenceIdentity": {
+          "$ref": "#/$defs/recurrenceIdentity"
+        },
+        "range": {
+          "enum": [
+            "this-and-future"
+          ]
+        },
+        "status": {
+          "enum": [
+            "active",
+            "cancelled"
+          ]
+        },
+        "fields": {
+          "$ref": "#/$defs/todoOverrideInputFields"
+        }
+      }
+    },
+    "eventCreateEntity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "fields"
+      ],
+      "properties": {
+        "kind": {
+          "const": "event"
+        },
+        "uid": {
+          "type": "string",
+          "minLength": 1
+        },
+        "fields": {
+          "$ref": "#/$defs/eventInputFields"
+        }
+      }
+    },
+    "todoCreateEntity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "fields"
+      ],
+      "properties": {
+        "kind": {
+          "const": "todo"
+        },
+        "uid": {
+          "type": "string",
+          "minLength": 1
+        },
+        "fields": {
+          "$ref": "#/$defs/todoInputFields"
+        }
+      }
+    },
+    "eventCreateInput": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "destination",
+        "entity"
+      ],
+      "properties": {
+        "destination": {
+          "$ref": "#/$defs/calendarDestination"
+        },
+        "entity": {
+          "$ref": "#/$defs/eventCreateEntity"
+        }
+      }
+    },
+    "todoCreateInput": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "destination",
+        "entity"
+      ],
+      "properties": {
+        "destination": {
+          "$ref": "#/$defs/calendarDestination"
+        },
+        "entity": {
+          "$ref": "#/$defs/todoCreateEntity"
+        }
+      }
+    },
+    "eventPatchInput": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "snapshot",
+        "target",
+        "patch"
+      ],
+      "properties": {
+        "snapshot": {
+          "$ref": "#/$defs/eventRevisionReference"
+        },
+        "target": {
+          "$ref": "#/$defs/mutationTarget"
+        },
+        "patch": {
+          "$ref": "#/$defs/eventSemanticPatch"
+        }
+      }
+    },
+    "todoPatchInput": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "snapshot",
+        "target",
+        "patch"
+      ],
+      "properties": {
+        "snapshot": {
+          "$ref": "#/$defs/todoRevisionReference"
+        },
+        "target": {
+          "$ref": "#/$defs/mutationTarget"
+        },
+        "patch": {
+          "$ref": "#/$defs/todoSemanticPatch"
+        }
+      }
+    },
+    "completionInput": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "snapshot"
+      ],
+      "properties": {
+        "snapshot": {
+          "$ref": "#/$defs/todoRevisionReference"
+        },
+        "recurrenceIdentity": {
+          "$ref": "#/$defs/recurrenceIdentity"
+        }
+      }
+    },
+    "occurrenceMutationInput": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "snapshot",
+        "recurrenceIdentity"
+      ],
+      "properties": {
+        "snapshot": {
+          "$ref": "#/$defs/revisionReference"
+        },
+        "recurrenceIdentity": {
+          "$ref": "#/$defs/recurrenceIdentity"
+        }
+      }
+    },
+    "semanticMoveInput": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "revision",
+        "destination"
+      ],
+      "properties": {
+        "revision": {
+          "$ref": "#/$defs/revisionReference"
+        },
+        "destination": {
+          "$ref": "#/$defs/calendarDestination"
+        }
+      }
+    },
+    "exactCreateInput": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "destinationHref"
+      ],
+      "properties": {
+        "destinationHref": {
+          "type": "string",
+          "format": "uri"
+        },
+        "utf8Resource": {
+          "type": "string",
+          "minLength": 1
+        },
+        "base64Utf8Resource": {
+          "type": "string",
+          "minLength": 1,
+          "contentEncoding": "base64"
+        }
+      },
+      "oneOf": [
+        {
+          "required": [
+            "utf8Resource"
+          ]
+        },
+        {
+          "required": [
+            "base64Utf8Resource"
+          ]
+        }
+      ]
+    },
+    "exactReplaceInput": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "revision"
+      ],
+      "properties": {
+        "revision": {
+          "$ref": "#/$defs/revisionReference"
+        },
+        "utf8Resource": {
+          "type": "string",
+          "minLength": 1
+        },
+        "base64Utf8Resource": {
+          "type": "string",
+          "minLength": 1,
+          "contentEncoding": "base64"
+        }
+      },
+      "oneOf": [
+        {
+          "required": [
+            "utf8Resource"
+          ]
+        },
+        {
+          "required": [
+            "base64Utf8Resource"
+          ]
+        }
+      ]
+    },
+    "exactMoveInput": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "revision",
+        "destinationHref"
+      ],
+      "properties": {
+        "revision": {
+          "$ref": "#/$defs/revisionReference"
+        },
+        "destinationHref": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "deleteInput": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "revision"
+      ],
+      "properties": {
+        "revision": {
+          "$ref": "#/$defs/revisionReference"
+        }
+      }
+    },
+    "calendarListSuccess": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "outcome",
+        "items",
+        "diagnostics",
+        "pagination"
+      ],
+      "properties": {
+        "outcome": {
+          "const": "success"
+        },
+        "items": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/calendarDescriptor"
+          }
+        },
+        "diagnostics": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/diagnostic"
+          }
+        },
+        "pagination": {
+          "$ref": "#/$defs/pagination"
+        }
+      }
+    },
+    "entityQuerySuccess": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "outcome",
+        "items",
+        "diagnostics",
+        "pagination"
+      ],
+      "properties": {
+        "outcome": {
+          "const": "success"
+        },
+        "items": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/calendarSnapshot"
+          }
+        },
+        "diagnostics": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/diagnostic"
+          }
+        },
+        "temporalEvaluationContext": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "timeZone",
+            "source"
+          ],
+          "properties": {
+            "timeZone": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 255
+            },
+            "source": {
+              "enum": [
+                "caller",
+                "configuration"
+              ]
+            }
+          }
+        },
+        "pagination": {
+          "$ref": "#/$defs/entityQueryPagination"
+        }
+      }
+    },
+    "entityQueryErrorOutcome": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "code",
+        "category",
+        "message",
+        "retryable",
+        "phase"
+      ],
+      "properties": {
+        "code": {
+          "enum": [
+            "invalid_input",
+            "cursor_expired",
+            "limit_exhausted",
+            "busy",
+            "payload_too_large",
+            "upstream_protocol_error",
+            "unsupported_capability",
+            "concurrency_unavailable",
+            "temporal_unresolved",
+            "recurrence_unevaluable",
+            "upstream_unavailable",
+            "upstream_unauthorized",
+            "upstream_forbidden",
+            "upstream_rate_limited",
+            "not_found",
+            "ambiguous",
+            "outside_scope"
+          ]
+        },
+        "category": {
+          "enum": [
+            "input",
+            "state",
+            "limitsAndAdmission",
+            "upstream",
+            "capabilityAndProjection",
+            "selection"
+          ]
+        },
+        "message": {
+          "type": "string"
+        },
+        "retryable": {
+          "type": "boolean"
+        },
+        "phase": {
+          "enum": [
+            "schemaLexicalDiscriminator",
+            "pagination",
+            "execution",
+            "admissionAndPayload",
+            "selectionDiscoveryCapability",
+            "targetRevision",
+            "completeResourceSemantics",
+            "originScopeAuthorization"
+          ]
+        },
+        "violations": {
+          "type": "array",
+          "maxItems": 32,
+          "items": {
+            "$ref": "#/$defs/violation"
+          }
+        },
+        "limits": {
+          "$ref": "#/$defs/executionLimits"
+        },
+        "retryAfterMs": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 600000
+        },
+        "authorizedCandidates": {
+          "type": "array",
+          "maxItems": 32,
+          "items": {
+            "$ref": "#/$defs/authorizedCandidate"
+          }
+        }
+      }
+    },
+    "occurrenceQuerySuccess": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "outcome",
+        "items",
+        "diagnostics",
+        "pagination"
+      ],
+      "properties": {
+        "outcome": {
+          "const": "success"
+        },
+        "items": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/occurrenceSnapshot"
+          }
+        },
+        "diagnostics": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/diagnostic"
+          }
+        },
+        "temporalEvaluationContext": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "timeZone",
+            "source"
+          ],
+          "properties": {
+            "timeZone": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 255
+            },
+            "source": {
+              "enum": [
+                "caller",
+                "configuration"
+              ]
+            }
+          }
+        },
+        "pagination": {
+          "$ref": "#/$defs/entityQueryPagination"
+        }
+      }
+    },
+    "resourceSuccess": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "outcome",
+        "snapshot"
+      ],
+      "properties": {
+        "outcome": {
+          "const": "success"
+        },
+        "snapshot": {
+          "$ref": "#/$defs/calendarSnapshot"
+        }
+      }
+    },
+    "exactGetSuccess": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "outcome",
+        "resourceLink"
+      ],
+      "properties": {
+        "outcome": {
+          "const": "success"
+        },
+        "resourceLink": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "type",
+            "uri",
+            "name"
+          ],
+          "properties": {
+            "type": {
+              "const": "resource_link"
+            },
+            "uri": {
+              "type": "string",
+              "format": "uri"
+            },
+            "name": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "errorOutcome": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "code",
+        "category",
+        "message",
+        "retryable",
+        "phase"
+      ],
+      "properties": {
+        "code": {
+          "enum": [
+            "invalid_input",
+            "invalid_calendar_data",
+            "not_found",
+            "ambiguous",
+            "outside_scope",
+            "entity_kind_mismatch",
+            "unsupported_capability",
+            "opaque_resource",
+            "temporal_unresolved",
+            "recurrence_unevaluable",
+            "conflict",
+            "destination_conflict",
+            "concurrency_unavailable",
+            "completion_state_conflict",
+            "limit_exhausted",
+            "payload_too_large",
+            "busy",
+            "upstream_unauthorized",
+            "upstream_forbidden",
+            "upstream_rate_limited",
+            "upstream_unavailable",
+            "upstream_protocol_error",
+            "confirmation_expired",
+            "cursor_expired",
+            "confirmation_mismatch",
+            "fidelity_failure",
+            "committed_but_unverified",
+            "committed_but_concurrency_unavailable",
+            "indeterminate"
+          ]
+        },
+        "category": {
+          "enum": [
+            "input",
+            "selection",
+            "capabilityAndProjection",
+            "state",
+            "limitsAndAdmission",
+            "upstream",
+            "confirmation",
+            "postWriteTruth"
+          ]
+        },
+        "message": {
+          "type": "string"
+        },
+        "retryable": {
+          "type": "boolean"
+        },
+        "phase": {
+          "enum": [
+            "transportAuthorization",
+            "admissionAndPayload",
+            "schemaLexicalDiscriminator",
+            "pagination",
+            "originScopeAuthorization",
+            "selectionDiscoveryCapability",
+            "targetRevision",
+            "completeResourceSemantics",
+            "mrtr",
+            "execution",
+            "postWriteVerificationOrReconciliation"
+          ]
+        },
+        "violations": {
+          "type": "array",
+          "maxItems": 32,
+          "items": {
+            "$ref": "#/$defs/violation"
+          }
+        },
+        "limits": {
+          "$ref": "#/$defs/executionLimits"
+        },
+        "retryAfterMs": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "authorizedCandidates": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/authorizedCandidate"
+          }
+        },
+        "currentSnapshot": {
+          "$ref": "#/$defs/calendarSnapshot"
+        }
+      }
+    },
+    "geo": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "latitude",
+        "longitude"
+      ],
+      "properties": {
+        "latitude": {
+          "type": "number",
+          "minimum": -90,
+          "maximum": 90
+        },
+        "longitude": {
+          "type": "number",
+          "minimum": -180,
+          "maximum": 180
+        }
+      }
+    },
+    "recurrenceIdentity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "value"
+      ],
+      "properties": {
+        "value": {
+          "$ref": "#/$defs/temporalValue"
+        }
+      }
+    },
+    "todoRecurrenceIdentity": {
+      "$ref": "#/$defs/temporalValue"
+    },
+    "recurrenceDateInput": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/temporalValue"
+        },
+        {
+          "$ref": "#/$defs/recurrencePeriodInput"
+        }
+      ]
+    },
+    "recurrencePeriodInput": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "start"
+      ],
+      "properties": {
+        "kind": {
+          "const": "period"
+        },
+        "start": {
+          "$ref": "#/$defs/temporalValue"
+        },
+        "end": {
+          "$ref": "#/$defs/temporalValue"
+        },
+        "duration": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "oneOf": [
+        {
+          "required": [
+            "end"
+          ]
+        },
+        {
+          "required": [
+            "duration"
+          ]
+        }
+      ]
+    },
+    "orphanReconciliation": {
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "kind",
+            "recurrenceIdentity",
+            "disposition"
+          ],
+          "properties": {
+            "kind": {
+              "const": "exdate"
+            },
+            "recurrenceIdentity": {
+              "$ref": "#/$defs/recurrenceIdentity"
+            },
+            "disposition": {
+              "const": "remove"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "kind",
+            "recurrenceIdentity",
+            "overrideKind",
+            "disposition"
+          ],
+          "properties": {
+            "kind": {
+              "const": "override"
+            },
+            "recurrenceIdentity": {
+              "$ref": "#/$defs/recurrenceIdentity"
+            },
+            "overrideKind": {
+              "enum": [
+                "individual",
+                "this-and-future"
+              ]
+            },
+            "disposition": {
+              "const": "remove"
+            }
+          }
+        }
+      ]
+    },
+    "recurrenceSetInput": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "rrule": {
+          "type": "string",
+          "minLength": 1
+        },
+        "rdates": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/recurrenceDateInput"
+          }
+        },
+        "exdates": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/temporalValue"
+          }
+        },
+        "overrides": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/recurrenceOverride"
+          }
+        }
+      }
+    },
+    "eventRecurrenceSetInput": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "rrule": {
+          "type": "string",
+          "minLength": 1
+        },
+        "rdates": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/recurrenceDateInput"
+          }
+        },
+        "exdates": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/temporalValue"
+          }
+        },
+        "overrides": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/eventRecurrenceOverrideInput"
+          }
+        }
+      }
+    },
+    "todoRecurrenceSetInput": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "rrule": {
+          "type": "string",
+          "minLength": 1
+        },
+        "rdates": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/recurrenceDateInput"
+          }
+        },
+        "exdates": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/temporalValue"
+          }
+        },
+        "overrides": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/todoRecurrenceOverrideInput"
+          }
+        }
+      }
+    },
+    "recurrenceSet": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "evaluationState",
+        "rrules",
+        "rdates",
+        "exdates",
+        "overrides"
+      ],
+      "properties": {
+        "evaluationState": {
+          "enum": [
+            "evaluable",
+            "unevaluable"
+          ]
+        },
+        "rrules": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/recurrenceRule"
+          }
+        },
+        "rdates": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/recurrenceDateInput"
+          }
+        },
+        "exdates": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/temporalValue"
+          }
+        },
+        "overrides": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/recurrenceOverride"
+          }
+        }
+      }
+    },
+    "recurrenceRule": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "text"
+      ],
+      "properties": {
+        "text": {
+          "type": "string",
+          "minLength": 1
+        },
+        "originalSlice": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "recurrenceOverride": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "recurrenceIdentity",
+        "entityKind",
+        "status",
+        "fields"
+      ],
+      "properties": {
+        "recurrenceIdentity": {
+          "$ref": "#/$defs/recurrenceIdentity"
+        },
+        "entityKind": {
+          "enum": [
+            "event",
+            "todo"
+          ]
+        },
+        "range": {
+          "enum": [
+            "this-and-prior",
+            "this-and-future"
+          ]
+        },
+        "status": {
+          "enum": [
+            "active",
+            "cancelled"
+          ]
+        },
+        "fields": {},
+        "movedStart": {
+          "$ref": "#/$defs/temporalValue"
+        },
+        "movedEnd": {
+          "$ref": "#/$defs/temporalValue"
+        }
+      },
+      "allOf": [
+        {
+          "oneOf": [
+            {
+              "properties": {
+                "entityKind": { "const": "event" },
+                "fields": { "$ref": "#/$defs/eventOverrideFields" }
+              }
+            },
+            {
+              "properties": {
+                "entityKind": { "const": "todo" },
+                "fields": { "$ref": "#/$defs/todoOverrideFields" }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "namedComponentInput": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["uid", "parameters"],
+      "properties": {
+        "uid": { "type": "string", "minLength": 1 },
+        "name": { "$ref": "#/$defs/textProperty" },
+        "parameters": { "type": "array", "items": { "$ref": "#/$defs/icalParameter" } },
+        "description": { "$ref": "#/$defs/textProperty" },
+        "geo": { "$ref": "#/$defs/geoProperty" },
+        "componentTypes": { "$ref": "#/$defs/textListProperty" },
+        "url": { "$ref": "#/$defs/uriProperty" },
+        "relatedTo": { "type": "array", "items": { "$ref": "#/$defs/relationInput" } },
+        "concepts": { "type": "array", "items": { "$ref": "#/$defs/uriProperty" } },
+        "links": { "type": "array", "items": { "$ref": "#/$defs/namedUri" } },
+        "structuredDataUris": { "type": "array", "items": { "$ref": "#/$defs/uriProperty" } }
+      }
+    },
+    "resourceComponentInput": {
+      "allOf": [
+        { "$ref": "#/$defs/namedComponentInput" },
+        { "not": { "required": ["url"] } },
+        {
+          "properties": {
+            "componentTypes": {
+              "properties": {
+                "value": {
+                  "minItems": 1,
+                  "maxItems": 1,
+                  "items": { "type": "string", "enum": ["projector", "room", "remote-conference-audio", "remote-conference-video"] }
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "attendeeInput": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["uri", "parameters"],
+      "properties": {
+        "uri": { "type": "string", "format": "uri" },
+        "commonName": { "type": "string" },
+        "role": { "type": "string", "minLength": 1 },
+        "partStat": { "type": "string" },
+        "cutype": { "type": "string" },
+        "rsvp": { "type": "boolean" },
+        "delegatedTo": { "type": "array", "items": { "type": "string", "format": "uri" } },
+        "delegatedFrom": { "type": "array", "items": { "type": "string", "format": "uri" } },
+        "sentBy": { "type": "string", "format": "uri" },
+        "directory": { "type": "string", "format": "uri" },
+        "parameters": { "type": "array", "items": { "$ref": "#/$defs/icalParameter" } }
+      }
+    },
+    "relationInput": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["value", "parameters"],
+      "properties": {
+        "value": { "type": "string", "minLength": 1 },
+        "relationType": { "type": "string" },
+        "parameters": { "type": "array", "items": { "$ref": "#/$defs/icalParameter" } }
+      }
+    },
+    "participantInput": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["uid", "participantType"],
+      "properties": {
+        "uid": { "$ref": "#/$defs/textProperty" },
+        "participantType": { "$ref": "#/$defs/textProperty" },
+        "calendarAddress": { "$ref": "#/$defs/uriProperty" },
+        "created": { "$ref": "#/$defs/utcTemporalProperty" },
+        "description": { "$ref": "#/$defs/textProperty" },
+        "timestamp": { "$ref": "#/$defs/utcTemporalProperty" },
+        "geo": { "$ref": "#/$defs/geoProperty" },
+        "lastModified": { "$ref": "#/$defs/utcTemporalProperty" },
+        "priority": { "$ref": "#/$defs/priorityProperty" },
+        "sequence": { "$ref": "#/$defs/nonNegativeIntegerProperty" },
+        "status": { "$ref": "#/$defs/textProperty" },
+        "summary": { "$ref": "#/$defs/textProperty" },
+        "url": { "$ref": "#/$defs/uriProperty" },
+        "attachments": { "type": "array", "items": { "$ref": "#/$defs/namedUri" } },
+        "categories": { "$ref": "#/$defs/textListProperty" },
+        "comments": { "type": "array", "items": { "$ref": "#/$defs/textProperty" } },
+        "contacts": { "type": "array", "items": { "$ref": "#/$defs/textProperty" } },
+        "locations": { "type": "array", "items": { "$ref": "#/$defs/textProperty" } },
+        "requestStatuses": { "type": "array", "items": { "$ref": "#/$defs/requestStatus" } },
+        "relatedTo": { "type": "array", "items": { "$ref": "#/$defs/relationInput" } },
+        "resources": { "type": "array", "items": { "$ref": "#/$defs/textProperty" } },
+        "styledDescriptions": { "type": "array", "items": { "$ref": "#/$defs/textProperty" } },
+        "structuredDataUris": { "type": "array", "items": { "$ref": "#/$defs/uriProperty" } },
+        "locationUris": { "type": "array", "items": { "$ref": "#/$defs/namedComponentInput" } },
+        "resourceUris": { "type": "array", "items": { "$ref": "#/$defs/resourceComponentInput" } }
+      }
+    },
+    "alarmInput": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["action", "trigger"],
+      "properties": {
+        "action": { "$ref": "#/$defs/alarmActionInputProperty" },
+        "trigger": { "$ref": "#/$defs/textProperty" },
+        "description": { "$ref": "#/$defs/textProperty" },
+        "repeat": { "$ref": "#/$defs/positiveIntegerProperty" },
+        "duration": { "$ref": "#/$defs/durationProperty" },
+        "summary": { "$ref": "#/$defs/textProperty" },
+        "attendees": { "type": "array", "items": { "$ref": "#/$defs/attendeeInput" } },
+        "attachments": { "type": "array", "items": { "$ref": "#/$defs/namedUri" } },
+        "uid": { "$ref": "#/$defs/textProperty" },
+        "acknowledged": { "$ref": "#/$defs/utcTemporalProperty" },
+        "proximity": { "$ref": "#/$defs/textProperty" },
+        "relatedTo": { "type": "array", "items": { "$ref": "#/$defs/relationInput" } },
+        "proximityLocations": { "type": "array", "items": { "$ref": "#/$defs/namedComponentInput" } }
+      }
+    },
+    "structuredDataInput": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "organizer": { "$ref": "#/$defs/namedUri" },
+        "attendees": { "type": "array", "items": { "$ref": "#/$defs/attendeeInput" } },
+        "participants": { "type": "array", "items": { "$ref": "#/$defs/participantInput" } },
+        "contacts": { "type": "array", "items": { "$ref": "#/$defs/textProperty" } },
+        "resources": { "type": "array", "items": { "$ref": "#/$defs/textProperty" } },
+        "relatedTo": { "type": "array", "items": { "$ref": "#/$defs/relationInput" } },
+        "requestStatuses": { "type": "array", "items": { "$ref": "#/$defs/requestStatus" } },
+        "alarms": { "type": "array", "items": { "$ref": "#/$defs/alarmInput" } },
+        "attachments": { "type": "array", "items": { "$ref": "#/$defs/namedUri" } },
+        "comments": { "type": "array", "items": { "$ref": "#/$defs/textProperty" } },
+        "styledDescriptions": { "type": "array", "items": { "$ref": "#/$defs/textProperty" } },
+        "images": { "type": "array", "items": { "$ref": "#/$defs/namedUri" } },
+        "conferences": { "type": "array", "items": { "$ref": "#/$defs/namedUri" } },
+        "links": { "type": "array", "items": { "$ref": "#/$defs/namedUri" } },
+        "concepts": { "type": "array", "items": { "$ref": "#/$defs/uriProperty" } },
+        "structuredDataUris": { "type": "array", "items": { "$ref": "#/$defs/uriProperty" } },
+        "locationUris": { "type": "array", "items": { "$ref": "#/$defs/namedComponentInput" } },
+        "resourceUris": { "type": "array", "items": { "$ref": "#/$defs/resourceComponentInput" } }
+      }
+    },
+    "attendee": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "uri",
+        "parameters"
+      ],
+      "properties": {
+        "uri": {
+          "type": "string",
+          "format": "uri"
+        },
+        "commonName": {
+          "type": "string"
+        },
+        "role": {
+          "$ref": "#/$defs/effectiveOpenEnumValue"
+        },
+        "partStat": {
+          "$ref": "#/$defs/effectiveOpenEnumValue"
+        },
+        "cutype": {
+          "$ref": "#/$defs/effectiveOpenEnumValue"
+        },
+        "rsvp": {
+          "$ref": "#/$defs/effectiveBooleanValue"
+        },
+        "delegatedTo": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "format": "uri"
+          }
+        },
+        "delegatedFrom": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "format": "uri"
+          }
+        },
+        "sentBy": {
+          "type": "string",
+          "format": "uri"
+        },
+        "directory": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parameters": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/icalParameter"
+          }
+        }
+      }
+    },
+    "participant": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "uid",
+        "participantType",
+        "schedulable"
+      ],
+      "properties": {
+        "uid": {
+          "$ref": "#/$defs/textProperty"
+        },
+        "participantType": {
+          "$ref": "#/$defs/openEnumValue"
+        },
+        "schedulable": {
+          "type": "boolean"
+        },
+        "calendarAddress": {
+          "$ref": "#/$defs/uriProperty"
+        },
+        "created": {
+          "$ref": "#/$defs/utcTemporalProperty"
+        },
+        "description": {
+          "$ref": "#/$defs/textProperty"
+        },
+        "timestamp": {
+          "$ref": "#/$defs/utcTemporalProperty"
+        },
+        "geo": {
+          "$ref": "#/$defs/geoProperty"
+        },
+        "lastModified": {
+          "$ref": "#/$defs/utcTemporalProperty"
+        },
+        "priority": {
+          "$ref": "#/$defs/priorityProperty"
+        },
+        "sequence": {
+          "$ref": "#/$defs/nonNegativeIntegerProperty"
+        },
+        "status": {
+          "$ref": "#/$defs/openEnumValue"
+        },
+        "summary": {
+          "$ref": "#/$defs/textProperty"
+        },
+        "url": {
+          "$ref": "#/$defs/uriProperty"
+        },
+        "attachments": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/namedUri"
+          }
+        },
+        "categories": {
+          "$ref": "#/$defs/textListProperty"
+        },
+        "comments": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/textProperty"
+          }
+        },
+        "contacts": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/textProperty"
+          }
+        },
+        "locations": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/textProperty"
+          }
+        },
+        "requestStatuses": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/requestStatus"
+          }
+        },
+        "relatedTo": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/relation"
+          }
+        },
+        "resources": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/textProperty"
+          }
+        },
+        "styledDescriptions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/textProperty"
+          }
+        },
+        "structuredDataUris": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/uriProperty"
+          }
+        },
+        "locationUris": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/namedComponent"
+          }
+        },
+        "resourceUris": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/resourceComponent"
+          }
+        }
+      }
+    },
+    "relation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "value",
+        "parameters"
+      ],
+      "properties": {
+        "value": {
+          "type": "string",
+          "minLength": 1
+        },
+        "relationType": {
+          "$ref": "#/$defs/effectiveOpenEnumValue"
+        },
+        "parameters": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/icalParameter"
+          }
+        }
+      }
+    },
+    "requestStatus": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "code",
+        "description",
+        "parameters"
+      ],
+      "properties": {
+        "code": {
+          "type": "string",
+          "pattern": "^\\d+\\.\\d+$"
+        },
+        "description": {
+          "type": "string"
+        },
+        "exceptionData": {
+          "type": "string"
+        },
+        "parameters": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/icalParameter"
+          }
+        }
+      }
+    },
+    "namedUri": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "uri",
+        "parameters"
+      ],
+      "properties": {
+        "uri": {
+          "type": "string",
+          "format": "uri"
+        },
+        "label": {
+          "type": "string"
+        },
+        "parameters": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/icalParameter"
+          }
+        }
+      }
+    },
+    "namedComponent": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["uid", "parameters"],
+      "properties": {
+        "uid": { "type": "string", "minLength": 1 },
+        "name": { "$ref": "#/$defs/textProperty" },
+        "parameters": { "type": "array", "items": { "$ref": "#/$defs/icalParameter" } },
+        "description": { "$ref": "#/$defs/textProperty" },
+        "geo": { "$ref": "#/$defs/geoProperty" },
+        "componentTypes": {
+          "oneOf": [
+            { "$ref": "#/$defs/textListProperty" },
+            { "$ref": "#/$defs/openEnumProperty" }
+          ]
+        },
+        "url": { "$ref": "#/$defs/uriProperty" },
+        "relatedTo": { "type": "array", "items": { "$ref": "#/$defs/relation" } },
+        "concepts": { "type": "array", "items": { "$ref": "#/$defs/uriProperty" } },
+        "links": { "type": "array", "items": { "$ref": "#/$defs/namedUri" } },
+        "structuredDataUris": { "type": "array", "items": { "$ref": "#/$defs/uriProperty" } }
+      }
+    },
+    "resourceComponent": {
+      "allOf": [
+        { "$ref": "#/$defs/namedComponent" },
+        { "not": { "required": ["url"] } },
+        {
+          "properties": {
+            "componentTypes": { "$ref": "#/$defs/openEnumProperty" }
+          }
+        }
+      ]
+    },
+    "uriProperty": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "uri",
+        "parameters"
+      ],
+      "properties": {
+        "uri": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parameters": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/icalParameter"
+          }
+        }
+      }
+    },
+    "textProperty": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "value",
+        "parameters"
+      ],
+      "properties": {
+        "value": {
+          "type": "string"
+        },
+        "parameters": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/icalParameter"
+          }
+        }
+      }
+    },
+    "structuredData": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "organizer": {
+          "$ref": "#/$defs/namedUri"
+        },
+        "attendees": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/attendee"
+          }
+        },
+        "participants": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/participant"
+          }
+        },
+        "contacts": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/textProperty"
+          }
+        },
+        "resources": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/textProperty"
+          }
+        },
+        "relatedTo": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/relation"
+          }
+        },
+        "requestStatuses": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/requestStatus"
+          }
+        },
+        "alarms": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/alarm"
+          }
+        },
+        "attachments": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/namedUri"
+          }
+        },
+        "comments": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/textProperty"
+          }
+        },
+        "styledDescriptions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/textProperty"
+          }
+        },
+        "images": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/namedUri"
+          }
+        },
+        "conferences": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/namedUri"
+          }
+        },
+        "links": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/namedUri"
+          }
+        },
+        "concepts": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/uriProperty"
+          }
+        },
+        "structuredDataUris": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/uriProperty"
+          }
+        },
+        "locationUris": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/namedComponent"
+          }
+        },
+        "resourceUris": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/resourceComponent"
+          }
+        }
+      }
+    },
+    "alarmActionInputProperty": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "value",
+        "parameters"
+      ],
+      "properties": {
+        "value": {
+          "enum": [
+            "display",
+            "audio",
+            "email"
+          ]
+        },
+        "parameters": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/icalParameter"
+          }
+        }
+      }
+    },
+    "alarmActionProperty": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "value",
+        "parameters"
+      ],
+      "properties": {
+        "value": {
+          "$ref": "#/$defs/openEnumValue"
+        },
+        "parameters": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/icalParameter"
+          }
+        }
+      }
+    },
+    "alarm": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "action",
+        "trigger"
+      ],
+      "properties": {
+        "action": {
+          "$ref": "#/$defs/alarmActionProperty"
+        },
+        "trigger": {
+          "$ref": "#/$defs/textProperty"
+        },
+        "description": {
+          "$ref": "#/$defs/textProperty"
+        },
+        "repeat": {
+          "$ref": "#/$defs/positiveIntegerProperty"
+        },
+        "duration": {
+          "$ref": "#/$defs/durationProperty"
+        },
+        "summary": {
+          "$ref": "#/$defs/textProperty"
+        },
+        "attendees": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/attendee"
+          }
+        },
+        "attachments": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/namedUri"
+          }
+        },
+        "uid": {
+          "$ref": "#/$defs/textProperty"
+        },
+        "acknowledged": {
+          "$ref": "#/$defs/utcTemporalProperty"
+        },
+        "proximity": {
+          "$ref": "#/$defs/alarmActionProperty"
+        },
+        "relatedTo": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/relation"
+          }
+        },
+        "proximityLocations": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/namedComponent"
+          }
+        }
+      }
+    },
+    "collectionPatch": {
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "field",
+            "operation"
+          ],
+          "properties": {
+            "field": {
+              "const": "categories"
+            },
+            "operation": {
+              "const": "addRemove"
+            },
+            "add": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "remove": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "anyOf": [
+            {
+              "required": [
+                "add"
+              ],
+              "properties": {
+                "add": {
+                  "minItems": 1
+                }
+              }
+            },
+            {
+              "required": [
+                "remove"
+              ],
+              "properties": {
+                "remove": {
+                  "minItems": 1
+                }
+              }
+            }
+          ]
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "field",
+            "operation",
+            "values"
+          ],
+          "properties": {
+            "field": {
+              "const": "categories"
+            },
+            "operation": {
+              "const": "replaceAll"
+            },
+            "values": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "field",
+            "operation"
+          ],
+          "properties": {
+            "field": {
+              "const": "attendees"
+            },
+            "operation": {
+              "const": "addRemove"
+            },
+            "add": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/attendeeInput"
+              }
+            },
+            "remove": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/attendeeInput"
+              }
+            }
+          },
+          "anyOf": [
+            {
+              "required": [
+                "add"
+              ],
+              "properties": {
+                "add": {
+                  "minItems": 1
+                }
+              }
+            },
+            {
+              "required": [
+                "remove"
+              ],
+              "properties": {
+                "remove": {
+                  "minItems": 1
+                }
+              }
+            }
+          ]
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "field",
+            "operation",
+            "values"
+          ],
+          "properties": {
+            "field": {
+              "const": "attendees"
+            },
+            "operation": {
+              "const": "replaceAll"
+            },
+            "values": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/attendeeInput"
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "field",
+            "operation"
+          ],
+          "properties": {
+            "field": {
+              "const": "participants"
+            },
+            "operation": {
+              "const": "addRemove"
+            },
+            "add": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/participantInput"
+              }
+            },
+            "remove": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/participantInput"
+              }
+            }
+          },
+          "anyOf": [
+            {
+              "required": [
+                "add"
+              ],
+              "properties": {
+                "add": {
+                  "minItems": 1
+                }
+              }
+            },
+            {
+              "required": [
+                "remove"
+              ],
+              "properties": {
+                "remove": {
+                  "minItems": 1
+                }
+              }
+            }
+          ]
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "field",
+            "operation",
+            "values"
+          ],
+          "properties": {
+            "field": {
+              "const": "participants"
+            },
+            "operation": {
+              "const": "replaceAll"
+            },
+            "values": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/participantInput"
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "field",
+            "operation"
+          ],
+          "properties": {
+            "field": {
+              "const": "contacts"
+            },
+            "operation": {
+              "const": "addRemove"
+            },
+            "add": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/textProperty"
+              }
+            },
+            "remove": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/textProperty"
+              }
+            }
+          },
+          "anyOf": [
+            {
+              "required": [
+                "add"
+              ],
+              "properties": {
+                "add": {
+                  "minItems": 1
+                }
+              }
+            },
+            {
+              "required": [
+                "remove"
+              ],
+              "properties": {
+                "remove": {
+                  "minItems": 1
+                }
+              }
+            }
+          ]
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "field",
+            "operation",
+            "values"
+          ],
+          "properties": {
+            "field": {
+              "const": "contacts"
+            },
+            "operation": {
+              "const": "replaceAll"
+            },
+            "values": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/textProperty"
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "field",
+            "operation"
+          ],
+          "properties": {
+            "field": {
+              "const": "resources"
+            },
+            "operation": {
+              "const": "addRemove"
+            },
+            "add": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/textProperty"
+              }
+            },
+            "remove": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/textProperty"
+              }
+            }
+          },
+          "anyOf": [
+            {
+              "required": [
+                "add"
+              ],
+              "properties": {
+                "add": {
+                  "minItems": 1
+                }
+              }
+            },
+            {
+              "required": [
+                "remove"
+              ],
+              "properties": {
+                "remove": {
+                  "minItems": 1
+                }
+              }
+            }
+          ]
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "field",
+            "operation",
+            "values"
+          ],
+          "properties": {
+            "field": {
+              "const": "resources"
+            },
+            "operation": {
+              "const": "replaceAll"
+            },
+            "values": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/textProperty"
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "field",
+            "operation"
+          ],
+          "properties": {
+            "field": {
+              "const": "relatedTo"
+            },
+            "operation": {
+              "const": "addRemove"
+            },
+            "add": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/relationInput"
+              }
+            },
+            "remove": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/relationInput"
+              }
+            }
+          },
+          "anyOf": [
+            {
+              "required": [
+                "add"
+              ],
+              "properties": {
+                "add": {
+                  "minItems": 1
+                }
+              }
+            },
+            {
+              "required": [
+                "remove"
+              ],
+              "properties": {
+                "remove": {
+                  "minItems": 1
+                }
+              }
+            }
+          ]
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "field",
+            "operation",
+            "values"
+          ],
+          "properties": {
+            "field": {
+              "const": "relatedTo"
+            },
+            "operation": {
+              "const": "replaceAll"
+            },
+            "values": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/relationInput"
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "field",
+            "operation"
+          ],
+          "properties": {
+            "field": {
+              "const": "requestStatuses"
+            },
+            "operation": {
+              "const": "addRemove"
+            },
+            "add": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/requestStatus"
+              }
+            },
+            "remove": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/requestStatus"
+              }
+            }
+          },
+          "anyOf": [
+            {
+              "required": [
+                "add"
+              ],
+              "properties": {
+                "add": {
+                  "minItems": 1
+                }
+              }
+            },
+            {
+              "required": [
+                "remove"
+              ],
+              "properties": {
+                "remove": {
+                  "minItems": 1
+                }
+              }
+            }
+          ]
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "field",
+            "operation",
+            "values"
+          ],
+          "properties": {
+            "field": {
+              "const": "requestStatuses"
+            },
+            "operation": {
+              "const": "replaceAll"
+            },
+            "values": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/requestStatus"
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "field",
+            "operation"
+          ],
+          "properties": {
+            "field": {
+              "const": "alarms"
+            },
+            "operation": {
+              "const": "addRemove"
+            },
+            "add": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/alarmInput"
+              }
+            },
+            "remove": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/alarmInput"
+              }
+            }
+          },
+          "anyOf": [
+            {
+              "required": [
+                "add"
+              ],
+              "properties": {
+                "add": {
+                  "minItems": 1
+                }
+              }
+            },
+            {
+              "required": [
+                "remove"
+              ],
+              "properties": {
+                "remove": {
+                  "minItems": 1
+                }
+              }
+            }
+          ]
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "field",
+            "operation",
+            "values"
+          ],
+          "properties": {
+            "field": {
+              "const": "alarms"
+            },
+            "operation": {
+              "const": "replaceAll"
+            },
+            "values": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/alarmInput"
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "field",
+            "operation"
+          ],
+          "properties": {
+            "field": {
+              "const": "attachments"
+            },
+            "operation": {
+              "const": "addRemove"
+            },
+            "add": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/namedUri"
+              }
+            },
+            "remove": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/namedUri"
+              }
+            }
+          },
+          "anyOf": [
+            {
+              "required": [
+                "add"
+              ],
+              "properties": {
+                "add": {
+                  "minItems": 1
+                }
+              }
+            },
+            {
+              "required": [
+                "remove"
+              ],
+              "properties": {
+                "remove": {
+                  "minItems": 1
+                }
+              }
+            }
+          ]
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "field",
+            "operation",
+            "values"
+          ],
+          "properties": {
+            "field": {
+              "const": "attachments"
+            },
+            "operation": {
+              "const": "replaceAll"
+            },
+            "values": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/namedUri"
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "field",
+            "operation"
+          ],
+          "properties": {
+            "field": {
+              "const": "comments"
+            },
+            "operation": {
+              "const": "addRemove"
+            },
+            "add": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/textProperty"
+              }
+            },
+            "remove": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/textProperty"
+              }
+            }
+          },
+          "anyOf": [
+            {
+              "required": [
+                "add"
+              ],
+              "properties": {
+                "add": {
+                  "minItems": 1
+                }
+              }
+            },
+            {
+              "required": [
+                "remove"
+              ],
+              "properties": {
+                "remove": {
+                  "minItems": 1
+                }
+              }
+            }
+          ]
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "field",
+            "operation",
+            "values"
+          ],
+          "properties": {
+            "field": {
+              "const": "comments"
+            },
+            "operation": {
+              "const": "replaceAll"
+            },
+            "values": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/textProperty"
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "field",
+            "operation"
+          ],
+          "properties": {
+            "field": {
+              "const": "styledDescriptions"
+            },
+            "operation": {
+              "const": "addRemove"
+            },
+            "add": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/textProperty"
+              }
+            },
+            "remove": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/textProperty"
+              }
+            }
+          },
+          "anyOf": [
+            {
+              "required": [
+                "add"
+              ],
+              "properties": {
+                "add": {
+                  "minItems": 1
+                }
+              }
+            },
+            {
+              "required": [
+                "remove"
+              ],
+              "properties": {
+                "remove": {
+                  "minItems": 1
+                }
+              }
+            }
+          ]
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "field",
+            "operation",
+            "values"
+          ],
+          "properties": {
+            "field": {
+              "const": "styledDescriptions"
+            },
+            "operation": {
+              "const": "replaceAll"
+            },
+            "values": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/textProperty"
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "field",
+            "operation"
+          ],
+          "properties": {
+            "field": {
+              "const": "images"
+            },
+            "operation": {
+              "const": "addRemove"
+            },
+            "add": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/namedUri"
+              }
+            },
+            "remove": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/namedUri"
+              }
+            }
+          },
+          "anyOf": [
+            {
+              "required": [
+                "add"
+              ],
+              "properties": {
+                "add": {
+                  "minItems": 1
+                }
+              }
+            },
+            {
+              "required": [
+                "remove"
+              ],
+              "properties": {
+                "remove": {
+                  "minItems": 1
+                }
+              }
+            }
+          ]
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "field",
+            "operation",
+            "values"
+          ],
+          "properties": {
+            "field": {
+              "const": "images"
+            },
+            "operation": {
+              "const": "replaceAll"
+            },
+            "values": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/namedUri"
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "field",
+            "operation"
+          ],
+          "properties": {
+            "field": {
+              "const": "conferences"
+            },
+            "operation": {
+              "const": "addRemove"
+            },
+            "add": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/namedUri"
+              }
+            },
+            "remove": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/namedUri"
+              }
+            }
+          },
+          "anyOf": [
+            {
+              "required": [
+                "add"
+              ],
+              "properties": {
+                "add": {
+                  "minItems": 1
+                }
+              }
+            },
+            {
+              "required": [
+                "remove"
+              ],
+              "properties": {
+                "remove": {
+                  "minItems": 1
+                }
+              }
+            }
+          ]
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "field",
+            "operation",
+            "values"
+          ],
+          "properties": {
+            "field": {
+              "const": "conferences"
+            },
+            "operation": {
+              "const": "replaceAll"
+            },
+            "values": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/namedUri"
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "field",
+            "operation"
+          ],
+          "properties": {
+            "field": {
+              "const": "links"
+            },
+            "operation": {
+              "const": "addRemove"
+            },
+            "add": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/namedUri"
+              }
+            },
+            "remove": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/namedUri"
+              }
+            }
+          },
+          "anyOf": [
+            {
+              "required": [
+                "add"
+              ],
+              "properties": {
+                "add": {
+                  "minItems": 1
+                }
+              }
+            },
+            {
+              "required": [
+                "remove"
+              ],
+              "properties": {
+                "remove": {
+                  "minItems": 1
+                }
+              }
+            }
+          ]
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "field",
+            "operation",
+            "values"
+          ],
+          "properties": {
+            "field": {
+              "const": "links"
+            },
+            "operation": {
+              "const": "replaceAll"
+            },
+            "values": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/namedUri"
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "field",
+            "operation"
+          ],
+          "properties": {
+            "field": {
+              "const": "concepts"
+            },
+            "operation": {
+              "const": "addRemove"
+            },
+            "add": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/uriProperty"
+              }
+            },
+            "remove": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/uriProperty"
+              }
+            }
+          },
+          "anyOf": [
+            {
+              "required": [
+                "add"
+              ],
+              "properties": {
+                "add": {
+                  "minItems": 1
+                }
+              }
+            },
+            {
+              "required": [
+                "remove"
+              ],
+              "properties": {
+                "remove": {
+                  "minItems": 1
+                }
+              }
+            }
+          ]
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "field",
+            "operation",
+            "values"
+          ],
+          "properties": {
+            "field": {
+              "const": "concepts"
+            },
+            "operation": {
+              "const": "replaceAll"
+            },
+            "values": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/uriProperty"
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "field",
+            "operation"
+          ],
+          "properties": {
+            "field": {
+              "const": "structuredDataUris"
+            },
+            "operation": {
+              "const": "addRemove"
+            },
+            "add": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/uriProperty"
+              }
+            },
+            "remove": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/uriProperty"
+              }
+            }
+          },
+          "anyOf": [
+            {
+              "required": [
+                "add"
+              ],
+              "properties": {
+                "add": {
+                  "minItems": 1
+                }
+              }
+            },
+            {
+              "required": [
+                "remove"
+              ],
+              "properties": {
+                "remove": {
+                  "minItems": 1
+                }
+              }
+            }
+          ]
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "field",
+            "operation",
+            "values"
+          ],
+          "properties": {
+            "field": {
+              "const": "structuredDataUris"
+            },
+            "operation": {
+              "const": "replaceAll"
+            },
+            "values": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/uriProperty"
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "field",
+            "operation"
+          ],
+          "properties": {
+            "field": {
+              "const": "locationUris"
+            },
+            "operation": {
+              "const": "addRemove"
+            },
+            "add": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/namedComponentInput"
+              }
+            },
+            "remove": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/namedComponentInput"
+              }
+            }
+          },
+          "anyOf": [
+            {
+              "required": [
+                "add"
+              ],
+              "properties": {
+                "add": {
+                  "minItems": 1
+                }
+              }
+            },
+            {
+              "required": [
+                "remove"
+              ],
+              "properties": {
+                "remove": {
+                  "minItems": 1
+                }
+              }
+            }
+          ]
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "field",
+            "operation",
+            "values"
+          ],
+          "properties": {
+            "field": {
+              "const": "locationUris"
+            },
+            "operation": {
+              "const": "replaceAll"
+            },
+            "values": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/namedComponentInput"
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "field",
+            "operation"
+          ],
+          "properties": {
+            "field": {
+              "const": "resourceUris"
+            },
+            "operation": {
+              "const": "addRemove"
+            },
+            "add": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/resourceComponentInput"
+              }
+            },
+            "remove": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/resourceComponentInput"
+              }
+            }
+          },
+          "anyOf": [
+            {
+              "required": [
+                "add"
+              ],
+              "properties": {
+                "add": {
+                  "minItems": 1
+                }
+              }
+            },
+            {
+              "required": [
+                "remove"
+              ],
+              "properties": {
+                "remove": {
+                  "minItems": 1
+                }
+              }
+            }
+          ]
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "field",
+            "operation",
+            "values"
+          ],
+          "properties": {
+            "field": {
+              "const": "resourceUris"
+            },
+            "operation": {
+              "const": "replaceAll"
+            },
+            "values": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/resourceComponentInput"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "eventScalarPatch": {
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "field",
+            "operation",
+            "value"
+          ],
+          "properties": {
+            "field": {
+              "const": "summary"
+            },
+            "operation": {
+              "const": "set"
+            },
+            "value": {
+              "type": "string"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "field",
+            "operation"
+          ],
+          "properties": {
+            "field": {
+              "const": "summary"
+            },
+            "operation": {
+              "const": "clear"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "field",
+            "operation",
+            "value"
+          ],
+          "properties": {
+            "field": {
+              "const": "description"
+            },
+            "operation": {
+              "const": "set"
+            },
+            "value": {
+              "type": "string"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "field",
+            "operation"
+          ],
+          "properties": {
+            "field": {
+              "const": "description"
+            },
+            "operation": {
+              "const": "clear"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "field",
+            "operation",
+            "value"
+          ],
+          "properties": {
+            "field": {
+              "const": "start"
+            },
+            "operation": {
+              "const": "set"
+            },
+            "value": {
+              "$ref": "#/$defs/temporalValue"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "field",
+            "operation"
+          ],
+          "properties": {
+            "field": {
+              "const": "start"
+            },
+            "operation": {
+              "const": "clear"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "field",
+            "operation",
+            "value"
+          ],
+          "properties": {
+            "field": {
+              "const": "end"
+            },
+            "operation": {
+              "const": "set"
+            },
+            "value": {
+              "$ref": "#/$defs/temporalValue"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "field",
+            "operation"
+          ],
+          "properties": {
+            "field": {
+              "const": "end"
+            },
+            "operation": {
+              "const": "clear"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "field",
+            "operation",
+            "value"
+          ],
+          "properties": {
+            "field": {
+              "const": "duration"
+            },
+            "operation": {
+              "const": "set"
+            },
+            "value": {
+              "type": "string"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "field",
+            "operation"
+          ],
+          "properties": {
+            "field": {
+              "const": "duration"
+            },
+            "operation": {
+              "const": "clear"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "field",
+            "operation",
+            "value"
+          ],
+          "properties": {
+            "field": {
+              "const": "location"
+            },
+            "operation": {
+              "const": "set"
+            },
+            "value": {
+              "type": "string"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "field",
+            "operation"
+          ],
+          "properties": {
+            "field": {
+              "const": "location"
+            },
+            "operation": {
+              "const": "clear"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "field",
+            "operation",
+            "value"
+          ],
+          "properties": {
+            "field": {
+              "const": "geo"
+            },
+            "operation": {
+              "const": "set"
+            },
+            "value": {
+              "$ref": "#/$defs/geo"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "field",
+            "operation"
+          ],
+          "properties": {
+            "field": {
+              "const": "geo"
+            },
+            "operation": {
+              "const": "clear"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "field",
+            "operation",
+            "value"
+          ],
+          "properties": {
+            "field": {
+              "const": "status"
+            },
+            "operation": {
+              "const": "set"
+            },
+            "value": {
+              "type": "string"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "field",
+            "operation"
+          ],
+          "properties": {
+            "field": {
+              "const": "status"
+            },
+            "operation": {
+              "const": "clear"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "field",
+            "operation",
+            "value"
+          ],
+          "properties": {
+            "field": {
+              "const": "transparency"
+            },
+            "operation": {
+              "const": "set"
+            },
+            "value": {
+              "type": "string"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "field",
+            "operation"
+          ],
+          "properties": {
+            "field": {
+              "const": "transparency"
+            },
+            "operation": {
+              "const": "clear"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "field",
+            "operation",
+            "value"
+          ],
+          "properties": {
+            "field": {
+              "const": "classification"
+            },
+            "operation": {
+              "const": "set"
+            },
+            "value": {
+              "type": "string"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "field",
+            "operation"
+          ],
+          "properties": {
+            "field": {
+              "const": "classification"
+            },
+            "operation": {
+              "const": "clear"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "field",
+            "operation",
+            "value"
+          ],
+          "properties": {
+            "field": {
+              "const": "priority"
+            },
+            "operation": {
+              "const": "set"
+            },
+            "value": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 9
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "field",
+            "operation"
+          ],
+          "properties": {
+            "field": {
+              "const": "priority"
+            },
+            "operation": {
+              "const": "clear"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "field",
+            "operation",
+            "value"
+          ],
+          "properties": {
+            "field": {
+              "const": "url"
+            },
+            "operation": {
+              "const": "set"
+            },
+            "value": {
+              "type": "string",
+              "format": "uri"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "field",
+            "operation"
+          ],
+          "properties": {
+            "field": {
+              "const": "url"
+            },
+            "operation": {
+              "const": "clear"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "field",
+            "operation",
+            "value"
+          ],
+          "properties": {
+            "field": {
+              "const": "recurrenceSet"
+            },
+            "operation": {
+              "const": "set"
+            },
+            "value": {
+              "$ref": "#/$defs/recurrenceSetInput"
+            },
+            "orphanReconciliations": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/orphanReconciliation"
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "field",
+            "operation"
+          ],
+          "properties": {
+            "field": {
+              "const": "recurrenceSet"
+            },
+            "operation": {
+              "const": "clear"
+            },
+            "orphanReconciliations": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/orphanReconciliation"
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "field",
+            "operation",
+            "value"
+          ],
+          "properties": {
+            "field": {
+              "const": "organizer"
+            },
+            "operation": {
+              "const": "set"
+            },
+            "value": {
+              "$ref": "#/$defs/namedUri"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "field",
+            "operation"
+          ],
+          "properties": {
+            "field": {
+              "const": "organizer"
+            },
+            "operation": {
+              "const": "clear"
+            }
+          }
+        }
+      ]
+    },
+    "todoScalarPatch": {
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "field",
+            "operation",
+            "value"
+          ],
+          "properties": {
+            "field": {
+              "const": "percentComplete"
+            },
+            "operation": {
+              "const": "set"
+            },
+            "value": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 100
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "field",
+            "operation"
+          ],
+          "properties": {
+            "field": {
+              "const": "percentComplete"
+            },
+            "operation": {
+              "const": "clear"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "field",
+            "operation",
+            "value"
+          ],
+          "properties": {
+            "field": {
+              "const": "summary"
+            },
+            "operation": {
+              "const": "set"
+            },
+            "value": {
+              "type": "string"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "field",
+            "operation"
+          ],
+          "properties": {
+            "field": {
+              "const": "summary"
+            },
+            "operation": {
+              "const": "clear"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "field",
+            "operation",
+            "value"
+          ],
+          "properties": {
+            "field": {
+              "const": "description"
+            },
+            "operation": {
+              "const": "set"
+            },
+            "value": {
+              "type": "string"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "field",
+            "operation"
+          ],
+          "properties": {
+            "field": {
+              "const": "description"
+            },
+            "operation": {
+              "const": "clear"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "field",
+            "operation",
+            "value"
+          ],
+          "properties": {
+            "field": {
+              "const": "start"
+            },
+            "operation": {
+              "const": "set"
+            },
+            "value": {
+              "$ref": "#/$defs/temporalValue"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "field",
+            "operation"
+          ],
+          "properties": {
+            "field": {
+              "const": "start"
+            },
+            "operation": {
+              "const": "clear"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "field",
+            "operation",
+            "value"
+          ],
+          "properties": {
+            "field": {
+              "const": "due"
+            },
+            "operation": {
+              "const": "set"
+            },
+            "value": {
+              "$ref": "#/$defs/temporalValue"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "field",
+            "operation"
+          ],
+          "properties": {
+            "field": {
+              "const": "due"
+            },
+            "operation": {
+              "const": "clear"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "field",
+            "operation",
+            "value"
+          ],
+          "properties": {
+            "field": {
+              "const": "duration"
+            },
+            "operation": {
+              "const": "set"
+            },
+            "value": {
+              "type": "string"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "field",
+            "operation"
+          ],
+          "properties": {
+            "field": {
+              "const": "duration"
+            },
+            "operation": {
+              "const": "clear"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "field",
+            "operation",
+            "value"
+          ],
+          "properties": {
+            "field": {
+              "const": "status"
+            },
+            "operation": {
+              "const": "set"
+            },
+            "value": {
+              "type": "string"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "field",
+            "operation"
+          ],
+          "properties": {
+            "field": {
+              "const": "status"
+            },
+            "operation": {
+              "const": "clear"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "field",
+            "operation",
+            "value"
+          ],
+          "properties": {
+            "field": {
+              "const": "priority"
+            },
+            "operation": {
+              "const": "set"
+            },
+            "value": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 9
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "field",
+            "operation"
+          ],
+          "properties": {
+            "field": {
+              "const": "priority"
+            },
+            "operation": {
+              "const": "clear"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "field",
+            "operation",
+            "value"
+          ],
+          "properties": {
+            "field": {
+              "const": "recurrenceSet"
+            },
+            "operation": {
+              "const": "set"
+            },
+            "value": {
+              "$ref": "#/$defs/recurrenceSetInput"
+            },
+            "orphanReconciliations": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/orphanReconciliation"
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "field",
+            "operation"
+          ],
+          "properties": {
+            "field": {
+              "const": "recurrenceSet"
+            },
+            "operation": {
+              "const": "clear"
+            },
+            "orphanReconciliations": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/orphanReconciliation"
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "field",
+            "operation",
+            "value"
+          ],
+          "properties": {
+            "field": {
+              "const": "organizer"
+            },
+            "operation": {
+              "const": "set"
+            },
+            "value": {
+              "$ref": "#/$defs/namedUri"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "field",
+            "operation"
+          ],
+          "properties": {
+            "field": {
+              "const": "organizer"
+            },
+            "operation": {
+              "const": "clear"
+            }
+          }
+        }
+      ]
+    },
+    "eventSemanticPatch": {
+      "type": "object",
+      "additionalProperties": false,
+      "minProperties": 1,
+      "properties": {
+        "scalars": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/eventScalarPatch"
+          }
+        },
+        "collections": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/collectionPatch"
+          }
+        }
+      }
+    },
+    "todoSemanticPatch": {
+      "type": "object",
+      "additionalProperties": false,
+      "minProperties": 1,
+      "properties": {
+        "scalars": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/todoScalarPatch"
+          }
+        },
+        "collections": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/collectionPatch"
+          }
+        }
+      }
+    },
+    "mutationTarget": {
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "scope"
+          ],
+          "properties": {
+            "scope": {
+              "enum": [
+                "master",
+                "entire-set"
+              ]
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "scope",
+            "recurrenceIdentity"
+          ],
+          "properties": {
+            "scope": {
+              "enum": [
+                "one-occurrence",
+                "this-and-future"
+              ]
+            },
+            "recurrenceIdentity": {
+              "$ref": "#/$defs/recurrenceIdentity"
+            }
+          }
+        }
+      ]
+    },
+    "diagnostic": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "code",
+        "message",
+        "severity"
+      ],
+      "properties": {
+        "code": {
+          "type": "string"
+        },
+        "message": {
+          "type": "string"
+        },
+        "severity": {
+          "enum": [
+            "info",
+            "warning",
+            "error"
+          ]
+        }
+      }
+    },
+    "pagination": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "mode",
+        "nextCursor"
+      ],
+      "properties": {
+        "mode": {
+          "const": "non_snapshot"
+        },
+        "nextCursor": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "entityQueryPagination": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "mode",
+        "nextCursor"
+      ],
+      "properties": {
+        "mode": {
+          "const": "query_result_snapshot"
+        },
+        "nextCursor": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "maxLength": 2048
+        }
+      }
+    },
+    "capabilityEvidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "source",
+        "value"
+      ],
+      "properties": {
+        "source": {
+          "enum": [
+            "supported-calendar-component-set",
+            "DAV-resourcetype",
+            "probe",
+            "server-response"
+          ]
+        },
+        "value": {
+          "type": "string"
+        }
+      }
+    },
+    "entityKindCapability": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "state",
+        "evidence"
+      ],
+      "properties": {
+        "state": {
+          "enum": [
+            "advertised",
+            "not_advertised",
+            "unknown"
+          ]
+        },
+        "evidence": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/capabilityEvidence"
+          }
+        }
+      }
+    },
+    "entityKinds": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "event",
+        "todo"
+      ],
+      "properties": {
+        "event": {
+          "$ref": "#/$defs/entityKindCapability"
+        },
+        "todo": {
+          "$ref": "#/$defs/entityKindCapability"
+        }
+      }
+    },
+    "calendarDescriptor": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "calendar",
+        "displayName",
+        "displayNameProvenance",
+        "entityKinds"
+      ],
+      "properties": {
+        "calendar": {
+          "$ref": "#/$defs/calendarHref"
+        },
+        "displayName": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "displayNameProvenance": {
+          "enum": [
+            "dav-displayname",
+            "derived-from-href",
+            "missing"
+          ]
+        },
+        "description": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "color": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "pattern": "^#[0-9A-Fa-f]{6}$"
+        },
+        "entityKinds": {
+          "$ref": "#/$defs/entityKinds"
+        }
+      }
+    },
+    "icalParameter": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "values"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "values": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "componentPathSegment": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "occurrence"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "pattern": "^[A-Za-z0-9-]+$"
+        },
+        "occurrence": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "calendarProperty": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "componentPath",
+        "name",
+        "parameters",
+        "valueType",
+        "rawEncodedValue",
+        "originalSlice"
+      ],
+      "properties": {
+        "componentPath": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/componentPathSegment"
+          }
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "parameters": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/icalParameter"
+          }
+        },
+        "valueType": {
+          "enum": [
+            "text",
+            "uri",
+            "date",
+            "date-time",
+            "duration",
+            "integer",
+            "float",
+            "period",
+          "recur",
+          "binary",
+          "uid",
+          "unknown"
+          ]
+        },
+        "rawEncodedValue": {
+          "type": "string"
+        },
+        "originalSlice": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "eventProjection": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "uid",
+        "fields"
+      ],
+      "properties": {
+        "kind": {
+          "const": "event"
+        },
+        "uid": {
+          "type": "string",
+          "minLength": 1
+        },
+        "fields": {
+          "$ref": "#/$defs/eventFields"
+        }
+      }
+    },
+    "todoProjection": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "uid",
+        "fields"
+      ],
+      "properties": {
+        "kind": {
+          "const": "todo"
+        },
+        "uid": {
+          "type": "string",
+          "minLength": 1
+        },
+        "fields": {
+          "$ref": "#/$defs/todoFields"
+        },
+        "completedAt": {
+          "$ref": "#/$defs/utcTemporalValue"
+        }
+      }
+    },
+    "opaqueProjection": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "properties"
+      ],
+      "properties": {
+        "kind": {
+          "const": "opaque"
+        },
+        "properties": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/calendarProperty"
+          }
+        }
+      }
+    },
+    "calendarSnapshot": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "calendar",
+        "resourceRevision",
+        "calendarProperties",
+        "projection",
+        "diagnostics"
+      ],
+      "properties": {
+        "calendar": {
+          "$ref": "#/$defs/calendarHref"
+        },
+        "calendarProperties": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/calendarProperty"
+          }
+        },
+        "projection": {
+          "oneOf": [
+            {
+              "$ref": "#/$defs/eventProjection"
+            },
+            {
+              "$ref": "#/$defs/todoProjection"
+            },
+            {
+              "$ref": "#/$defs/opaqueProjection"
+            }
+          ]
+        },
+        "diagnostics": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/diagnostic"
+          }
+        },
+        "resourceRevision": {
+          "$ref": "#/$defs/resourceRevision"
+        },
+        "entityRevision": {
+          "$ref": "#/$defs/revisionReference"
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "projection": {
+                "properties": {
+                  "kind": {
+                    "const": "opaque"
+                  }
+                },
+                "required": [
+                  "kind"
+                ]
+              }
+            },
+            "required": [
+              "projection"
+            ]
+          },
+          "then": {
+            "not": {
+              "required": [
+                "entityRevision"
+              ]
+            }
+          },
+          "else": {
+            "required": [
+              "entityRevision"
+            ]
+          }
+        }
+      ]
+    },
+    "exactConflictSnapshot": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "calendar",
+        "resourceRevision"
+      ],
+      "properties": {
+        "calendar": {
+          "$ref": "#/$defs/calendarHref"
+        },
+        "resourceRevision": {
+          "$ref": "#/$defs/resourceRevision"
+        },
+        "entityRevision": {
+          "$ref": "#/$defs/revisionReference"
+        }
+      }
+    },
+    "occurrenceSnapshot": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "snapshot",
+        "recurrenceIdentity",
+        "timing"
+      ],
+      "properties": {
+        "snapshot": {
+          "$ref": "#/$defs/calendarSnapshot"
+        },
+        "recurrenceIdentity": {
+          "$ref": "#/$defs/recurrenceIdentity"
+        },
+        "timing": {
+          "$ref": "#/$defs/occurrenceTiming"
+        }
+      }
+    },
+    "deletionReceipt": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "href",
+        "entityUid",
+        "entityKind",
+        "consumedEntityTag"
+      ],
+      "properties": {
+        "href": {
+          "type": "string",
+          "format": "uri"
+        },
+        "entityUid": {
+          "type": "string"
+        },
+        "entityKind": {
+          "enum": [
+            "event",
+            "todo"
+          ]
+        },
+        "consumedEntityTag": {
+          "type": "string"
+        }
+      }
+    },
+    "mrtrInputRequest": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "method",
+        "params"
+      ],
+      "properties": {
+        "method": {
+          "const": "elicitation/create"
+        },
+        "params": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "mode",
+            "message",
+            "requestedSchema"
+          ],
+          "properties": {
+            "message": {
+              "type": "string"
+            },
+            "requestedSchema": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "type",
+                "properties"
+              ],
+              "properties": {
+                "type": {
+                  "const": "object"
+                },
+                "properties": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "$ref": "#/$defs/mrtrRequestedProperty"
+                  }
+                },
+                "required": {
+                  "type": "array",
+                  "uniqueItems": true,
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "mode": {
+              "const": "form"
+            }
+          }
+        }
+      }
+    },
+    "mrtrInputResponse": {
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "action",
+            "content"
+          ],
+          "properties": {
+            "action": {
+              "const": "accept"
+            },
+            "content": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/$defs/mrtrResponseValue"
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "action"
+          ],
+          "properties": {
+            "action": {
+              "enum": [
+                "decline",
+                "cancel"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "calendarListOutcome": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/calendarListSuccess"
+        },
+        {
+          "$ref": "#/$defs/errorOutcome"
+        }
+      ]
+    },
+    "entityQueryOutcome": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/entityQuerySuccess"
+        },
+        {
+          "$ref": "#/$defs/entityQueryErrorOutcome"
+        }
+      ]
+    },
+    "occurrenceQueryOutcome": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/occurrenceQuerySuccess"
+        },
+        {
+          "$ref": "#/$defs/entityQueryErrorOutcome"
+        }
+      ]
+    },
+    "resourceOutcome": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/resourceSuccess"
+        },
+        {
+          "$ref": "#/$defs/errorOutcome"
+        }
+      ]
+    },
+    "exactGetOutcome": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/exactGetSuccess"
+        },
+        {
+          "$ref": "#/$defs/errorOutcome"
+        }
+      ]
+    },
+    "violation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "pointer",
+        "code"
+      ],
+      "properties": {
+        "pointer": {
+          "type": "string",
+          "pattern": "^/"
+        },
+        "code": {
+          "type": "string"
+        },
+        "message": {
+          "type": "string"
+        }
+      }
+    },
+    "executionLimits": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "resourcesInspected": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "calendarCount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "occurrenceCount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "byteCount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "itemCount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "snapshotCount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "dimension": {
+          "enum": [
+            "elapsed_time",
+            "resource_count",
+            "attempt_count",
+            "byte_count"
+          ]
+        },
+        "observed": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "limit": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "authorizedCandidate": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "calendar",
+        "displayName",
+        "entityKinds"
+      ],
+      "properties": {
+        "calendar": {
+          "$ref": "#/$defs/calendarHref"
+        },
+        "displayName": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "entityKinds": {
+          "$ref": "#/$defs/entityKinds"
+        }
+      }
+    },
+    "mutationErrorOutcome": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "code",
+        "category",
+        "message",
+        "retryable",
+        "phase",
+        "mutationState"
+      ],
+      "properties": {
+        "code": {
+          "enum": [
+            "invalid_input",
+            "invalid_calendar_data",
+            "not_found",
+            "ambiguous",
+            "outside_scope",
+            "entity_kind_mismatch",
+            "unsupported_capability",
+            "opaque_resource",
+            "temporal_unresolved",
+            "recurrence_unevaluable",
+            "conflict",
+            "destination_conflict",
+            "concurrency_unavailable",
+            "limit_exhausted",
+            "payload_too_large",
+            "busy",
+            "upstream_unauthorized",
+            "upstream_forbidden",
+            "upstream_rate_limited",
+            "upstream_unavailable",
+            "upstream_protocol_error",
+            "confirmation_expired",
+            "confirmation_mismatch",
+            "fidelity_failure",
+            "committed_but_unverified",
+            "committed_but_concurrency_unavailable",
+            "indeterminate"
+          ]
+        },
+        "category": {
+          "enum": [
+            "input",
+            "selection",
+            "capabilityAndProjection",
+            "state",
+            "limitsAndAdmission",
+            "upstream",
+            "confirmation",
+            "postWriteTruth"
+          ]
+        },
+        "message": {
+          "type": "string"
+        },
+        "retryable": {
+          "type": "boolean"
+        },
+        "phase": {
+          "enum": [
+            "transportAuthorization",
+            "admissionAndPayload",
+            "schemaLexicalDiscriminator",
+            "originScopeAuthorization",
+            "selectionDiscoveryCapability",
+            "targetRevision",
+            "completeResourceSemantics",
+            "mrtr",
+            "execution",
+            "postWriteVerificationOrReconciliation"
+          ]
+        },
+        "violations": {
+          "type": "array",
+          "maxItems": 32,
+          "items": {
+            "$ref": "#/$defs/violation"
+          }
+        },
+        "limits": {
+          "$ref": "#/$defs/executionLimits"
+        },
+        "retryAfterMs": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "authorizedCandidates": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/authorizedCandidate"
+          }
+        },
+        "currentSnapshot": {
+          "$ref": "#/$defs/calendarSnapshot"
+        },
+        "mutationState": {
+          "enum": [
+            "not_attempted",
+            "not_committed",
+            "committed",
+            "unknown"
+          ]
+        }
+      }
+    },
+    "snapshotMutationSuccess": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "outcome",
+        "mutationState",
+        "snapshot",
+        "diagnostics"
+      ],
+      "properties": {
+        "outcome": {
+          "const": "success"
+        },
+        "mutationState": {
+          "const": "committed"
+        },
+        "snapshot": {
+          "$ref": "#/$defs/calendarSnapshot"
+        },
+        "diagnostics": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/diagnostic"
+          }
+        }
+      }
+    },
+    "deleteMutationSuccess": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "outcome",
+        "mutationState",
+        "deletionReceipt",
+        "diagnostics"
+      ],
+      "properties": {
+        "outcome": {
+          "const": "success"
+        },
+        "mutationState": {
+          "const": "committed"
+        },
+        "deletionReceipt": {
+          "$ref": "#/$defs/deletionReceipt"
+        },
+        "diagnostics": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/diagnostic"
+          }
+        }
+      }
+    },
+    "nonMutatingMutationSuccess": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "outcome",
+        "mutationState",
+        "diagnostics"
+      ],
+      "properties": {
+        "outcome": {
+          "enum": [
+            "no_change",
+            "confirmation_declined"
+          ]
+        },
+        "mutationState": {
+          "const": "not_attempted"
+        },
+        "diagnostics": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/diagnostic"
+          }
+        }
+      }
+    },
+    "snapshotMutationOutcome": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/snapshotMutationSuccess"
+        },
+        {
+          "$ref": "#/$defs/nonMutatingMutationSuccess"
+        },
+        {
+          "$ref": "#/$defs/mutationErrorOutcome"
+        }
+      ]
+    },
+    "exactMutationErrorOutcome": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "code",
+        "category",
+        "message",
+        "retryable",
+        "phase",
+        "mutationState"
+      ],
+      "properties": {
+        "code": {
+          "enum": [
+            "invalid_input",
+            "invalid_calendar_data",
+            "not_found",
+            "outside_scope",
+            "entity_kind_mismatch",
+            "unsupported_capability",
+            "conflict",
+            "destination_conflict",
+            "concurrency_unavailable",
+            "limit_exhausted",
+            "payload_too_large",
+            "busy",
+            "upstream_unauthorized",
+            "upstream_forbidden",
+            "upstream_rate_limited",
+            "upstream_unavailable",
+            "upstream_protocol_error",
+            "confirmation_expired",
+            "confirmation_mismatch",
+            "fidelity_failure",
+            "committed_but_unverified",
+            "committed_but_concurrency_unavailable",
+            "indeterminate"
+          ]
+        },
+        "category": {
+          "enum": [
+            "input",
+            "selection",
+            "capabilityAndProjection",
+            "state",
+            "limitsAndAdmission",
+            "upstream",
+            "confirmation",
+            "postWriteTruth"
+          ]
+        },
+        "message": {
+          "type": "string"
+        },
+        "retryable": {
+          "type": "boolean"
+        },
+        "phase": {
+          "enum": [
+            "transportAuthorization",
+            "admissionAndPayload",
+            "schemaLexicalDiscriminator",
+            "originScopeAuthorization",
+            "selectionDiscoveryCapability",
+            "targetRevision",
+            "completeResourceSemantics",
+            "mrtr",
+            "execution",
+            "postWriteVerificationOrReconciliation"
+          ]
+        },
+        "violations": {
+          "type": "array",
+          "maxItems": 32,
+          "items": { "$ref": "#/$defs/violation" }
+        },
+        "limits": {
+          "$ref": "#/$defs/executionLimits"
+        },
+        "mutationState": {
+          "enum": [
+            "not_attempted",
+            "not_committed",
+            "committed",
+            "unknown"
+          ]
+        },
+        "currentSnapshot": {
+          "$ref": "#/$defs/exactConflictSnapshot"
+        },
+        "retryAfterMs": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "exactSnapshotMutationOutcome": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/snapshotMutationSuccess"
+        },
+        {
+          "$ref": "#/$defs/nonMutatingMutationSuccess"
+        },
+        {
+          "$ref": "#/$defs/exactMutationErrorOutcome"
+        }
+      ]
+    },
+    "deleteMutationOutcome": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/deleteMutationSuccess"
+        },
+        {
+          "$ref": "#/$defs/nonMutatingMutationSuccess"
+        },
+        {
+          "$ref": "#/$defs/mutationErrorOutcome"
+        }
+      ]
+    },
+    "mrtrRequestedProperty": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "type"
+      ],
+      "properties": {
+        "type": {
+          "const": "boolean"
+        },
+        "title": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "default": {
+          "type": "boolean"
+        }
+      }
+    },
+    "mrtrCapability": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        }
+      }
+    },
+    "mrtrResponseValue": {
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "number"
+        },
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      ]
+    },
+    "occurrenceTiming": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "sourceStart",
+        "effectiveStart"
+      ],
+      "properties": {
+        "sourceStart": {
+          "$ref": "#/$defs/temporalValue"
+        },
+        "effectiveStart": {
+          "$ref": "#/$defs/temporalValue"
+        },
+        "sourceEnd": {
+          "$ref": "#/$defs/temporalValue"
+        },
+        "effectiveEnd": {
+          "$ref": "#/$defs/temporalValue"
+        },
+        "sourceDuration": {
+          "type": "string"
+        },
+        "effectiveDuration": {
+          "type": "string"
+        },
+        "evaluatedStartUtc": {
+          "$ref": "#/$defs/utcTemporalValue"
+        },
+        "evaluatedEndUtc": {
+          "$ref": "#/$defs/utcTemporalValue"
+        },
+        "evaluationTimeZone": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "calendarHref": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "href"
+      ],
+      "properties": {
+        "href": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "resourceRevision": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "href",
+        "entityTag"
+      ],
+      "properties": {
+        "href": {
+          "type": "string",
+          "format": "uri"
+        },
+        "entityTag": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    }
+  },
+  "duplicatePropertyPolicy": {
+    "parser": "reject",
+    "scope": "all contract inputs and protocol envelopes",
+    "failureCode": "invalid_input"
+  }
+}

--- a/contracts/0.2.3/radicale-3.7.8-profile.json
+++ b/contracts/0.2.3/radicale-3.7.8-profile.json
@@ -1,0 +1,18 @@
+{
+  "profile": "radicale-3.7.8",
+  "image": "ghcr.io/kozea/radicale@sha256:3a0080ea51ac69dcd74e345b9587dc14a8c8af0652046069005749f9a75c5c80",
+  "ociIndexDigest": "sha256:3a0080ea51ac69dcd74e345b9587dc14a8c8af0652046069005749f9a75c5c80",
+  "platformManifests": {
+    "linux/amd64": "sha256:7e2d729c434574762b058d57c7c81641ade11655da6d0eede948512d53873e71",
+    "linux/arm64": "sha256:1691eb75474f38f9c0ce75e60a026a3c338b7c91a1cd9ed622557f141b0eb5b8"
+  },
+  "runtime": { "radicale": "3.7.8", "python": "3.14.7", "vobject": "0.9.9" },
+  "variants": [
+    { "name": "baseline", "timeZone": "UTC", "strictPreconditions": false },
+    { "name": "strict-preconditions", "timeZone": "UTC", "strictPreconditions": true },
+    { "name": "alternate-time-zone", "timeZone": "America/New_York", "strictPreconditions": false }
+  ],
+  "selector": "RADICALE_CONFORMANCE_VARIANT",
+  "evidenceFixture": "RadicaleConformanceFixture",
+  "legacyTaskFixturesAreEvidence": false
+}

--- a/docs/migrating-0.2.2-to-0.2.3.md
+++ b/docs/migrating-0.2.2-to-0.2.3.md
@@ -1,0 +1,64 @@
+# Migrating from contract 0.2.2 to 0.2.3
+
+Contract 0.2.3 deliberately replaces query replay and Move preflight behavior.
+Tool names and the 17-tool default catalog remain unchanged, but the three query
+input contracts, their continuation tokens, Temporal Evaluation Context rules,
+and Move interoperability requirements change.
+
+## Query migration
+
+- Treat `calendar_entities.query`, `calendar_occurrences.query`, and
+  `todos.query` as strict Start-or-Continue unions.
+- Send query criteria only on Start. Send only the Continuation Cursor and
+  optional page size on Continue; do not repeat Start criteria.
+- Discard every 0.2.2 query cursor during upgrade. A 0.2.3 Continue addresses a
+  process-local Query Result Snapshot and is not portable across versions or
+  server restarts.
+- Expect a fixed ten-minute snapshot expiry from the first page. Continuing a
+  snapshot does not extend its lifetime and performs no CalDAV, parsing,
+  filtering, projection, or recurrence work.
+- Provide `evaluationTimeZone` or configure
+  `CALDAV_EVALUATION_TIME_ZONE` for every Occurrence or To-do Start and every
+  bounded Calendar Entity Start. Use an exact IANA time-zone identifier.
+- Do not send an unused caller time-zone override for an unbounded Calendar
+  Entity Start; it is rejected before discovery.
+
+Normal retrieval continues to use `calendar-multiget`. Direct GET Compatibility
+Mode is automatic only after verified HTTP 405, HTTP 501, or explicit DAV
+unsupported evidence. Other multiget failures return a typed
+`upstream_protocol_error` without partial query results.
+
+## Move migration
+
+Set `CALDAV_INTEROPERABILITY_PROFILE=radicale-3.7.8` only when the server is the
+digest-pinned verified profile. Semantic and Exact Move fail closed with
+`unsupported_capability` when that profile is absent. No legacy collection-scan
+fallback is available.
+
+Move now delegates destination and UID collision truth to one conditional MOVE
+and reconciles source and destination with bounded probes. Clients should treat
+`destination_conflict` as exact destination occupancy and other `conflict`
+results as deliberately non-disclosing. Exact Move still requires MRTR, but its
+opaque request state now binds a protected one-use execution plan. Discard
+pending 0.2.2 Move confirmations and request a new review after upgrade.
+
+## Telemetry configuration
+
+Telemetry remains disabled by default. A non-empty
+`OTEL_EXPORTER_OTLP_ENDPOINT` opts into the bounded, privacy-allowlisted OTLP
+pipeline unless `OTEL_SDK_DISABLED=true`. Review endpoint, protocol, headers,
+and service-name configuration before enabling export; no CalDAV identifiers,
+credentials, payloads, URLs, or exception details are intended to leave the
+process.
+
+## Deployment and rollback
+
+Before switching clients, configure the Temporal Evaluation Context and, when
+applicable, the verified interoperability profile. Restart the MCP process,
+rediscover the catalog, and start fresh query and MRTR flows. No CalDAV data
+migration or rewrite is performed.
+
+Rollback by pinning `dotnet-agents-caldav@0.2.2`, removing any configuration
+used only by 0.2.3 if desired, restarting the MCP process, and rediscovering the
+0.2.2 catalog. Discard all 0.2.3 Continuation Cursors and MRTR request states;
+they are not portable to the older contract.

--- a/scripts/verify-release-package.sh
+++ b/scripts/verify-release-package.sh
@@ -50,7 +50,7 @@ verify_identity() {
 require_entry() {
   local archive=$1
   local entry=$2
-  if ! unzip -Z1 "$archive" | grep -Fxq "$entry"; then
+  if ! unzip -Z1 "$archive" | grep -Fx "$entry" >/dev/null; then
     echo "missing required package entry: $entry" >&2
     return 1
   fi


### PR DESCRIPTION
Prepares the versioned 0.2.3 contract snapshot, migration guide, changelog, release notes, and README links. Also fixes final-package entry validation for larger archives under pipefail. Validated with the Release build, full isolated test suite, coverage gates, all Radicale variants, Slopwatch, and installation plus MCP smoke testing of the exact local 0.2.3 package.