### PR TITLE
Deepen operation-scoped Calendar discovery into one immutable authority

### DIFF
--- a/src/DotnetAgents.CalDav.Core/DependencyInjection/CalDavServiceCollectionExtensions.cs
+++ b/src/DotnetAgents.CalDav.Core/DependencyInjection/CalDavServiceCollectionExtensions.cs
@@ -137,7 +137,7 @@ public static class CalDavServiceCollectionExtensions
         {
             var policy = serviceProvider.GetRequiredService<CalendarDiscoveryPolicy>();
             return new CalendarOperationDiscovery(
-                serviceProvider.GetRequiredService<ICalendarClient>(),
+                new CalendarClientDiscoveryTransport(serviceProvider.GetRequiredService<ICalendarClient>()),
                 serviceProvider.GetRequiredService<IOptions<CalDavOptions>>(),
                 policy.ApplyScope,
                 policy.ResolveDefault);

--- a/src/DotnetAgents.CalDav.Core/Internal/CalDavClient.cs
+++ b/src/DotnetAgents.CalDav.Core/Internal/CalDavClient.cs
@@ -20,7 +20,7 @@ namespace DotnetAgents.CalDav.Core.Internal;
 /// HttpClient-based CalDAV client for Calendar Object Resources.
 /// Handles PROPFIND, REPORT, GET, PUT, MKCALENDAR, and DELETE verbs with XML/iCalendar encoding.
 /// </summary>
-internal sealed class CalDavClient : ICalendarClient, ICalendarCreateTransport, ICalendarMoveResourceTransport
+internal sealed class CalDavClient : ICalendarClient, ICalendarMoveResourceTransport
 {
     private const int MaximumCalendarResourceBytes = 4 * 1024 * 1024;
     private static readonly UTF8Encoding StrictUtf8 = new(false, true);

--- a/src/DotnetAgents.CalDav.Core/Internal/CalendarOperationDiscovery.cs
+++ b/src/DotnetAgents.CalDav.Core/Internal/CalendarOperationDiscovery.cs
@@ -94,14 +94,6 @@ internal sealed record CalendarOperationDiscoveryResult(
     CalendarSelectionResult EventDefault,
     CalendarSelectionResult TodoDefault)
 {
-    internal CalendarOperationDiscoveryResult(
-        CalendarDiscoveryResult discovery,
-        CalendarSelectionResult eventDefault,
-        CalendarSelectionResult todoDefault)
-        : this(default, discovery, eventDefault, todoDefault)
-    {
-    }
-
     internal CalendarSelectionResult Default(CalendarEntityKind entityKind) => entityKind switch
     {
         CalendarEntityKind.Event => EventDefault,

--- a/src/DotnetAgents.CalDav.Core/Internal/CalendarOperationDiscovery.cs
+++ b/src/DotnetAgents.CalDav.Core/Internal/CalendarOperationDiscovery.cs
@@ -7,10 +7,23 @@ using Microsoft.Extensions.Options;
 
 namespace DotnetAgents.CalDav.Core.Internal;
 
-/// <summary>Coordinates one immutable CalDAV discovery acquisition per authorization-bound key and operation.</summary>
-internal sealed class CalendarOperationDiscovery : ICalendarClient, ICalendarCreateTransport, ICalendarMoveTransport
+/// <summary>True-external seam for one CalDAV Calendar discovery acquisition.</summary>
+internal interface ICalendarDiscoveryTransport
 {
-    private readonly ICalendarClient _transport;
+    Task<IReadOnlyList<CalendarDescriptor>> DiscoverAsync(CancellationToken cancellationToken);
+}
+
+/// <summary>Production adapter from the broad CalDAV client to discovery-only acquisition.</summary>
+internal sealed class CalendarClientDiscoveryTransport(ICalendarClient client) : ICalendarDiscoveryTransport
+{
+    public Task<IReadOnlyList<CalendarDescriptor>> DiscoverAsync(CancellationToken cancellationToken) =>
+        client.GetCalendarsAsync(cancellationToken);
+}
+
+/// <summary>Coordinates one immutable CalDAV discovery acquisition per authorization-bound key and operation.</summary>
+internal sealed class CalendarOperationDiscovery
+{
+    private readonly ICalendarDiscoveryTransport _transport;
     private readonly Func<IReadOnlyList<CalendarDescriptor>, CalendarDiscoveryResult> _applyScope;
     private readonly Func<CalendarEntityKind, IReadOnlyList<CalendarDescriptor>, IReadOnlyList<CalendarDescriptor>, CalendarSelectionResult>
         _resolveDefault;
@@ -18,7 +31,7 @@ internal sealed class CalendarOperationDiscovery : ICalendarClient, ICalendarCre
     private readonly ConcurrentDictionary<CalendarDiscoveryKey, Lazy<Task<CalendarOperationDiscoveryResult>>> _results = new();
 
     public CalendarOperationDiscovery(
-        ICalendarClient transport,
+        ICalendarDiscoveryTransport transport,
         IOptions<CalDavOptions> options,
         Func<IReadOnlyList<CalendarDescriptor>, CalendarDiscoveryResult> applyScope,
         Func<CalendarEntityKind, IReadOnlyList<CalendarDescriptor>, IReadOnlyList<CalendarDescriptor>, CalendarSelectionResult>
@@ -30,117 +43,14 @@ internal sealed class CalendarOperationDiscovery : ICalendarClient, ICalendarCre
         _key = CalendarDiscoveryKey.Create(options.Value, CalendarOperationContextGeneration.Create());
     }
 
-    public void RediscoverCapabilities() => _transport.RediscoverCapabilities();
-
-    public async Task<IReadOnlyList<CalendarDescriptor>> GetCalendarsAsync(CancellationToken cancellationToken)
-    {
-        return (await GetResultAsync(cancellationToken).ConfigureAwait(false)).Discovery.Items;
-    }
-
-    public async Task<CalendarDiscoveryResult> GetScopedResultAsync(CancellationToken cancellationToken) =>
-        (await GetResultAsync(cancellationToken).ConfigureAwait(false)).Discovery;
-
-    public CalendarSelectionResult ResolveDefault(CalendarEntityKind entityKind)
-    {
-        if (!_results.TryGetValue(_key, out var acquisition))
-            throw new InvalidOperationException("Calendar discovery must complete before default selection.");
-        var task = acquisition.IsValueCreated ? acquisition.Value : null;
-        var result = task is { IsCompletedSuccessfully: true }
-            ? task.Result
-            : throw new InvalidOperationException("Calendar discovery must complete before default selection.");
-        return entityKind switch
-        {
-            CalendarEntityKind.Event => result.EventDefault,
-            CalendarEntityKind.Todo => result.TodoDefault,
-            _ => CalendarSelectionResult.Failure(CalendarSelectionCode.NotFound)
-        };
-    }
-
-    public Task<CalendarResourceRead> GetCalendarResourceAsync(
-        string href,
-        CancellationToken cancellationToken) => _transport.GetCalendarResourceAsync(href, cancellationToken);
-
-    public Task<CalendarResourceCreateResult> CreateCalendarResourceAsync(
-        CalendarResourceCreateRequest request,
-        CancellationToken cancellationToken) => _transport.CreateCalendarResourceAsync(request, cancellationToken);
-
-    public Task<CalendarResourceDeleteDispatchResult> DeleteCalendarResourceAsync(
-        CalendarResourceDeleteRequest request,
-        CancellationToken cancellationToken) => _transport.DeleteCalendarResourceAsync(request, cancellationToken);
-
-    public Task<CalendarResourceMoveDispatchResult> MoveCalendarResourceAsync(
-        CalendarResourceMoveDispatchRequest request,
-        CancellationToken cancellationToken) => _transport.MoveCalendarResourceAsync(request, cancellationToken);
-
-    public Task<CalendarResourceUpdateDispatchResult> UpdateCalendarResourceAsync(
-        CalendarResourceUpdateRequest request,
-        CancellationToken cancellationToken) => _transport.UpdateCalendarResourceAsync(request, cancellationToken);
-
-    async Task<CalendarMoveDiscoveryResult> ICalendarMoveTransport.DiscoverCalendarsAsync(
-        CancellationToken cancellationToken)
-    {
-        var result = await GetResultAsync(cancellationToken).ConfigureAwait(false);
-        return new CalendarMoveDiscoveryResult(
-            result.Discovery,
-            result.EventDefault,
-            result.TodoDefault);
-    }
-
-    Task<CalendarResourceRead> ICalendarMoveTransport.ReadSourceAsync(
-        string sourceCalendarHref,
-        string href,
-        CancellationToken cancellationToken) => _transport is ICalendarMoveResourceTransport moveTransport
-            ? moveTransport.ReadMoveResourceAsync(sourceCalendarHref, href, absenceProbe: false, cancellationToken)
-            : Task.FromResult(new CalendarResourceRead(CalendarResourceReadCode.UnsupportedCapability));
-
-    Task<CalendarResourceRead> ICalendarMoveTransport.ProbeDestinationPresenceAsync(
-        string destinationCalendarHref,
-        string href,
-        CancellationToken cancellationToken) => _transport is ICalendarMoveResourceTransport moveTransport
-            ? moveTransport.ProbeMoveResourcePresenceAsync(destinationCalendarHref, href, cancellationToken)
-            : Task.FromResult(new CalendarResourceRead(CalendarResourceReadCode.UnsupportedCapability));
-
-    Task<CalendarResourceRead> ICalendarMoveTransport.ObserveResourceAsync(
-        string authorizedCalendarHref,
-        string href,
-        CancellationToken cancellationToken) => ProbeThroughReadAsync(
-        authorizedCalendarHref,
-        href,
-        cancellationToken);
-
-    Task<CalendarResourceMoveDispatchResult> ICalendarMoveTransport.DispatchAsync(
-        string sourceCalendarHref,
-        string destinationCalendarHref,
-        CalendarResourceMoveDispatchRequest request,
-        CancellationToken cancellationToken) => _transport is ICalendarMoveResourceTransport moveTransport
-            ? moveTransport.DispatchMoveAsync(
-                sourceCalendarHref,
-                destinationCalendarHref,
-                request,
-                cancellationToken)
-            : Task.FromResult(new CalendarResourceMoveDispatchResult(
-                CalendarResourceMoveDispatchCode.UnsupportedCapability));
-
-    private async Task<CalendarResourceRead> ProbeThroughReadAsync(
-        string authorizedCalendarHref,
-        string href,
-        CancellationToken cancellationToken)
-    {
-        using var scope = CalendarHttpTelemetry.BeginAbsenceProbe();
-        return _transport is ICalendarMoveResourceTransport moveTransport
-            ? await moveTransport.ReadMoveResourceAsync(
-                authorizedCalendarHref,
-                href,
-                absenceProbe: true,
-                cancellationToken)
-            : new CalendarResourceRead(CalendarResourceReadCode.UnsupportedCapability);
-    }
+    public Task<CalendarOperationDiscoveryResult> DiscoverAsync(CancellationToken cancellationToken) =>
+        GetResultAsync(cancellationToken);
 
     private async Task<CalendarOperationDiscoveryResult> AcquireAsync(
         CalendarDiscoveryKey key,
         CancellationToken cancellationToken)
     {
-        var calendars = await _transport.GetCalendarsAsync(cancellationToken).ConfigureAwait(false);
+        var calendars = await _transport.DiscoverAsync(cancellationToken).ConfigureAwait(false);
         var scoped = _applyScope(calendars);
         var frozenItems = scoped.Items.Select(Freeze).ToImmutableArray();
         var frozenDiscovery = new CalendarDiscoveryResult(
@@ -149,8 +59,8 @@ internal sealed class CalendarOperationDiscovery : ICalendarClient, ICalendarCre
         return new CalendarOperationDiscoveryResult(
             key,
             frozenDiscovery,
-            _resolveDefault(CalendarEntityKind.Event, calendars, frozenItems),
-            _resolveDefault(CalendarEntityKind.Todo, calendars, frozenItems));
+            FreezeSelection(_resolveDefault(CalendarEntityKind.Event, calendars, frozenItems)),
+            FreezeSelection(_resolveDefault(CalendarEntityKind.Todo, calendars, frozenItems)));
     }
 
     private Task<CalendarOperationDiscoveryResult> GetResultAsync(CancellationToken cancellationToken)
@@ -165,9 +75,15 @@ internal sealed class CalendarOperationDiscovery : ICalendarClient, ICalendarCre
 
     private static CalendarDescriptor Freeze(CalendarDescriptor calendar) => calendar with
     {
-        EventEvidence = calendar.EventEvidence.ToArray(),
-        TodoEvidence = calendar.TodoEvidence.ToArray(),
-        UnavailableProperties = calendar.UnavailableProperties.ToArray()
+        EventEvidence = calendar.EventEvidence.ToImmutableArray(),
+        TodoEvidence = calendar.TodoEvidence.ToImmutableArray(),
+        UnavailableProperties = calendar.UnavailableProperties.ToImmutableArray()
+    };
+
+    private static CalendarSelectionResult FreezeSelection(CalendarSelectionResult selection) => selection.Code switch
+    {
+        CalendarSelectionCode.Success => CalendarSelectionResult.Success(selection.Calendar!),
+        _ => CalendarSelectionResult.Failure(selection.Code, selection.Candidates.ToImmutableArray())
     };
 
 }
@@ -176,7 +92,23 @@ internal sealed record CalendarOperationDiscoveryResult(
     CalendarDiscoveryKey Key,
     CalendarDiscoveryResult Discovery,
     CalendarSelectionResult EventDefault,
-    CalendarSelectionResult TodoDefault);
+    CalendarSelectionResult TodoDefault)
+{
+    internal CalendarOperationDiscoveryResult(
+        CalendarDiscoveryResult discovery,
+        CalendarSelectionResult eventDefault,
+        CalendarSelectionResult todoDefault)
+        : this(default, discovery, eventDefault, todoDefault)
+    {
+    }
+
+    internal CalendarSelectionResult Default(CalendarEntityKind entityKind) => entityKind switch
+    {
+        CalendarEntityKind.Event => EventDefault,
+        CalendarEntityKind.Todo => TodoDefault,
+        _ => CalendarSelectionResult.Failure(CalendarSelectionCode.NotFound)
+    };
+}
 
 internal readonly record struct CalendarDiscoveryKey(
     string Origin,

--- a/src/DotnetAgents.CalDav.Core/Internal/CalendarQueryTransport.cs
+++ b/src/DotnetAgents.CalDav.Core/Internal/CalendarQueryTransport.cs
@@ -7,14 +7,8 @@ internal sealed class CalendarQueryTransport(
     CalendarOperationDiscovery discovery,
     CalDavClient client) : ICalendarQueryTransport
 {
-    public async Task<CalendarQueryDiscovery> DiscoverAsync(CancellationToken cancellationToken)
-    {
-        var scoped = await discovery.GetScopedResultAsync(cancellationToken).ConfigureAwait(false);
-        return new CalendarQueryDiscovery(
-            scoped,
-            discovery.ResolveDefault(CalendarEntityKind.Event),
-            discovery.ResolveDefault(CalendarEntityKind.Todo));
-    }
+    public Task<CalendarOperationDiscoveryResult> DiscoverAsync(CancellationToken cancellationToken) =>
+        discovery.DiscoverAsync(cancellationToken);
 
     public async Task<IReadOnlyList<string>> QueryCandidateHrefsAsync(
         string calendarHref,

--- a/src/DotnetAgents.CalDav.Core/Internal/ICalendarCreateTransport.cs
+++ b/src/DotnetAgents.CalDav.Core/Internal/ICalendarCreateTransport.cs
@@ -5,7 +5,7 @@ namespace DotnetAgents.CalDav.Core.Internal;
 
 internal interface ICalendarCreateTransport
 {
-    Task<IReadOnlyList<CalendarDescriptor>> GetCalendarsAsync(CancellationToken cancellationToken);
+    Task<CalendarOperationDiscoveryResult> DiscoverAsync(CancellationToken cancellationToken);
 
     Task<CalendarResourceRead> GetCalendarResourceAsync(string href, CancellationToken cancellationToken);
 
@@ -22,10 +22,12 @@ internal interface ICalendarCreateTransport
         CancellationToken cancellationToken);
 }
 
-internal sealed class CalendarClientCreateTransport(ICalendarClient client) : ICalendarCreateTransport
+internal sealed class CalendarClientCreateTransport(
+    CalendarOperationDiscovery discovery,
+    ICalendarClient client) : ICalendarCreateTransport
 {
-    public Task<IReadOnlyList<CalendarDescriptor>> GetCalendarsAsync(CancellationToken cancellationToken) =>
-        client.GetCalendarsAsync(cancellationToken);
+    public Task<CalendarOperationDiscoveryResult> DiscoverAsync(CancellationToken cancellationToken) =>
+        discovery.DiscoverAsync(cancellationToken);
 
     public Task<CalendarResourceRead> GetCalendarResourceAsync(string href, CancellationToken cancellationToken) =>
         client.GetCalendarResourceAsync(href, cancellationToken);

--- a/src/DotnetAgents.CalDav.Core/Internal/ICalendarMoveTransport.cs
+++ b/src/DotnetAgents.CalDav.Core/Internal/ICalendarMoveTransport.cs
@@ -6,7 +6,7 @@ namespace DotnetAgents.CalDav.Core.Internal;
 /// <summary>Closed CalDAV seam for one server-authoritative Calendar Object Resource Move.</summary>
 internal interface ICalendarMoveTransport
 {
-    Task<CalendarMoveDiscoveryResult> DiscoverCalendarsAsync(CancellationToken cancellationToken);
+    Task<CalendarOperationDiscoveryResult> DiscoverAsync(CancellationToken cancellationToken);
 
     Task<CalendarResourceRead> ReadSourceAsync(
         string sourceCalendarHref,
@@ -50,15 +50,52 @@ internal interface ICalendarMoveResourceTransport
         CancellationToken cancellationToken);
 }
 
-internal sealed record CalendarMoveDiscoveryResult(
-    CalendarDiscoveryResult ScopedDiscovery,
-    CalendarSelectionResult EventDefault,
-    CalendarSelectionResult TodoDefault)
+internal sealed class CalendarClientMoveTransport(
+    CalendarOperationDiscovery discovery,
+    ICalendarClient client) : ICalendarMoveTransport
 {
-    internal CalendarSelectionResult ResolveDefault(CalendarEntityKind entityKind) => entityKind switch
+    public Task<CalendarOperationDiscoveryResult> DiscoverAsync(CancellationToken cancellationToken) =>
+        discovery.DiscoverAsync(cancellationToken);
+
+    public Task<CalendarResourceRead> ReadSourceAsync(
+        string sourceCalendarHref,
+        string href,
+        CancellationToken cancellationToken) => client is ICalendarMoveResourceTransport moveTransport
+            ? moveTransport.ReadMoveResourceAsync(sourceCalendarHref, href, absenceProbe: false, cancellationToken)
+            : Task.FromResult(new CalendarResourceRead(CalendarResourceReadCode.UnsupportedCapability));
+
+    public Task<CalendarResourceRead> ProbeDestinationPresenceAsync(
+        string destinationCalendarHref,
+        string href,
+        CancellationToken cancellationToken) => client is ICalendarMoveResourceTransport moveTransport
+            ? moveTransport.ProbeMoveResourcePresenceAsync(destinationCalendarHref, href, cancellationToken)
+            : Task.FromResult(new CalendarResourceRead(CalendarResourceReadCode.UnsupportedCapability));
+
+    public async Task<CalendarResourceRead> ObserveResourceAsync(
+        string authorizedCalendarHref,
+        string href,
+        CancellationToken cancellationToken)
     {
-        CalendarEntityKind.Event => EventDefault,
-        CalendarEntityKind.Todo => TodoDefault,
-        _ => CalendarSelectionResult.Failure(CalendarSelectionCode.NotFound)
-    };
+        using var scope = CalendarHttpTelemetry.BeginAbsenceProbe();
+        return client is ICalendarMoveResourceTransport moveTransport
+            ? await moveTransport.ReadMoveResourceAsync(
+                authorizedCalendarHref,
+                href,
+                absenceProbe: true,
+                cancellationToken)
+            : new CalendarResourceRead(CalendarResourceReadCode.UnsupportedCapability);
+    }
+
+    public Task<CalendarResourceMoveDispatchResult> DispatchAsync(
+        string sourceCalendarHref,
+        string destinationCalendarHref,
+        CalendarResourceMoveDispatchRequest request,
+        CancellationToken cancellationToken) => client is ICalendarMoveResourceTransport moveTransport
+            ? moveTransport.DispatchMoveAsync(
+                sourceCalendarHref,
+                destinationCalendarHref,
+                request,
+                cancellationToken)
+            : Task.FromResult(new CalendarResourceMoveDispatchResult(
+                CalendarResourceMoveDispatchCode.UnsupportedCapability));
 }

--- a/src/DotnetAgents.CalDav.Core/Internal/ICalendarQueryTransport.cs
+++ b/src/DotnetAgents.CalDav.Core/Internal/ICalendarQueryTransport.cs
@@ -5,7 +5,7 @@ namespace DotnetAgents.CalDav.Core.Internal;
 /// <summary>Narrow true-external seam used only by initial query execution.</summary>
 internal interface ICalendarQueryTransport
 {
-    Task<CalendarQueryDiscovery> DiscoverAsync(CancellationToken cancellationToken);
+    Task<CalendarOperationDiscoveryResult> DiscoverAsync(CancellationToken cancellationToken);
 
     Task<IReadOnlyList<string>> QueryCandidateHrefsAsync(
         string calendarHref,
@@ -35,17 +35,4 @@ internal abstract record CalendarMultigetResult
     internal sealed record Resources(IReadOnlyList<CalendarResourceRead> Values) : CalendarMultigetResult;
 
     internal sealed record VerifiedUnavailable : CalendarMultigetResult;
-}
-
-internal sealed record CalendarQueryDiscovery(
-    CalendarDiscoveryResult Discovery,
-    CalendarSelectionResult EventDefault,
-    CalendarSelectionResult TodoDefault)
-{
-    internal CalendarSelectionResult Default(CalendarEntityKind kind) => kind switch
-    {
-        CalendarEntityKind.Event => EventDefault,
-        CalendarEntityKind.Todo => TodoDefault,
-        _ => CalendarSelectionResult.Failure(CalendarSelectionCode.NotFound)
-    };
 }

--- a/src/DotnetAgents.CalDav.Core/Services/CalendarCreationModule.cs
+++ b/src/DotnetAgents.CalDav.Core/Services/CalendarCreationModule.cs
@@ -13,10 +13,7 @@ internal sealed class CalendarCreationModule(
     ICalendarCreateTransport transport,
     CalDavOptions options,
     TimeProvider timeProvider,
-    ICalendarEntityIdentityGenerator identityGenerator,
-    Func<IReadOnlyList<CalendarDescriptor>, CalendarDiscoveryResult> applyScope,
-    Func<CalendarEntityKind, IReadOnlyList<CalendarDescriptor>, IReadOnlyList<CalendarDescriptor>, CalendarSelectionResult>
-        resolveDefaultCalendar)
+    ICalendarEntityIdentityGenerator identityGenerator)
 {
     private const int MaximumAttempts = 3;
     private const int MaximumDiagnostics = 32;
@@ -353,10 +350,10 @@ internal sealed class CalendarCreationModule(
         CalendarEntityKind entityKind,
         CancellationToken cancellationToken)
     {
-        var discovered = await transport.GetCalendarsAsync(cancellationToken);
-        var scoped = applyScope(discovered).Items;
+        var discovery = await transport.DiscoverAsync(cancellationToken);
+        var scoped = discovery.Discovery.Items;
         if (destination.Mode == CalendarEntityScopeMode.Default)
-            return resolveDefaultCalendar(entityKind, discovered, scoped);
+            return discovery.Default(entityKind);
 
         var matches = FindCalendarMatches(scoped, destination.Calendar!);
         if (matches.Length == 0)
@@ -747,7 +744,7 @@ internal sealed class CalendarCreationModule(
         try
         {
             return new ExactDiscoveryAttempt(
-                applyScope(await transport.GetCalendarsAsync(cancellationToken)).Items,
+                (await transport.DiscoverAsync(cancellationToken)).Discovery.Items,
                 null);
         }
         catch (Exception exception) when (IsExactPhaseFailure(exception, cancellationToken))

--- a/src/DotnetAgents.CalDav.Core/Services/CalendarExactMoveModule.cs
+++ b/src/DotnetAgents.CalDav.Core/Services/CalendarExactMoveModule.cs
@@ -142,8 +142,8 @@ internal sealed class CalendarExactMoveModule(
         CalendarExactMoveRequest request,
         CancellationToken cancellationToken)
     {
-        var discovery = await transport.DiscoverCalendarsAsync(cancellationToken).ConfigureAwait(false);
-        var calendars = discovery.ScopedDiscovery.Items;
+        var discovery = await transport.DiscoverAsync(cancellationToken).ConfigureAwait(false);
+        var calendars = discovery.Discovery.Items;
         var sourceCalendar = FindCalendar(request.Revision.Href, calendars);
         var destinationCalendar = FindCalendar(request.DestinationHref, calendars);
         if (sourceCalendar is null || destinationCalendar is null)

--- a/src/DotnetAgents.CalDav.Core/Services/CalendarMoveModule.cs
+++ b/src/DotnetAgents.CalDav.Core/Services/CalendarMoveModule.cs
@@ -140,8 +140,8 @@ internal sealed class CalendarMoveModule(
         CalendarResourceMoveRequest request,
         CancellationToken cancellationToken)
     {
-        var discovery = await transport.DiscoverCalendarsAsync(cancellationToken);
-        var scoped = discovery.ScopedDiscovery.Items;
+        var discovery = await transport.DiscoverAsync(cancellationToken);
+        var scoped = discovery.Discovery.Items;
         var sourceUri = new Uri(request.Revision.Href, UriKind.Absolute);
         var sourceCalendar = scoped
             .Where(calendar => CalendarMoveHrefPolicy.IsSafeCalendarHref(calendar.Href, options.BaseUrl)
@@ -176,11 +176,11 @@ internal sealed class CalendarMoveModule(
     private static CalendarSelectionResult SelectCalendar(
         CalendarMoveDestination destination,
         CalendarEntityKind entityKind,
-        CalendarMoveDiscoveryResult discovery,
+        CalendarOperationDiscoveryResult discovery,
         IReadOnlyList<CalendarDescriptor> scoped)
     {
         if (destination.Mode == CalendarEntityScopeMode.Default)
-            return discovery.ResolveDefault(entityKind);
+            return discovery.Default(entityKind);
         var matches = FindCalendarMatches(scoped, destination.Calendar!);
         if (matches.Length == 0)
             return CalendarSelectionResult.Failure(CalendarSelectionCode.NotFound, scoped.Take(MaximumDiagnostics).ToArray());

--- a/src/DotnetAgents.CalDav.Core/Services/CalendarQueryAcquisitionExecutor.cs
+++ b/src/DotnetAgents.CalDav.Core/Services/CalendarQueryAcquisitionExecutor.cs
@@ -42,7 +42,7 @@ internal sealed class CalendarQueryAcquisitionExecutor(
         if (prevalidation is not null)
             return AcquiredCalendarQuery.Failure(prevalidation);
         var transport = transportFactory();
-        CalendarQueryDiscovery discovery;
+        CalendarOperationDiscoveryResult discovery;
         using (CalendarQueryTelemetry.StartPhase("discovery"))
             discovery = await transport.DiscoverAsync(cancellationToken).ConfigureAwait(false);
         discovery = ValidateDiscovery(discovery);
@@ -178,7 +178,7 @@ internal sealed class CalendarQueryAcquisitionExecutor(
 
     private static SelectionResult Select(
         CalendarQueryAcquisitionRequest request,
-        CalendarQueryDiscovery discovery) => request.Scope.Mode switch
+        CalendarOperationDiscoveryResult discovery) => request.Scope.Mode switch
         {
             CalendarEntityScopeMode.Default => SelectDefaults(request.EntityKinds, discovery),
             CalendarEntityScopeMode.Selected => SelectExplicit(request, discovery.Discovery.Items),
@@ -191,7 +191,7 @@ internal sealed class CalendarQueryAcquisitionExecutor(
 
     private static SelectionResult SelectDefaults(
         IReadOnlyList<CalendarEntityKind> kinds,
-        CalendarQueryDiscovery discovery)
+        CalendarOperationDiscoveryResult discovery)
     {
         var selected = new List<(CalendarDescriptor Calendar, CalendarEntityKind Kind)>();
         foreach (var kind in kinds)
@@ -225,7 +225,7 @@ internal sealed class CalendarQueryAcquisitionExecutor(
         return SelectionResult.Success(request.EntityKinds.Select(kind => (matches[0], kind)).ToArray(), diagnostics);
     }
 
-    private CalendarQueryDiscovery ValidateDiscovery(CalendarQueryDiscovery discovery)
+    private CalendarOperationDiscoveryResult ValidateDiscovery(CalendarOperationDiscoveryResult discovery)
     {
         var items = discovery.Discovery.Items;
         if (items.Count > 256
@@ -235,7 +235,8 @@ internal sealed class CalendarQueryAcquisitionExecutor(
             throw new CalendarDiscoveryProtocolException("The scoped Calendar discovery result is invalid.");
         var frozen = items.OrderBy(calendar => calendar.Href, StringComparer.Ordinal).Select(Freeze).ToArray();
         var byHref = frozen.ToDictionary(calendar => calendar.Href, StringComparer.Ordinal);
-        return new CalendarQueryDiscovery(
+        return new CalendarOperationDiscoveryResult(
+            discovery.Key,
             new CalendarDiscoveryResult(
                 frozen,
                 discovery.Discovery.Diagnostics.Select(FreezeDiagnostic).ToArray()),

--- a/src/DotnetAgents.CalDav.Core/Services/CalendarService.cs
+++ b/src/DotnetAgents.CalDav.Core/Services/CalendarService.cs
@@ -11,7 +11,6 @@ namespace DotnetAgents.CalDav.Core.Services;
 /// <summary>Applies configured Calendar Scope to standards-based Calendar discovery.</summary>
 internal sealed class CalendarService : ICalendarService
 {
-    private readonly ICalendarClient _rawCalendarClient;
     private readonly ICalendarClient _calendarClient;
     private readonly CalendarOperationDiscovery _operationDiscovery;
     private readonly IOptions<CalDavOptions> _options;
@@ -35,25 +34,24 @@ internal sealed class CalendarService : ICalendarService
         TimeProvider timeProvider,
         ICalendarEntityIdentityGenerator identityGenerator)
     {
-        _rawCalendarClient = calendarClient;
         _options = options;
         _logger = logger;
         _timeProvider = timeProvider;
         _identityGenerator = identityGenerator;
         _discoveryPolicy = new CalendarDiscoveryPolicy(options, logger);
         _operationDiscovery = new CalendarOperationDiscovery(
-            calendarClient,
+            new CalendarClientDiscoveryTransport(calendarClient),
             options,
             _discoveryPolicy.ApplyScope,
             _discoveryPolicy.ResolveDefault);
-        _calendarClient = _operationDiscovery;
+        _calendarClient = calendarClient;
     }
 
     /// <inheritdoc />
     public async Task<CalendarDiscoveryResult> GetCalendarsAsync(CancellationToken cancellationToken)
     {
         _calendarClient.RediscoverCapabilities();
-        return await _operationDiscovery.GetScopedResultAsync(cancellationToken);
+        return (await _operationDiscovery.DiscoverAsync(cancellationToken)).Discovery;
     }
 
     /// <inheritdoc />
@@ -61,14 +59,8 @@ internal sealed class CalendarService : ICalendarService
         CalendarEntityKind entityKind,
         CancellationToken cancellationToken)
     {
-        _ = await _calendarClient.GetCalendarsAsync(cancellationToken);
-        return _operationDiscovery.ResolveDefault(entityKind);
+        return (await _operationDiscovery.DiscoverAsync(cancellationToken)).Default(entityKind);
     }
-
-    private CalendarSelectionResult ResolveDefaultCalendar(
-        CalendarEntityKind entityKind,
-        IReadOnlyList<CalendarDescriptor> discovered,
-        IReadOnlyList<CalendarDescriptor> scoped) => _operationDiscovery.ResolveDefault(entityKind);
 
     /// <inheritdoc />
     public Task<CalendarResourceRead> GetResourceAsync(string href, CancellationToken cancellationToken) =>
@@ -138,7 +130,7 @@ internal sealed class CalendarService : ICalendarService
         if (configuredScope.Count > 0 && !configuredScope.Any(calendarHref => IsDirectResourceOf(resourceUri, calendarHref)))
             return new CalendarResourceRead(CalendarResourceReadCode.OutsideScope);
 
-        var calendars = ApplyScope(await _calendarClient.GetCalendarsAsync(cancellationToken)).Items;
+        var calendars = (await _operationDiscovery.DiscoverAsync(cancellationToken)).Discovery.Items;
         var calendar = calendars
             .Where(candidate => IsDirectResourceOf(resourceUri, candidate.Href))
             .OrderByDescending(candidate => candidate.Href.Length)
@@ -219,7 +211,7 @@ internal sealed class CalendarService : ICalendarService
     public async Task<CalendarResourceMoveResult> MoveResourceAsync(
         CalendarResourceMoveRequest request,
         CancellationToken cancellationToken) => await new CalendarMoveModule(
-            _operationDiscovery,
+            new CalendarClientMoveTransport(_operationDiscovery, _calendarClient),
             _options.Value,
             _timeProvider).MoveAsync(request, cancellationToken);
 
@@ -241,12 +233,10 @@ internal sealed class CalendarService : ICalendarService
     }
 
     private CalendarCreationModule CreationModule() => new(
-        _calendarClient as ICalendarCreateTransport ?? new CalendarClientCreateTransport(_calendarClient),
+        new CalendarClientCreateTransport(_operationDiscovery, _calendarClient),
         _options.Value,
         _timeProvider,
-        _identityGenerator,
-        ApplyScope,
-        ResolveDefaultCalendar);
+        _identityGenerator);
 
     private static CalendarEntityCreateResult RequireSemantic(CalendarCreationOutcome outcome) => outcome switch
     {
@@ -272,11 +262,13 @@ internal sealed class CalendarService : ICalendarService
         ApplyScope);
 
     private CalendarExactMoveModule ExactMoveModule() => new(
-        new CalendarOperationDiscovery(
-            _rawCalendarClient,
-            _options,
-            _discoveryPolicy.ApplyScope,
-            _discoveryPolicy.ResolveDefault),
+        new CalendarClientMoveTransport(
+            new CalendarOperationDiscovery(
+                new CalendarClientDiscoveryTransport(_calendarClient),
+                _options,
+                _discoveryPolicy.ApplyScope,
+                _discoveryPolicy.ResolveDefault),
+            _calendarClient),
         _options.Value,
         _timeProvider);
 

--- a/tests/DotnetAgents.CalDav.Core.Tests.Unit/Internal/CalendarOperationDiscoveryResultFactory.cs
+++ b/tests/DotnetAgents.CalDav.Core.Tests.Unit/Internal/CalendarOperationDiscoveryResultFactory.cs
@@ -1,0 +1,23 @@
+using DotnetAgents.CalDav.Core.Configuration;
+using DotnetAgents.CalDav.Core.Internal;
+using DotnetAgents.CalDav.Core.Models;
+
+namespace DotnetAgents.CalDav.Core.Tests.Unit;
+
+internal static class CalendarOperationDiscoveryResultFactory
+{
+    internal static CalendarOperationDiscoveryResult Create(
+        CalendarDiscoveryResult discovery,
+        CalendarSelectionResult eventDefault,
+        CalendarSelectionResult todoDefault) => new(
+            CalendarDiscoveryKey.Create(
+                new CalDavOptions
+                {
+                    BaseUrl = "https://cal.example/",
+                    Username = "scripted-principal"
+                },
+                CalendarOperationContextGeneration.Create()),
+            discovery,
+            eventDefault,
+            todoDefault);
+}

--- a/tests/DotnetAgents.CalDav.Core.Tests.Unit/Internal/CalendarOperationDiscoveryResultTests.cs
+++ b/tests/DotnetAgents.CalDav.Core.Tests.Unit/Internal/CalendarOperationDiscoveryResultTests.cs
@@ -10,7 +10,7 @@ public sealed class CalendarOperationDiscoveryResultTests
     [Fact]
     public void UnsupportedEntityKindCannotResolveADefaultCalendar()
     {
-        var discovery = new CalendarOperationDiscoveryResult(
+        var discovery = CalendarOperationDiscoveryResultFactory.Create(
             new CalendarDiscoveryResult([], []),
             CalendarSelectionResult.Failure(CalendarSelectionCode.Ambiguous),
             CalendarSelectionResult.Failure(CalendarSelectionCode.OutsideScope));

--- a/tests/DotnetAgents.CalDav.Core.Tests.Unit/Internal/CalendarOperationDiscoveryResultTests.cs
+++ b/tests/DotnetAgents.CalDav.Core.Tests.Unit/Internal/CalendarOperationDiscoveryResultTests.cs
@@ -5,12 +5,12 @@ using Xunit;
 
 namespace DotnetAgents.CalDav.Core.Tests.Unit.Internal;
 
-public sealed class CalendarQueryDiscoveryTests
+public sealed class CalendarOperationDiscoveryResultTests
 {
     [Fact]
     public void UnsupportedEntityKindCannotResolveADefaultCalendar()
     {
-        var discovery = new CalendarQueryDiscovery(
+        var discovery = new CalendarOperationDiscoveryResult(
             new CalendarDiscoveryResult([], []),
             CalendarSelectionResult.Failure(CalendarSelectionCode.Ambiguous),
             CalendarSelectionResult.Failure(CalendarSelectionCode.OutsideScope));

--- a/tests/DotnetAgents.CalDav.Core.Tests.Unit/Internal/CalendarOperationDiscoveryTests.cs
+++ b/tests/DotnetAgents.CalDav.Core.Tests.Unit/Internal/CalendarOperationDiscoveryTests.cs
@@ -1,4 +1,3 @@
-using DotnetAgents.CalDav.Core.Abstractions;
 using DotnetAgents.CalDav.Core.Configuration;
 using DotnetAgents.CalDav.Core.Internal;
 using DotnetAgents.CalDav.Core.Models;
@@ -12,31 +11,46 @@ namespace DotnetAgents.CalDav.Core.Tests.Unit.Internal;
 public sealed class CalendarOperationDiscoveryTests
 {
     [Fact]
-    public async Task AbsenceProbe_DefaultTransportMethodPreservesMarkerThroughDiscoveryDecorator()
+    public async Task DiscoverAsync_ReturnsOneCompleteImmutableAuthority()
     {
-        var markerObserved = false;
-        var client = Substitute.For<ICalendarClient>();
-        client.GetCalendarResourceAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .Returns(_ =>
-            {
-                markerObserved = CalendarHttpTelemetry.IsAbsenceProbe;
-                return Task.FromResult(new CalendarResourceRead(CalendarResourceReadCode.NotFound));
-            });
+        var transport = Substitute.For<ICalendarDiscoveryTransport>();
+        transport.DiscoverAsync(Arg.Any<CancellationToken>()).Returns(
+        [
+            Calendar("https://cal.example/events/", "Events", EntityKindSupport.Advertised, EntityKindSupport.NotAdvertised),
+            Calendar("https://cal.example/todos/", "To-dos", EntityKindSupport.NotAdvertised, EntityKindSupport.Advertised)
+        ]);
         var sut = new CalendarOperationDiscovery(
-            client,
+            transport,
             Options.Create(new CalDavOptions
             {
                 BaseUrl = "https://cal.example/",
                 Username = "principal"
             }),
             calendars => new CalendarDiscoveryResult(calendars, []),
-            static (_, _, _) => CalendarSelectionResult.Failure(CalendarSelectionCode.NotFound));
+            static (kind, discovered, authorized) => CalendarSelectionResult.Success(
+                authorized.Single(calendar => kind == CalendarEntityKind.Event
+                    ? calendar.EventSupport == EntityKindSupport.Advertised
+                    : calendar.TodoSupport == EntityKindSupport.Advertised)));
 
-        var result = await ((ICalendarCreateTransport)sut).ProbeCalendarResourceAbsenceAsync(
-            "https://cal.example/events/missing.ics",
-            CancellationToken.None);
+        var authority = await sut.DiscoverAsync(CancellationToken.None);
 
-        result.Code.ShouldBe(CalendarResourceReadCode.NotFound);
-        markerObserved.ShouldBeTrue();
+        authority.Discovery.Items.Select(calendar => calendar.Href).ShouldBe(
+            ["https://cal.example/events/", "https://cal.example/todos/"]);
+        authority.Default(CalendarEntityKind.Event).Calendar!.Href.ShouldBe("https://cal.example/events/");
+        authority.Default(CalendarEntityKind.Todo).Calendar!.Href.ShouldBe("https://cal.example/todos/");
+        await transport.Received(1).DiscoverAsync(Arg.Any<CancellationToken>());
     }
+
+    private static CalendarDescriptor Calendar(
+        string href,
+        string displayName,
+        EntityKindSupport eventSupport,
+        EntityKindSupport todoSupport) => new()
+        {
+            Href = href,
+            DisplayName = displayName,
+            DisplayNameProvenance = DisplayNameProvenance.DavDisplayName,
+            EventSupport = eventSupport,
+            TodoSupport = todoSupport
+        };
 }

--- a/tests/DotnetAgents.CalDav.Core.Tests.Unit/Services/CalendarCreationModuleTests.cs
+++ b/tests/DotnetAgents.CalDav.Core.Tests.Unit/Services/CalendarCreationModuleTests.cs
@@ -101,7 +101,7 @@ public sealed class CalendarCreationModuleTests
         public Task<CalendarOperationDiscoveryResult> DiscoverAsync(CancellationToken cancellationToken)
         {
             DiscoveryCount++;
-            return Task.FromResult(new CalendarOperationDiscoveryResult(
+            return Task.FromResult(CalendarOperationDiscoveryResultFactory.Create(
                 new CalendarDiscoveryResult([calendar], []),
                 CalendarSelectionResult.Success(calendar),
                 CalendarSelectionResult.Success(calendar)));

--- a/tests/DotnetAgents.CalDav.Core.Tests.Unit/Services/CalendarCreationModuleTests.cs
+++ b/tests/DotnetAgents.CalDav.Core.Tests.Unit/Services/CalendarCreationModuleTests.cs
@@ -36,12 +36,7 @@ public sealed class CalendarCreationModuleTests
                 DefaultTodoCalendarName = "Mixed"
             },
             TimeProvider.System,
-            identities,
-            calendars => new CalendarDiscoveryResult(calendars, []),
-            (
-                CalendarEntityKind kind,
-                IReadOnlyList<CalendarDescriptor> discovered,
-                IReadOnlyList<CalendarDescriptor> scoped) => CalendarSelectionResult.Success(scoped.Single()));
+            identities);
 
         var eventOutcome = await module.CreateAsync(
             new CalendarCreationCommand.Event(new CalendarEventCreateRequest(
@@ -103,10 +98,13 @@ public sealed class CalendarCreationModuleTests
 
         public int ConditionalPutCount { get; private set; }
 
-        public Task<IReadOnlyList<CalendarDescriptor>> GetCalendarsAsync(CancellationToken cancellationToken)
+        public Task<CalendarOperationDiscoveryResult> DiscoverAsync(CancellationToken cancellationToken)
         {
             DiscoveryCount++;
-            return Task.FromResult<IReadOnlyList<CalendarDescriptor>>([calendar]);
+            return Task.FromResult(new CalendarOperationDiscoveryResult(
+                new CalendarDiscoveryResult([calendar], []),
+                CalendarSelectionResult.Success(calendar),
+                CalendarSelectionResult.Success(calendar)));
         }
 
         public Task<CalendarResourceRead> GetCalendarResourceAsync(

--- a/tests/DotnetAgents.CalDav.Core.Tests.Unit/Services/CalendarMoveModuleTests.cs
+++ b/tests/DotnetAgents.CalDav.Core.Tests.Unit/Services/CalendarMoveModuleTests.cs
@@ -443,7 +443,7 @@ public sealed class CalendarMoveModuleTests
         var sourceCalendar = TodoCalendar("https://cal.example/tasks/", "Tasks");
         var transport = ScriptedTransport(Resource(SourceHref, "\"r1\"", Uid)) with
         {
-            Discovery = new CalendarMoveDiscoveryResult(
+            Discovery = new CalendarOperationDiscoveryResult(
                 new CalendarDiscoveryResult([sourceCalendar], []),
                 CalendarSelectionResult.Success(sourceCalendar),
                 CalendarSelectionResult.Success(sourceCalendar))
@@ -475,7 +475,7 @@ public sealed class CalendarMoveModuleTests
             };
         var transport = ScriptedTransport(Resource(SourceHref, "\"r1\"", Uid)) with
         {
-            Discovery = new CalendarMoveDiscoveryResult(
+            Discovery = new CalendarOperationDiscoveryResult(
                 new CalendarDiscoveryResult([
                     TodoCalendar("https://cal.example/tasks/", "Tasks"),
                     destination
@@ -514,7 +514,7 @@ public sealed class CalendarMoveModuleTests
     {
         var discovery = ScriptedTransport(Resource(SourceHref, "\"r1\"", Uid)).Discovery;
 
-        var selection = discovery.ResolveDefault((CalendarEntityKind)999);
+        var selection = discovery.Default((CalendarEntityKind)999);
 
         selection.Code.ShouldBe(CalendarSelectionCode.NotFound);
         selection.Calendar.ShouldBeNull();
@@ -533,7 +533,7 @@ public sealed class CalendarMoveModuleTests
         var destination = TodoCalendar(DestinationCalendarHref, "Archive");
         var transport = ScriptedTransport(Resource(SourceHref, "\"r1\"", Uid)) with
         {
-            Discovery = new CalendarMoveDiscoveryResult(
+            Discovery = new CalendarOperationDiscoveryResult(
                 new CalendarDiscoveryResult([
                     TodoCalendar(sourceCalendarHref, "Invalid source"),
                     destination
@@ -566,7 +566,7 @@ public sealed class CalendarMoveModuleTests
 
     private static ScriptedMoveTransport ScriptedTransport(CalendarResourceRead source) => new()
     {
-        Discovery = new CalendarMoveDiscoveryResult(
+        Discovery = new CalendarOperationDiscoveryResult(
             new CalendarDiscoveryResult([
                 TodoCalendar("https://cal.example/tasks/", "Tasks"),
                 TodoCalendar(DestinationCalendarHref, "Archive")
@@ -672,7 +672,7 @@ public sealed class CalendarMoveModuleTests
 
     private sealed record ScriptedMoveTransport : ICalendarMoveTransport
     {
-        internal required CalendarMoveDiscoveryResult Discovery { get; init; }
+        internal required CalendarOperationDiscoveryResult Discovery { get; init; }
 
         internal required CalendarResourceRead Source { get; init; }
 
@@ -696,7 +696,7 @@ public sealed class CalendarMoveModuleTests
 
         internal ConcurrentQueue<string> Trace { get; } = new();
 
-        public Task<CalendarMoveDiscoveryResult> DiscoverCalendarsAsync(CancellationToken cancellationToken)
+        public Task<CalendarOperationDiscoveryResult> DiscoverAsync(CancellationToken cancellationToken)
         {
             Trace.Enqueue("discover");
             return Task.FromResult(Discovery);

--- a/tests/DotnetAgents.CalDav.Core.Tests.Unit/Services/CalendarMoveModuleTests.cs
+++ b/tests/DotnetAgents.CalDav.Core.Tests.Unit/Services/CalendarMoveModuleTests.cs
@@ -443,7 +443,7 @@ public sealed class CalendarMoveModuleTests
         var sourceCalendar = TodoCalendar("https://cal.example/tasks/", "Tasks");
         var transport = ScriptedTransport(Resource(SourceHref, "\"r1\"", Uid)) with
         {
-            Discovery = new CalendarOperationDiscoveryResult(
+            Discovery = CalendarOperationDiscoveryResultFactory.Create(
                 new CalendarDiscoveryResult([sourceCalendar], []),
                 CalendarSelectionResult.Success(sourceCalendar),
                 CalendarSelectionResult.Success(sourceCalendar))
@@ -475,7 +475,7 @@ public sealed class CalendarMoveModuleTests
             };
         var transport = ScriptedTransport(Resource(SourceHref, "\"r1\"", Uid)) with
         {
-            Discovery = new CalendarOperationDiscoveryResult(
+            Discovery = CalendarOperationDiscoveryResultFactory.Create(
                 new CalendarDiscoveryResult([
                     TodoCalendar("https://cal.example/tasks/", "Tasks"),
                     destination
@@ -533,7 +533,7 @@ public sealed class CalendarMoveModuleTests
         var destination = TodoCalendar(DestinationCalendarHref, "Archive");
         var transport = ScriptedTransport(Resource(SourceHref, "\"r1\"", Uid)) with
         {
-            Discovery = new CalendarOperationDiscoveryResult(
+            Discovery = CalendarOperationDiscoveryResultFactory.Create(
                 new CalendarDiscoveryResult([
                     TodoCalendar(sourceCalendarHref, "Invalid source"),
                     destination
@@ -566,7 +566,7 @@ public sealed class CalendarMoveModuleTests
 
     private static ScriptedMoveTransport ScriptedTransport(CalendarResourceRead source) => new()
     {
-        Discovery = new CalendarOperationDiscoveryResult(
+        Discovery = CalendarOperationDiscoveryResultFactory.Create(
             new CalendarDiscoveryResult([
                 TodoCalendar("https://cal.example/tasks/", "Tasks"),
                 TodoCalendar(DestinationCalendarHref, "Archive")

--- a/tests/DotnetAgents.CalDav.Core.Tests.Unit/Services/CalendarOccurrenceQueryModuleTests.cs
+++ b/tests/DotnetAgents.CalDav.Core.Tests.Unit/Services/CalendarOccurrenceQueryModuleTests.cs
@@ -338,7 +338,7 @@ public sealed class CalendarOccurrenceQueryModuleTests
                 EventSupport = EntityKindSupport.Advertised,
                 TodoSupport = EntityKindSupport.NotAdvertised
             };
-            return Task.FromResult(new CalendarOperationDiscoveryResult(
+            return Task.FromResult(CalendarOperationDiscoveryResultFactory.Create(
                 new CalendarDiscoveryResult([calendar], []),
                 CalendarSelectionResult.Success(calendar),
                 CalendarSelectionResult.Failure(CalendarSelectionCode.NotFound)));

--- a/tests/DotnetAgents.CalDav.Core.Tests.Unit/Services/CalendarOccurrenceQueryModuleTests.cs
+++ b/tests/DotnetAgents.CalDav.Core.Tests.Unit/Services/CalendarOccurrenceQueryModuleTests.cs
@@ -327,7 +327,7 @@ public sealed class CalendarOccurrenceQueryModuleTests
         internal int TotalCalls { get; private set; }
         internal string EntityTag { get; init; } = "\"r1\"";
 
-        public Task<CalendarQueryDiscovery> DiscoverAsync(CancellationToken cancellationToken)
+        public Task<CalendarOperationDiscoveryResult> DiscoverAsync(CancellationToken cancellationToken)
         {
             TotalCalls++;
             var calendar = new CalendarDescriptor
@@ -338,7 +338,7 @@ public sealed class CalendarOccurrenceQueryModuleTests
                 EventSupport = EntityKindSupport.Advertised,
                 TodoSupport = EntityKindSupport.NotAdvertised
             };
-            return Task.FromResult(new CalendarQueryDiscovery(
+            return Task.FromResult(new CalendarOperationDiscoveryResult(
                 new CalendarDiscoveryResult([calendar], []),
                 CalendarSelectionResult.Success(calendar),
                 CalendarSelectionResult.Failure(CalendarSelectionCode.NotFound)));

--- a/tests/DotnetAgents.CalDav.Core.Tests.Unit/Services/CalendarQueryDirectGetTests.cs
+++ b/tests/DotnetAgents.CalDav.Core.Tests.Unit/Services/CalendarQueryDirectGetTests.cs
@@ -646,8 +646,8 @@ public sealed class CalendarQueryDirectGetTests
         internal int InFlight => Volatile.Read(ref _inFlight);
         internal List<string> RequestedHrefs { get; } = [];
 
-        public Task<CalendarQueryDiscovery> DiscoverAsync(CancellationToken cancellationToken) => Task.FromResult(
-            new CalendarQueryDiscovery(
+        public Task<CalendarOperationDiscoveryResult> DiscoverAsync(CancellationToken cancellationToken) => Task.FromResult(
+            new CalendarOperationDiscoveryResult(
                 new CalendarDiscoveryResult([new CalendarDescriptor
                 {
                     Href = CalendarHref,
@@ -708,7 +708,7 @@ public sealed class CalendarQueryDirectGetTests
 
     private sealed class TimeoutFallbackTransport(HttpClient client) : ICalendarQueryTransport
     {
-        public Task<CalendarQueryDiscovery> DiscoverAsync(CancellationToken cancellationToken) =>
+        public Task<CalendarOperationDiscoveryResult> DiscoverAsync(CancellationToken cancellationToken) =>
             throw new NotSupportedException();
 
         public Task<IReadOnlyList<string>> QueryCandidateHrefsAsync(
@@ -774,7 +774,7 @@ public sealed class CalendarQueryDirectGetTests
         private IReadOnlyList<string> Hrefs { get; }
         internal int WireAttempts => Volatile.Read(ref _wireAttempts);
 
-        public Task<CalendarQueryDiscovery> DiscoverAsync(CancellationToken cancellationToken) =>
+        public Task<CalendarOperationDiscoveryResult> DiscoverAsync(CancellationToken cancellationToken) =>
             throw new NotSupportedException();
 
         public Task<IReadOnlyList<string>> QueryCandidateHrefsAsync(
@@ -849,7 +849,7 @@ public sealed class CalendarQueryDirectGetTests
 
         internal int WireAttempts => Volatile.Read(ref _wireAttempts);
 
-        public Task<CalendarQueryDiscovery> DiscoverAsync(CancellationToken cancellationToken) =>
+        public Task<CalendarOperationDiscoveryResult> DiscoverAsync(CancellationToken cancellationToken) =>
             throw new NotSupportedException();
 
         public Task<IReadOnlyList<string>> QueryCandidateHrefsAsync(

--- a/tests/DotnetAgents.CalDav.Core.Tests.Unit/Services/CalendarQueryDirectGetTests.cs
+++ b/tests/DotnetAgents.CalDav.Core.Tests.Unit/Services/CalendarQueryDirectGetTests.cs
@@ -647,7 +647,7 @@ public sealed class CalendarQueryDirectGetTests
         internal List<string> RequestedHrefs { get; } = [];
 
         public Task<CalendarOperationDiscoveryResult> DiscoverAsync(CancellationToken cancellationToken) => Task.FromResult(
-            new CalendarOperationDiscoveryResult(
+            CalendarOperationDiscoveryResultFactory.Create(
                 new CalendarDiscoveryResult([new CalendarDescriptor
                 {
                     Href = CalendarHref,

--- a/tests/DotnetAgents.CalDav.Core.Tests.Unit/Services/CalendarQueryModuleTests.cs
+++ b/tests/DotnetAgents.CalDav.Core.Tests.Unit/Services/CalendarQueryModuleTests.cs
@@ -919,7 +919,7 @@ public sealed class CalendarQueryModuleTests
         var transport = new DelegateTransport(discover: _ =>
         {
             discoveryCount++;
-            return Task.FromResult(new CalendarQueryDiscovery(
+            return Task.FromResult(new CalendarOperationDiscoveryResult(
                 new CalendarDiscoveryResult([calendar], []),
                 CalendarSelectionResult.Failure(CalendarSelectionCode.OutsideScope, [calendar]),
                 CalendarSelectionResult.Failure(CalendarSelectionCode.NotFound, [calendar])));
@@ -955,7 +955,7 @@ public sealed class CalendarQueryModuleTests
             {
                 discoveryCount++;
                 var calendar = Calendar(current);
-                return Task.FromResult(new CalendarQueryDiscovery(
+                return Task.FromResult(new CalendarOperationDiscoveryResult(
                     new CalendarDiscoveryResult([calendar], []),
                     CalendarSelectionResult.Success(calendar),
                     CalendarSelectionResult.Failure(CalendarSelectionCode.NotFound)));
@@ -1097,7 +1097,7 @@ public sealed class CalendarQueryModuleTests
             "unsupported" => new CalendarDiscoveryUnsupportedCapabilityException("private"),
             _ => throw new ArgumentOutOfRangeException(nameof(scenario))
         };
-        var transport = new DelegateTransport(discover: _ => Task.FromException<CalendarQueryDiscovery>(exception));
+        var transport = new DelegateTransport(discover: _ => Task.FromException<CalendarOperationDiscoveryResult>(exception));
         await using var provider = CreateProvider(transport, new MutableTimeProvider(Now));
 
         var failure = (await provider.GetRequiredService<ICalendarQueryModule>().QueryEntitiesAsync(
@@ -1198,7 +1198,7 @@ public sealed class CalendarQueryModuleTests
     {
         const string calendarHref = "https://cal.example/calendars/work/";
         var calendar = Calendar(calendarHref);
-        var discovery = new CalendarQueryDiscovery(
+        var discovery = new CalendarOperationDiscoveryResult(
             new CalendarDiscoveryResult([calendar], []),
             CalendarSelectionResult.Failure(selectionCode, [calendar]),
             CalendarSelectionResult.Failure(CalendarSelectionCode.NotFound, [calendar]));
@@ -1225,7 +1225,7 @@ public sealed class CalendarQueryModuleTests
             EventSupport = EntityKindSupport.NotAdvertised,
             TodoSupport = EntityKindSupport.Advertised
         };
-        var discovery = new CalendarQueryDiscovery(
+        var discovery = new CalendarOperationDiscoveryResult(
             new CalendarDiscoveryResult([todos, events], []),
             CalendarSelectionResult.Success(events),
             CalendarSelectionResult.Success(todos));
@@ -1253,7 +1253,7 @@ public sealed class CalendarQueryModuleTests
     {
         const string calendarHref = "https://cal.example/calendars/work/";
         var calendar = Calendar(calendarHref);
-        var discovery = new CalendarQueryDiscovery(
+        var discovery = new CalendarOperationDiscoveryResult(
             new CalendarDiscoveryResult([calendar], []),
             CalendarSelectionResult.Success(calendar),
             CalendarSelectionResult.Failure(CalendarSelectionCode.NotFound));
@@ -1276,7 +1276,7 @@ public sealed class CalendarQueryModuleTests
         const string secondHref = "https://cal.example/calendars/second/";
         var first = Calendar(firstHref) with { DisplayName = " Work ", EventSupport = EntityKindSupport.NotAdvertised };
         var second = Calendar(secondHref) with { DisplayName = "work", EventSupport = EntityKindSupport.NotAdvertised };
-        var discovery = new CalendarQueryDiscovery(
+        var discovery = new CalendarOperationDiscoveryResult(
             new CalendarDiscoveryResult([first, second], []),
             CalendarSelectionResult.Failure(CalendarSelectionCode.NotFound, [first, second]),
             CalendarSelectionResult.Failure(CalendarSelectionCode.NotFound, [first, second]));
@@ -1348,7 +1348,7 @@ public sealed class CalendarQueryModuleTests
     {
         const string calendarHref = "https://cal.example/calendars/work/";
         var calendar = Calendar(calendarHref) with { EventSupport = EntityKindSupport.NotAdvertised };
-        var discovery = new CalendarQueryDiscovery(
+        var discovery = new CalendarOperationDiscoveryResult(
             new CalendarDiscoveryResult([calendar],
             [
                 new CalendarDiagnostic("duplicate_calendar_href", "private duplicate", CalendarDiagnosticSeverity.Info),
@@ -1402,7 +1402,7 @@ public sealed class CalendarQueryModuleTests
             "missing_success_default" => new CalendarSelectionResult(CalendarSelectionCode.Success, null, []),
             _ => CalendarSelectionResult.Success(calendars[0])
         };
-        var discovery = new CalendarQueryDiscovery(
+        var discovery = new CalendarOperationDiscoveryResult(
             new CalendarDiscoveryResult(calendars, diagnostics),
             eventDefault,
             CalendarSelectionResult.Failure(CalendarSelectionCode.NotFound, calendars));
@@ -2035,14 +2035,14 @@ public sealed class CalendarQueryModuleTests
 
         internal int MultigetCount { get; private set; }
 
-        public Task<CalendarQueryDiscovery> DiscoverAsync(CancellationToken cancellationToken)
+        public Task<CalendarOperationDiscoveryResult> DiscoverAsync(CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
             DiscoveryCount++;
             var scoped = new CalendarDiscoveryResult(calendars, []);
             var eventDefault = CalendarSelectionResult.Success(calendars[0]);
             var todoDefault = CalendarSelectionResult.Failure(CalendarSelectionCode.NotFound, calendars);
-            return Task.FromResult(new CalendarQueryDiscovery(scoped, eventDefault, todoDefault));
+            return Task.FromResult(new CalendarOperationDiscoveryResult(scoped, eventDefault, todoDefault));
         }
 
         public Task<IReadOnlyList<string>> QueryCandidateHrefsAsync(
@@ -2088,7 +2088,7 @@ public sealed class CalendarQueryModuleTests
 
         internal List<string> MultigetCalls { get; } = [];
 
-        public Task<CalendarQueryDiscovery> DiscoverAsync(CancellationToken cancellationToken)
+        public Task<CalendarOperationDiscoveryResult> DiscoverAsync(CancellationToken cancellationToken)
         {
             var calendars = new[]
             {
@@ -2103,7 +2103,7 @@ public sealed class CalendarQueryModuleTests
                     TodoSupport = EntityKindSupport.Advertised
                 }
             };
-            return Task.FromResult(new CalendarQueryDiscovery(
+            return Task.FromResult(new CalendarOperationDiscoveryResult(
                 new CalendarDiscoveryResult(calendars, []),
                 CalendarSelectionResult.Success(calendars[0]),
                 CalendarSelectionResult.Success(calendars[1])));
@@ -2142,15 +2142,15 @@ public sealed class CalendarQueryModuleTests
     }
 
     private sealed class DelegateTransport(
-        Func<CancellationToken, Task<CalendarQueryDiscovery>>? discover = null,
+        Func<CancellationToken, Task<CalendarOperationDiscoveryResult>>? discover = null,
         Func<string, CalendarEntityKind, DateTimeOffset?, DateTimeOffset?, CancellationToken,
             Task<IReadOnlyList<string>>>? candidates = null,
         Func<string, IReadOnlyList<string>, CancellationToken,
             Task<IReadOnlyList<CalendarResourceRead>>>? multiget = null) : ICalendarQueryTransport
     {
-        public Task<CalendarQueryDiscovery> DiscoverAsync(CancellationToken cancellationToken) =>
+        public Task<CalendarOperationDiscoveryResult> DiscoverAsync(CancellationToken cancellationToken) =>
             discover?.Invoke(cancellationToken)
-            ?? Task.FromResult(new CalendarQueryDiscovery(
+            ?? Task.FromResult(new CalendarOperationDiscoveryResult(
                 new CalendarDiscoveryResult([Calendar("https://cal.example/calendars/work/")], []),
                 CalendarSelectionResult.Success(Calendar("https://cal.example/calendars/work/")),
                 CalendarSelectionResult.Failure(CalendarSelectionCode.NotFound)));

--- a/tests/DotnetAgents.CalDav.Core.Tests.Unit/Services/CalendarQueryModuleTests.cs
+++ b/tests/DotnetAgents.CalDav.Core.Tests.Unit/Services/CalendarQueryModuleTests.cs
@@ -919,7 +919,7 @@ public sealed class CalendarQueryModuleTests
         var transport = new DelegateTransport(discover: _ =>
         {
             discoveryCount++;
-            return Task.FromResult(new CalendarOperationDiscoveryResult(
+            return Task.FromResult(CalendarOperationDiscoveryResultFactory.Create(
                 new CalendarDiscoveryResult([calendar], []),
                 CalendarSelectionResult.Failure(CalendarSelectionCode.OutsideScope, [calendar]),
                 CalendarSelectionResult.Failure(CalendarSelectionCode.NotFound, [calendar])));
@@ -955,7 +955,7 @@ public sealed class CalendarQueryModuleTests
             {
                 discoveryCount++;
                 var calendar = Calendar(current);
-                return Task.FromResult(new CalendarOperationDiscoveryResult(
+                return Task.FromResult(CalendarOperationDiscoveryResultFactory.Create(
                     new CalendarDiscoveryResult([calendar], []),
                     CalendarSelectionResult.Success(calendar),
                     CalendarSelectionResult.Failure(CalendarSelectionCode.NotFound)));
@@ -1198,7 +1198,7 @@ public sealed class CalendarQueryModuleTests
     {
         const string calendarHref = "https://cal.example/calendars/work/";
         var calendar = Calendar(calendarHref);
-        var discovery = new CalendarOperationDiscoveryResult(
+        var discovery = CalendarOperationDiscoveryResultFactory.Create(
             new CalendarDiscoveryResult([calendar], []),
             CalendarSelectionResult.Failure(selectionCode, [calendar]),
             CalendarSelectionResult.Failure(CalendarSelectionCode.NotFound, [calendar]));
@@ -1225,7 +1225,7 @@ public sealed class CalendarQueryModuleTests
             EventSupport = EntityKindSupport.NotAdvertised,
             TodoSupport = EntityKindSupport.Advertised
         };
-        var discovery = new CalendarOperationDiscoveryResult(
+        var discovery = CalendarOperationDiscoveryResultFactory.Create(
             new CalendarDiscoveryResult([todos, events], []),
             CalendarSelectionResult.Success(events),
             CalendarSelectionResult.Success(todos));
@@ -1253,7 +1253,7 @@ public sealed class CalendarQueryModuleTests
     {
         const string calendarHref = "https://cal.example/calendars/work/";
         var calendar = Calendar(calendarHref);
-        var discovery = new CalendarOperationDiscoveryResult(
+        var discovery = CalendarOperationDiscoveryResultFactory.Create(
             new CalendarDiscoveryResult([calendar], []),
             CalendarSelectionResult.Success(calendar),
             CalendarSelectionResult.Failure(CalendarSelectionCode.NotFound));
@@ -1276,7 +1276,7 @@ public sealed class CalendarQueryModuleTests
         const string secondHref = "https://cal.example/calendars/second/";
         var first = Calendar(firstHref) with { DisplayName = " Work ", EventSupport = EntityKindSupport.NotAdvertised };
         var second = Calendar(secondHref) with { DisplayName = "work", EventSupport = EntityKindSupport.NotAdvertised };
-        var discovery = new CalendarOperationDiscoveryResult(
+        var discovery = CalendarOperationDiscoveryResultFactory.Create(
             new CalendarDiscoveryResult([first, second], []),
             CalendarSelectionResult.Failure(CalendarSelectionCode.NotFound, [first, second]),
             CalendarSelectionResult.Failure(CalendarSelectionCode.NotFound, [first, second]));
@@ -1348,7 +1348,7 @@ public sealed class CalendarQueryModuleTests
     {
         const string calendarHref = "https://cal.example/calendars/work/";
         var calendar = Calendar(calendarHref) with { EventSupport = EntityKindSupport.NotAdvertised };
-        var discovery = new CalendarOperationDiscoveryResult(
+        var discovery = CalendarOperationDiscoveryResultFactory.Create(
             new CalendarDiscoveryResult([calendar],
             [
                 new CalendarDiagnostic("duplicate_calendar_href", "private duplicate", CalendarDiagnosticSeverity.Info),
@@ -1402,7 +1402,7 @@ public sealed class CalendarQueryModuleTests
             "missing_success_default" => new CalendarSelectionResult(CalendarSelectionCode.Success, null, []),
             _ => CalendarSelectionResult.Success(calendars[0])
         };
-        var discovery = new CalendarOperationDiscoveryResult(
+        var discovery = CalendarOperationDiscoveryResultFactory.Create(
             new CalendarDiscoveryResult(calendars, diagnostics),
             eventDefault,
             CalendarSelectionResult.Failure(CalendarSelectionCode.NotFound, calendars));
@@ -2042,7 +2042,7 @@ public sealed class CalendarQueryModuleTests
             var scoped = new CalendarDiscoveryResult(calendars, []);
             var eventDefault = CalendarSelectionResult.Success(calendars[0]);
             var todoDefault = CalendarSelectionResult.Failure(CalendarSelectionCode.NotFound, calendars);
-            return Task.FromResult(new CalendarOperationDiscoveryResult(scoped, eventDefault, todoDefault));
+            return Task.FromResult(CalendarOperationDiscoveryResultFactory.Create(scoped, eventDefault, todoDefault));
         }
 
         public Task<IReadOnlyList<string>> QueryCandidateHrefsAsync(
@@ -2103,7 +2103,7 @@ public sealed class CalendarQueryModuleTests
                     TodoSupport = EntityKindSupport.Advertised
                 }
             };
-            return Task.FromResult(new CalendarOperationDiscoveryResult(
+            return Task.FromResult(CalendarOperationDiscoveryResultFactory.Create(
                 new CalendarDiscoveryResult(calendars, []),
                 CalendarSelectionResult.Success(calendars[0]),
                 CalendarSelectionResult.Success(calendars[1])));
@@ -2150,7 +2150,7 @@ public sealed class CalendarQueryModuleTests
     {
         public Task<CalendarOperationDiscoveryResult> DiscoverAsync(CancellationToken cancellationToken) =>
             discover?.Invoke(cancellationToken)
-            ?? Task.FromResult(new CalendarOperationDiscoveryResult(
+            ?? Task.FromResult(CalendarOperationDiscoveryResultFactory.Create(
                 new CalendarDiscoveryResult([Calendar("https://cal.example/calendars/work/")], []),
                 CalendarSelectionResult.Success(Calendar("https://cal.example/calendars/work/")),
                 CalendarSelectionResult.Failure(CalendarSelectionCode.NotFound)));

--- a/tests/DotnetAgents.CalDav.Core.Tests.Unit/Services/CalendarResourceMoveServiceTests.cs
+++ b/tests/DotnetAgents.CalDav.Core.Tests.Unit/Services/CalendarResourceMoveServiceTests.cs
@@ -368,7 +368,15 @@ public sealed class CalendarResourceMoveServiceTests
 
         result.Code.ShouldBe(CalendarResourceMoveCode.UnsupportedCapability);
         result.MutationState.ShouldBe(CalendarMutationState.NotAttempted);
-        result.AuthorizedCandidates.ShouldBe([destination]);
+        var candidate = result.AuthorizedCandidates.ShouldHaveSingleItem();
+        candidate.Href.ShouldBe(destination.Href);
+        candidate.DisplayName.ShouldBe(destination.DisplayName);
+        candidate.DisplayNameProvenance.ShouldBe(destination.DisplayNameProvenance);
+        candidate.EventSupport.ShouldBe(destination.EventSupport);
+        candidate.TodoSupport.ShouldBe(destination.TodoSupport);
+        candidate.EventEvidence.ShouldBe(destination.EventEvidence);
+        candidate.TodoEvidence.ShouldBe(destination.TodoEvidence);
+        candidate.UnavailableProperties.ShouldBe(destination.UnavailableProperties);
         await client.DidNotReceive().MoveCalendarResourceAsync(
             Arg.Any<CalendarResourceMoveDispatchRequest>(),
             Arg.Any<CancellationToken>());

--- a/tests/DotnetAgents.CalDav.Core.Tests.Unit/Services/CalendarServiceTests.cs
+++ b/tests/DotnetAgents.CalDav.Core.Tests.Unit/Services/CalendarServiceTests.cs
@@ -19,40 +19,40 @@ namespace DotnetAgents.CalDav.Core.Tests.Unit.Services;
 public sealed class CalendarServiceTests
 {
     [Fact]
-    public async Task GetCalendarsAsync_ConcurrentConsumersShareOneCompleteAcquisition()
+    public async Task DiscoverAsync_ConcurrentConsumersShareOneCompleteAuthority()
     {
         var client = Substitute.For<ICalendarClient>();
         var acquisition = new TaskCompletionSource<IReadOnlyList<CalendarDescriptor>>(
             TaskCreationOptions.RunContinuationsAsynchronously);
         client.GetCalendarsAsync(Arg.Any<CancellationToken>()).Returns(acquisition.Task);
-        var sut = Service(client);
+        var sut = Discovery(client);
 
-        var first = sut.GetCalendarsAsync(CancellationToken.None);
-        var second = sut.GetCalendarsAsync(CancellationToken.None);
+        var first = sut.DiscoverAsync(CancellationToken.None);
+        var second = sut.DiscoverAsync(CancellationToken.None);
         acquisition.SetResult([EntityCalendar(
             "https://cal.example/events/",
             "Events",
             EntityKindSupport.Advertised,
             EntityKindSupport.NotAdvertised)]);
 
-        (await first).Items.ShouldHaveSingleItem();
-        (await second).Items.ShouldHaveSingleItem();
+        (await first).Discovery.Items.ShouldHaveSingleItem();
+        (await second).Discovery.Items.ShouldHaveSingleItem();
         await client.Received(1).GetCalendarsAsync(Arg.Any<CancellationToken>());
     }
 
     [Fact]
-    public async Task GetCalendarsAsync_SharedFailureIsMemoizedForTheToolCall()
+    public async Task DiscoverAsync_SharedFailureIsMemoizedForTheToolCall()
     {
         var client = Substitute.For<ICalendarClient>();
         var failure = new CalendarDiscoveryProtocolException("private upstream response");
         client.GetCalendarsAsync(Arg.Any<CancellationToken>())
             .Returns(Task.FromException<IReadOnlyList<CalendarDescriptor>>(failure));
-        var sut = Service(client);
+        var sut = Discovery(client);
 
         var first = await Should.ThrowAsync<CalendarDiscoveryProtocolException>(
-            () => sut.GetCalendarsAsync(CancellationToken.None));
+            () => sut.DiscoverAsync(CancellationToken.None));
         var second = await Should.ThrowAsync<CalendarDiscoveryProtocolException>(
-            () => sut.ResolveDefaultCalendarAsync(CalendarEntityKind.Event, CancellationToken.None));
+            () => sut.DiscoverAsync(CancellationToken.None));
 
         first.ShouldBeSameAs(failure);
         second.ShouldBeSameAs(failure);
@@ -60,7 +60,7 @@ public sealed class CalendarServiceTests
     }
 
     [Fact]
-    public async Task GetCalendarsAsync_SharedCancellationStopsTheSingleAcquisition()
+    public async Task DiscoverAsync_SharedCancellationStopsTheSingleAcquisition()
     {
         var client = Substitute.For<ICalendarClient>();
         var acquisition = new TaskCompletionSource<IReadOnlyList<CalendarDescriptor>>(
@@ -71,11 +71,11 @@ public sealed class CalendarServiceTests
             token.Register(() => acquisition.TrySetCanceled(token));
             return acquisition.Task;
         });
-        var sut = Service(client);
+        var sut = Discovery(client);
         using var cancellation = new CancellationTokenSource();
 
-        var first = sut.GetCalendarsAsync(cancellation.Token);
-        var second = sut.GetCalendarsAsync(cancellation.Token);
+        var first = sut.DiscoverAsync(cancellation.Token);
+        var second = sut.DiscoverAsync(cancellation.Token);
         cancellation.Cancel();
 
         await Should.ThrowAsync<OperationCanceledException>(() => first);
@@ -84,18 +84,18 @@ public sealed class CalendarServiceTests
     }
 
     [Fact]
-    public async Task GetCalendarsAsync_LaterSameKeyTokenDoesNotOverrideTheOperationToken()
+    public async Task DiscoverAsync_LaterSameKeyTokenDoesNotOverrideTheOperationToken()
     {
         var client = Substitute.For<ICalendarClient>();
         var acquisition = new TaskCompletionSource<IReadOnlyList<CalendarDescriptor>>(
             TaskCreationOptions.RunContinuationsAsynchronously);
         client.GetCalendarsAsync(Arg.Any<CancellationToken>()).Returns(acquisition.Task);
-        var sut = Service(client);
+        var sut = Discovery(client);
         using var operationCancellation = new CancellationTokenSource();
         using var laterConsumerCancellation = new CancellationTokenSource();
 
-        var operation = sut.GetCalendarsAsync(operationCancellation.Token);
-        var laterConsumer = sut.GetCalendarsAsync(laterConsumerCancellation.Token);
+        var operation = sut.DiscoverAsync(operationCancellation.Token);
+        var laterConsumer = sut.DiscoverAsync(laterConsumerCancellation.Token);
         laterConsumerCancellation.Cancel();
         acquisition.SetResult([EntityCalendar(
             "https://cal.example/events/",
@@ -103,13 +103,13 @@ public sealed class CalendarServiceTests
             EntityKindSupport.Advertised,
             EntityKindSupport.NotAdvertised)]);
 
-        (await operation).Items.ShouldHaveSingleItem();
-        (await laterConsumer).Items.ShouldHaveSingleItem();
+        (await operation).Discovery.Items.ShouldHaveSingleItem();
+        (await laterConsumer).Discovery.Items.ShouldHaveSingleItem();
         await client.Received(1).GetCalendarsAsync(Arg.Any<CancellationToken>());
     }
 
     [Fact]
-    public async Task GetCalendarsAsync_OperationCancellationIsTheSharedSameKeyOutcome()
+    public async Task DiscoverAsync_OperationCancellationIsTheSharedSameKeyOutcome()
     {
         var client = Substitute.For<ICalendarClient>();
         var acquisition = new TaskCompletionSource<IReadOnlyList<CalendarDescriptor>>(
@@ -120,11 +120,11 @@ public sealed class CalendarServiceTests
             token.Register(() => acquisition.TrySetCanceled(token));
             return acquisition.Task;
         });
-        var sut = Service(client);
+        var sut = Discovery(client);
         using var operationCancellation = new CancellationTokenSource();
 
-        var operation = sut.GetCalendarsAsync(operationCancellation.Token);
-        var laterConsumer = sut.GetCalendarsAsync(CancellationToken.None);
+        var operation = sut.DiscoverAsync(operationCancellation.Token);
+        var laterConsumer = sut.DiscoverAsync(CancellationToken.None);
         operationCancellation.Cancel();
 
         await Should.ThrowAsync<OperationCanceledException>(() => operation);
@@ -134,7 +134,7 @@ public sealed class CalendarServiceTests
     }
 
     [Fact]
-    public async Task GetCalendarsAsync_CancelledToolCallDoesNotPoisonAnotherToolCall()
+    public async Task DiscoverAsync_CancelledToolCallDoesNotPoisonAnotherToolCall()
     {
         var client = Substitute.For<ICalendarClient>();
         var firstAcquisition = new TaskCompletionSource<IReadOnlyList<CalendarDescriptor>>(
@@ -156,18 +156,18 @@ public sealed class CalendarServiceTests
         });
         using var cancelled = new CancellationTokenSource();
 
-        var cancelledCall = Service(client).GetCalendarsAsync(cancelled.Token);
+        var cancelledCall = Discovery(client).DiscoverAsync(cancelled.Token);
         cancelled.Cancel();
 
         await Should.ThrowAsync<OperationCanceledException>(() => cancelledCall);
-        var unrelated = await Service(client).GetCalendarsAsync(CancellationToken.None);
+        var unrelated = await Discovery(client).DiscoverAsync(CancellationToken.None);
 
-        unrelated.Items.ShouldHaveSingleItem();
+        unrelated.Discovery.Items.ShouldHaveSingleItem();
         await client.Received(2).GetCalendarsAsync(Arg.Any<CancellationToken>());
     }
 
     [Fact]
-    public async Task GetCalendarsAsync_NewToolCallDoesNotReuseReviewTimeDiscovery()
+    public async Task DiscoverAsync_NewToolCallDoesNotReuseReviewTimeAuthority()
     {
         var client = Substitute.For<ICalendarClient>();
         var calls = 0;
@@ -187,13 +187,13 @@ public sealed class CalendarServiceTests
             CalendarHrefs = "https://cal.example/events-1/,https://cal.example/events-2/"
         });
 
-        var reviewCall = Service(client, options);
-        var executionCall = Service(client, options);
-        var reviewed = await reviewCall.GetCalendarsAsync(CancellationToken.None);
-        var executed = await executionCall.GetCalendarsAsync(CancellationToken.None);
+        var reviewCall = Discovery(client, options);
+        var executionCall = Discovery(client, options);
+        var reviewed = await reviewCall.DiscoverAsync(CancellationToken.None);
+        var executed = await executionCall.DiscoverAsync(CancellationToken.None);
 
-        reviewed.Items.ShouldHaveSingleItem().Href.ShouldBe("https://cal.example/events-1/");
-        executed.Items.ShouldHaveSingleItem().Href.ShouldBe("https://cal.example/events-2/");
+        reviewed.Discovery.Items.ShouldHaveSingleItem().Href.ShouldBe("https://cal.example/events-1/");
+        executed.Discovery.Items.ShouldHaveSingleItem().Href.ShouldBe("https://cal.example/events-2/");
         await client.Received(2).GetCalendarsAsync(Arg.Any<CancellationToken>());
     }
 
@@ -317,7 +317,7 @@ public sealed class CalendarServiceTests
     }
 
     [Fact]
-    public async Task GetCalendarsAsync_FreezesDiscoveryEvidenceForTheToolCall()
+    public async Task DiscoverAsync_FreezesCalendarsAndDefaultDecisionsForTheToolCall()
     {
         var evidence = new List<CapabilityEvidence> { new("supported-calendar-component-set", "VEVENT") };
         var calendars = new List<CalendarDescriptor>
@@ -333,15 +333,21 @@ public sealed class CalendarServiceTests
         };
         var client = Substitute.For<ICalendarClient>();
         client.GetCalendarsAsync(Arg.Any<CancellationToken>()).Returns(calendars);
-        var sut = Service(client);
+        var sut = Discovery(client, Options.Create(new CalDavOptions
+        {
+            BaseUrl = "https://cal.example",
+            DefaultEventCalendarName = "Events"
+        }));
 
-        var first = await sut.GetCalendarsAsync(CancellationToken.None);
+        var first = await sut.DiscoverAsync(CancellationToken.None);
         calendars.Clear();
         evidence.Clear();
-        var second = await sut.GetCalendarsAsync(CancellationToken.None);
+        var second = await sut.DiscoverAsync(CancellationToken.None);
 
-        first.Items.ShouldHaveSingleItem().EventEvidence.ShouldHaveSingleItem();
-        second.Items.ShouldHaveSingleItem().EventEvidence.ShouldHaveSingleItem();
+        first.Discovery.Items.ShouldHaveSingleItem().EventEvidence.ShouldHaveSingleItem();
+        first.EventDefault.Calendar!.EventEvidence.ShouldHaveSingleItem();
+        second.Discovery.Items.ShouldHaveSingleItem().EventEvidence.ShouldHaveSingleItem();
+        second.EventDefault.Calendar!.EventEvidence.ShouldHaveSingleItem();
         await client.Received(1).GetCalendarsAsync(Arg.Any<CancellationToken>());
     }
 
@@ -735,6 +741,23 @@ public sealed class CalendarServiceTests
         };
 
     private static ICalendarClient QueryClientSubstitute() => Substitute.For<ICalendarClient>();
+
+    private static CalendarOperationDiscovery Discovery(
+        ICalendarClient client,
+        IOptions<CalDavOptions>? options = null)
+    {
+        var configured = options ?? Options.Create(new CalDavOptions
+        {
+            BaseUrl = "https://cal.example",
+            Username = "principal"
+        });
+        var policy = new CalendarDiscoveryPolicy(configured, Substitute.For<ILogger<CalendarService>>());
+        return new CalendarOperationDiscovery(
+            new CalendarClientDiscoveryTransport(client),
+            configured,
+            policy.ApplyScope,
+            policy.ResolveDefault);
+    }
 
     private static CalendarService Service(
         ICalendarClient client,

--- a/tests/DotnetAgents.CalDav.Core.Tests.Unit/Services/CalendarTodoQueryModuleTests.cs
+++ b/tests/DotnetAgents.CalDav.Core.Tests.Unit/Services/CalendarTodoQueryModuleTests.cs
@@ -544,7 +544,7 @@ public sealed class CalendarTodoQueryModuleTests
                 EventSupport = EntityKindSupport.Advertised,
                 TodoSupport = EntityKindSupport.Advertised
             };
-            return Task.FromResult(new CalendarOperationDiscoveryResult(
+            return Task.FromResult(CalendarOperationDiscoveryResultFactory.Create(
                 new CalendarDiscoveryResult([calendar], []),
                 CalendarSelectionResult.Success(calendar),
                 CalendarSelectionResult.Success(calendar)));

--- a/tests/DotnetAgents.CalDav.Core.Tests.Unit/Services/CalendarTodoQueryModuleTests.cs
+++ b/tests/DotnetAgents.CalDav.Core.Tests.Unit/Services/CalendarTodoQueryModuleTests.cs
@@ -532,7 +532,7 @@ public sealed class CalendarTodoQueryModuleTests
 
         internal List<IReadOnlyList<string>> MultigetRequests { get; } = [];
 
-        public Task<CalendarQueryDiscovery> DiscoverAsync(CancellationToken cancellationToken)
+        public Task<CalendarOperationDiscoveryResult> DiscoverAsync(CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
             DiscoveryCount++;
@@ -544,7 +544,7 @@ public sealed class CalendarTodoQueryModuleTests
                 EventSupport = EntityKindSupport.Advertised,
                 TodoSupport = EntityKindSupport.Advertised
             };
-            return Task.FromResult(new CalendarQueryDiscovery(
+            return Task.FromResult(new CalendarOperationDiscoveryResult(
                 new CalendarDiscoveryResult([calendar], []),
                 CalendarSelectionResult.Success(calendar),
                 CalendarSelectionResult.Success(calendar)));

--- a/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/LegacyContractRemovalTests.cs
+++ b/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/LegacyContractRemovalTests.cs
@@ -142,17 +142,27 @@ public sealed class LegacyContractRemovalTests
     }
 
     [Fact]
-    public void ShippedCore_HasOneQueryTransportSeamAndOneProductionAdapter()
+    public void ShippedCore_HasOneDiscoveryAuthorityAndNarrowProductionAdapters()
     {
         var coreTypes = typeof(ICalendarQueryModule).Assembly.GetTypes();
         coreTypes.ShouldNotContain(type => type.Name == "ICalendarQueryResourceTransport");
         typeof(ICalendarClient).GetMethods()
             .ShouldNotContain(method => method.Name.Contains("Query", StringComparison.Ordinal));
-        coreTypes.Single(type => type.Name == "CalendarOperationDiscovery").GetMethods(
+        var discovery = coreTypes.Single(type => type.Name == "CalendarOperationDiscovery");
+        discovery.GetMethods(
                 System.Reflection.BindingFlags.Instance
                 | System.Reflection.BindingFlags.Public
-                | System.Reflection.BindingFlags.NonPublic)
-            .ShouldNotContain(method => method.Name.Contains("Query", StringComparison.Ordinal));
+                | System.Reflection.BindingFlags.DeclaredOnly)
+            .Select(method => method.Name)
+            .ShouldBe(["DiscoverAsync"]);
+        typeof(ICalendarClient).IsAssignableFrom(discovery).ShouldBeFalse();
+        coreTypes.Single(type => type.Name == "ICalendarCreateTransport").IsAssignableFrom(discovery).ShouldBeFalse();
+        coreTypes.Single(type => type.Name == "ICalendarMoveTransport").IsAssignableFrom(discovery).ShouldBeFalse();
+
+        var discoveryTransport = coreTypes.Single(type => type.Name == "ICalendarDiscoveryTransport");
+        coreTypes.Where(type => !type.IsInterface && discoveryTransport.IsAssignableFrom(type))
+            .Select(type => type.Name)
+            .ShouldBe(["CalendarClientDiscoveryTransport"]);
 
         var transport = coreTypes.Single(type => type.Name == "ICalendarQueryTransport");
         coreTypes.Where(type => !type.IsInterface && transport.IsAssignableFrom(type))


### PR DESCRIPTION
Closes #133

## Summary

- returns one complete immutable discovery authority per MCP call
- precomputes scoped Calendars plus Event and To-do Default Calendar decisions atomically
- makes Query, Create, Semantic Move, and Exact Move consume the shared authority
- removes acquire-then-resolve sequencing and unrelated CalDAV pass-throughs
- keeps MRTR continuation discovery fresh and operation-local

## Verification

- focused post-rebase regression: 488/488
- MCP project on this branch: 1014/1014
- composed #139→#143 rootless gate on current main: Core 2413, MCP 1014, integration 112, strict-preconditions 11, alternate-time-zone 11; no skips
- composed coverage: 94.3% line, 85.9% branch
- Release build: 0 warnings/errors
- Slopwatch: 0 findings
- Standards review: 0 findings
- Spec review: 0 findings

The local full suite used the rootless Docker endpoint and the digest-pinned Radicale profile. This is the bottom PR for dependent #134.