### PR TITLE
Remove the Calendar collection tool service locator

### DIFF
--- a/src/DotnetAgents.CalDav.Mcp/Tools/CalendarCollectionTools.cs
+++ b/src/DotnetAgents.CalDav.Mcp/Tools/CalendarCollectionTools.cs
@@ -3,7 +3,6 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using DotnetAgents.CalDav.Core.Abstractions;
 using DotnetAgents.CalDav.Core.Models;
-using Microsoft.Extensions.DependencyInjection;
 using ModelContextProtocol.Protocol;
 using ModelContextProtocol.Server;
 
@@ -11,7 +10,7 @@ namespace DotnetAgents.CalDav.Mcp.Tools;
 
 /// <summary>Creates Calendar collections and deletes them through MRTR confirmation.</summary>
 [McpServerToolType]
-public sealed class CalendarCollectionTools
+internal sealed class CalendarCollectionTools
 {
     internal const int MaximumArgumentBytes = CalendarQueryToolSupport.MaximumArgumentBytes;
     private const string ConfirmationKey = "confirm_delete";
@@ -20,15 +19,7 @@ public sealed class CalendarCollectionTools
     private readonly CalendarMutationRequestStateProtector _stateProtector;
     private readonly TimeProvider _timeProvider;
 
-    public CalendarCollectionTools(IServiceProvider services)
-        : this(
-            services.GetRequiredService<ICalendarCollectionModule>(),
-            services.GetRequiredService<CalendarMutationRequestStateProtector>(),
-            services.GetRequiredService<TimeProvider>())
-    {
-    }
-
-    internal CalendarCollectionTools(
+    public CalendarCollectionTools(
         ICalendarCollectionModule module,
         CalendarMutationRequestStateProtector stateProtector,
         TimeProvider timeProvider)

--- a/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/CalDavHostBuilderTests.cs
+++ b/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/CalDavHostBuilderTests.cs
@@ -162,6 +162,16 @@ public class CalDavHostBuilderTests
         invalidTypes.ShouldBeEmpty($"Types marked [McpServerToolType] without [McpServerTool] methods: {string.Join(", ", invalidTypes)}");
     }
 
+    [Fact]
+    public void McpToolTypes_DoNotUseServiceLocatorConstructors()
+    {
+        var constructors = typeof(DotnetAgents.CalDav.Mcp.Tools.CalendarCollectionTools)
+            .GetConstructors(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+
+        constructors.ShouldNotContain(constructor => constructor.GetParameters()
+            .Any(parameter => parameter.ParameterType == typeof(IServiceProvider)));
+    }
+
     private static List<string> GetTypesWithoutToolMethods(List<Type> toolTypes)
     {
         return toolTypes


### PR DESCRIPTION
Follow-up to #137.

## Summary

- removes the `IServiceProvider` constructor from `CalendarCollectionTools`
- declares the three runtime dependencies in one typed constructor
- keeps `CalendarMutationRequestStateProtector` internal by making the tool type internal
- adds a structural host test that rejects a service-locator constructor on this adapter

The nine preexisting MCP adapter locators are intentionally tracked separately in #140.

## Verification

- Release build: 0 warnings/errors
- structural regression: 1/1
- MCP project on this branch: 1015/1015
- composed #141→#145 rootless gate: Core 2376, MCP 1014, integration 112, strict-preconditions 11, alternate-time-zone 11; no skips
- composed coverage: 94.4% line, 85.8% branch
- Slopwatch: 0 findings
- Standards review: 0 findings
- Spec review: 0 findings
