### PR TITLE
Replace legacy MCP tool service locators with typed constructors

### DIFF
--- a/src/DotnetAgents.CalDav.Mcp/Hosting/CalDavHostBuilder.cs
+++ b/src/DotnetAgents.CalDav.Mcp/Hosting/CalDavHostBuilder.cs
@@ -73,12 +73,6 @@ public sealed class CalDavHostBuilder
         builder.Services.AddSingleton(TimeProvider.System);
         builder.Services.AddSingleton<CalendarOperationAdmission>();
         builder.Services.AddSingleton<CalendarMutationRequestStateProtector>();
-        builder.Services.AddTransient(serviceProvider => new CalendarEntityTools(
-            serviceProvider.GetRequiredService<DotnetAgents.CalDav.Core.Abstractions.ICalendarQueryModule>()));
-        builder.Services.AddTransient(serviceProvider => new CalendarOccurrenceTools(
-            serviceProvider.GetRequiredService<DotnetAgents.CalDav.Core.Abstractions.ICalendarQueryModule>()));
-        builder.Services.AddTransient(serviceProvider => new CalendarTodoTools(
-            serviceProvider.GetRequiredService<DotnetAgents.CalDav.Core.Abstractions.ICalendarQueryModule>()));
         return builder;
     }
 

--- a/src/DotnetAgents.CalDav.Mcp/Tools/CalendarEntityCreateTools.cs
+++ b/src/DotnetAgents.CalDav.Mcp/Tools/CalendarEntityCreateTools.cs
@@ -4,7 +4,6 @@ using System.Text.Json.Serialization;
 using System.Xml;
 using DotnetAgents.CalDav.Core.Abstractions;
 using DotnetAgents.CalDav.Core.Models;
-using Microsoft.Extensions.DependencyInjection;
 using ModelContextProtocol.Protocol;
 using ModelContextProtocol.Server;
 
@@ -18,14 +17,7 @@ public sealed class CalendarEntityCreateTools
     private readonly ICalendarService _calendarService;
     private readonly TimeProvider _timeProvider;
 
-    public CalendarEntityCreateTools(IServiceProvider services)
-        : this(
-            services.GetRequiredService<ICalendarService>(),
-            services.GetRequiredService<TimeProvider>())
-    {
-    }
-
-    internal CalendarEntityCreateTools(ICalendarService calendarService, TimeProvider timeProvider)
+    public CalendarEntityCreateTools(ICalendarService calendarService, TimeProvider timeProvider)
     {
         _calendarService = calendarService;
         _timeProvider = timeProvider;

--- a/src/DotnetAgents.CalDav.Mcp/Tools/CalendarEntityPatchTools.cs
+++ b/src/DotnetAgents.CalDav.Mcp/Tools/CalendarEntityPatchTools.cs
@@ -2,7 +2,6 @@ using System.ComponentModel;
 using System.Text.Json;
 using DotnetAgents.CalDav.Core.Abstractions;
 using DotnetAgents.CalDav.Core.Models;
-using Microsoft.Extensions.DependencyInjection;
 using ModelContextProtocol.Protocol;
 using ModelContextProtocol.Server;
 
@@ -10,7 +9,7 @@ namespace DotnetAgents.CalDav.Mcp.Tools;
 
 /// <summary>Applies revision-bound lossless Event and To-do patches.</summary>
 [McpServerToolType]
-public sealed class CalendarEntityPatchTools
+internal sealed class CalendarEntityPatchTools
 {
     internal const int MaximumArgumentBytes = CalendarQueryToolSupport.MaximumArgumentBytes;
     private const string EventOperation = "events.patch";
@@ -23,20 +22,12 @@ public sealed class CalendarEntityPatchTools
     private readonly CalendarMutationRequestStateProtector? _stateProtector;
     private readonly TimeProvider _timeProvider;
 
-    public CalendarEntityPatchTools(IServiceProvider services)
-        : this(
-            services.GetRequiredService<ICalendarService>(),
-            services.GetRequiredService<TimeProvider>(),
-            services.GetRequiredService<CalendarMutationRequestStateProtector>())
-    {
-    }
-
     internal CalendarEntityPatchTools(ICalendarService calendarService, TimeProvider timeProvider)
         : this(calendarService, timeProvider, null)
     {
     }
 
-    internal CalendarEntityPatchTools(
+    public CalendarEntityPatchTools(
         ICalendarService calendarService,
         TimeProvider timeProvider,
         CalendarMutationRequestStateProtector? stateProtector)

--- a/src/DotnetAgents.CalDav.Mcp/Tools/CalendarEntityTools.cs
+++ b/src/DotnetAgents.CalDav.Mcp/Tools/CalendarEntityTools.cs
@@ -3,7 +3,6 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using DotnetAgents.CalDav.Core.Abstractions;
 using DotnetAgents.CalDav.Core.Models;
-using Microsoft.Extensions.DependencyInjection;
 using ModelContextProtocol.Protocol;
 using ModelContextProtocol.Server;
 
@@ -19,12 +18,7 @@ public sealed class CalendarEntityTools
     private const int MaximumCursorCharacters = 2048;
     private readonly ICalendarQueryModule _queryModule;
 
-    public CalendarEntityTools(IServiceProvider services)
-        : this(services.GetRequiredService<ICalendarQueryModule>())
-    {
-    }
-
-    internal CalendarEntityTools(ICalendarQueryModule queryModule)
+    public CalendarEntityTools(ICalendarQueryModule queryModule)
     {
         _queryModule = queryModule;
     }

--- a/src/DotnetAgents.CalDav.Mcp/Tools/CalendarOccurrenceMutationTools.cs
+++ b/src/DotnetAgents.CalDav.Mcp/Tools/CalendarOccurrenceMutationTools.cs
@@ -3,7 +3,6 @@ using System.Globalization;
 using System.Text.Json;
 using DotnetAgents.CalDav.Core.Abstractions;
 using DotnetAgents.CalDav.Core.Models;
-using Microsoft.Extensions.DependencyInjection;
 using ModelContextProtocol.Protocol;
 using ModelContextProtocol.Server;
 
@@ -16,13 +15,7 @@ public sealed class CalendarOccurrenceMutationTools
     internal const int MaximumArgumentBytes = CalendarQueryToolSupport.MaximumArgumentBytes;
     private readonly ICalendarService _calendarService;
 
-    public CalendarOccurrenceMutationTools(IServiceProvider services)
-        : this(
-            services.GetRequiredService<ICalendarService>())
-    {
-    }
-
-    internal CalendarOccurrenceMutationTools(ICalendarService calendarService)
+    public CalendarOccurrenceMutationTools(ICalendarService calendarService)
     {
         _calendarService = calendarService;
     }

--- a/src/DotnetAgents.CalDav.Mcp/Tools/CalendarOccurrenceTools.cs
+++ b/src/DotnetAgents.CalDav.Mcp/Tools/CalendarOccurrenceTools.cs
@@ -3,7 +3,6 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using DotnetAgents.CalDav.Core.Abstractions;
 using DotnetAgents.CalDav.Core.Models;
-using Microsoft.Extensions.DependencyInjection;
 using ModelContextProtocol.Protocol;
 using ModelContextProtocol.Server;
 
@@ -17,12 +16,7 @@ public sealed class CalendarOccurrenceTools
     internal const int MaximumArgumentBytes = CalendarQueryToolSupport.MaximumArgumentBytes;
     private readonly ICalendarQueryModule _queryModule;
 
-    public CalendarOccurrenceTools(IServiceProvider services)
-        : this(services.GetRequiredService<ICalendarQueryModule>())
-    {
-    }
-
-    internal CalendarOccurrenceTools(ICalendarQueryModule queryModule)
+    public CalendarOccurrenceTools(ICalendarQueryModule queryModule)
     {
         _queryModule = queryModule;
     }

--- a/src/DotnetAgents.CalDav.Mcp/Tools/CalendarResourceDeleteTools.cs
+++ b/src/DotnetAgents.CalDav.Mcp/Tools/CalendarResourceDeleteTools.cs
@@ -3,7 +3,6 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using DotnetAgents.CalDav.Core.Abstractions;
 using DotnetAgents.CalDav.Core.Models;
-using Microsoft.Extensions.DependencyInjection;
 using ModelContextProtocol.Protocol;
 using ModelContextProtocol.Server;
 
@@ -11,7 +10,7 @@ namespace DotnetAgents.CalDav.Mcp.Tools;
 
 /// <summary>Deletes one reviewed Calendar Object Resource through revision-bound MRTR confirmation.</summary>
 [McpServerToolType]
-public sealed class CalendarResourceDeleteTools
+internal sealed class CalendarResourceDeleteTools
 {
     internal const int MaximumArgumentBytes = CalendarQueryToolSupport.MaximumArgumentBytes;
     private const string ConfirmationKey = "confirm_delete";
@@ -22,15 +21,7 @@ public sealed class CalendarResourceDeleteTools
     private readonly CalendarMutationRequestStateProtector _stateProtector;
     private readonly TimeProvider _timeProvider;
 
-    public CalendarResourceDeleteTools(IServiceProvider services)
-        : this(
-            services.GetRequiredService<ICalendarService>(),
-            services.GetRequiredService<CalendarMutationRequestStateProtector>(),
-            services.GetRequiredService<TimeProvider>())
-    {
-    }
-
-    internal CalendarResourceDeleteTools(
+    public CalendarResourceDeleteTools(
         ICalendarService calendarService,
         CalendarMutationRequestStateProtector stateProtector,
         TimeProvider timeProvider)

--- a/src/DotnetAgents.CalDav.Mcp/Tools/CalendarResourceMoveTools.cs
+++ b/src/DotnetAgents.CalDav.Mcp/Tools/CalendarResourceMoveTools.cs
@@ -2,7 +2,6 @@ using System.ComponentModel;
 using System.Text.Json;
 using DotnetAgents.CalDav.Core.Abstractions;
 using DotnetAgents.CalDav.Core.Models;
-using Microsoft.Extensions.DependencyInjection;
 using ModelContextProtocol.Protocol;
 using ModelContextProtocol.Server;
 
@@ -17,14 +16,7 @@ public sealed class CalendarResourceMoveTools
     private readonly ICalendarService _calendarService;
     private readonly TimeProvider _timeProvider;
 
-    public CalendarResourceMoveTools(IServiceProvider services)
-        : this(
-            services.GetRequiredService<ICalendarService>(),
-            services.GetRequiredService<TimeProvider>())
-    {
-    }
-
-    internal CalendarResourceMoveTools(
+    public CalendarResourceMoveTools(
         ICalendarService calendarService,
         TimeProvider timeProvider)
     {

--- a/src/DotnetAgents.CalDav.Mcp/Tools/CalendarTodoTools.cs
+++ b/src/DotnetAgents.CalDav.Mcp/Tools/CalendarTodoTools.cs
@@ -3,7 +3,6 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using DotnetAgents.CalDav.Core.Abstractions;
 using DotnetAgents.CalDav.Core.Models;
-using Microsoft.Extensions.DependencyInjection;
 using ModelContextProtocol.Protocol;
 using ModelContextProtocol.Server;
 
@@ -24,12 +23,7 @@ public sealed class CalendarTodoTools
     internal const int MaximumArgumentBytes = CalendarQueryToolSupport.MaximumArgumentBytes;
     private readonly ICalendarQueryModule _queryModule;
 
-    public CalendarTodoTools(IServiceProvider services)
-        : this(services.GetRequiredService<ICalendarQueryModule>())
-    {
-    }
-
-    internal CalendarTodoTools(ICalendarQueryModule queryModule)
+    public CalendarTodoTools(ICalendarQueryModule queryModule)
     {
         _queryModule = queryModule;
     }

--- a/src/DotnetAgents.CalDav.Mcp/Tools/ExactCalendarResourceWriteTools.cs
+++ b/src/DotnetAgents.CalDav.Mcp/Tools/ExactCalendarResourceWriteTools.cs
@@ -6,7 +6,6 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using DotnetAgents.CalDav.Core.Abstractions;
 using DotnetAgents.CalDav.Core.Models;
-using Microsoft.Extensions.DependencyInjection;
 using ModelContextProtocol.Protocol;
 using ModelContextProtocol.Server;
 
@@ -14,7 +13,7 @@ namespace DotnetAgents.CalDav.Mcp.Tools;
 
 /// <summary>Opt-in complete-resource writes protected by MCP Multi Round-Trip Requests.</summary>
 [McpServerToolType]
-public sealed class ExactCalendarResourceWriteTools
+internal sealed class ExactCalendarResourceWriteTools
 {
     internal const int MaximumDecodedResourceBytes = 4 * 1024 * 1024;
     private const int MaximumJsonBytesPerDecodedResourceByte = 6;
@@ -34,15 +33,7 @@ public sealed class ExactCalendarResourceWriteTools
     private readonly CalendarMutationRequestStateProtector _stateProtector;
     private readonly TimeProvider _timeProvider;
 
-    public ExactCalendarResourceWriteTools(IServiceProvider services)
-        : this(
-            services.GetRequiredService<ICalendarService>(),
-            services.GetRequiredService<CalendarMutationRequestStateProtector>(),
-            services.GetRequiredService<TimeProvider>())
-    {
-    }
-
-    internal ExactCalendarResourceWriteTools(
+    public ExactCalendarResourceWriteTools(
         ICalendarService calendarService,
         CalendarMutationRequestStateProtector stateProtector,
         TimeProvider timeProvider)

--- a/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/CalDavHostBuilderTests.cs
+++ b/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/CalDavHostBuilderTests.cs
@@ -163,13 +163,20 @@ public class CalDavHostBuilderTests
     }
 
     [Fact]
-    public void McpToolTypes_DoNotUseServiceLocatorConstructors()
+    public void RegisteredMcpToolTypes_DoNotUseServiceLocatorConstructors()
     {
-        var constructors = typeof(DotnetAgents.CalDav.Mcp.Tools.CalendarCollectionTools)
-            .GetConstructors(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+        var registeredToolTypes = GetRegisteredMcpToolTypes(CalDavHostBuilder.CreateBuilder().Services)
+            .Concat(GetRegisteredMcpToolTypes(CalDavHostBuilder.CreateBuilder(exposeExactTools: true).Services))
+            .Distinct();
 
-        constructors.ShouldNotContain(constructor => constructor.GetParameters()
-            .Any(parameter => parameter.ParameterType == typeof(IServiceProvider)));
+        var serviceLocatorToolTypes = registeredToolTypes
+            .Where(toolType => toolType.GetConstructors(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
+                .Any(constructor => constructor.GetParameters()
+                    .Any(parameter => parameter.ParameterType == typeof(IServiceProvider))))
+            .Select(toolType => toolType.FullName)
+            .ToArray();
+
+        serviceLocatorToolTypes.ShouldBeEmpty("Registered MCP tool types must declare their exact dependencies for SDK activation.");
     }
 
     private static List<string> GetTypesWithoutToolMethods(List<Type> toolTypes)
@@ -406,27 +413,10 @@ public class CalDavHostBuilderTests
     }
 
     [Fact]
-    public void BuildHost_ActivatesCalendarEntityCreateToolsThroughTheSdkConstructionPath()
+    public void BuildHost_ActivatesEveryRegisteredMcpToolTypeThroughTheSdkConstructionPath()
     {
-        var builder = CalDavHostBuilder.CreateBuilder();
-        builder.Services.ConfigureCalDav(ValidOptions);
-        using var host = builder.Build();
-
-        ActivatorUtilities.CreateInstance<DotnetAgents.CalDav.Mcp.Tools.CalendarEntityCreateTools>(host.Services)
-            .ShouldNotBeNull();
-    }
-
-    [Fact]
-    public void BuildHost_ActivatesCalendarEntityToolsThroughTheSdkConstructionPath()
-    {
-        var builder = CalDavHostBuilder.CreateBuilder();
-        builder.Services.ConfigureCalDav(ValidOptions);
-        using var host = builder.Build();
-
-        host.Services.GetRequiredService<DotnetAgents.CalDav.Mcp.Tools.CalendarEntityTools>()
-            .ShouldNotBeNull();
-        ActivatorUtilities.CreateInstance<DotnetAgents.CalDav.Mcp.Tools.CalendarEntityTools>(host.Services)
-            .ShouldNotBeNull();
+        AssertActivatesRegisteredToolTypes(exposeExactTools: false);
+        AssertActivatesRegisteredToolTypes(exposeExactTools: true);
     }
 
     [Fact]
@@ -699,6 +689,16 @@ public class CalDavHostBuilderTests
             .Where(toolType => knownToolTypes.Contains(toolType))
             .Distinct()
             .ToArray();
+    }
+
+    private static void AssertActivatesRegisteredToolTypes(bool exposeExactTools)
+    {
+        var builder = CalDavHostBuilder.CreateBuilder(exposeExactTools);
+        builder.Services.ConfigureCalDav(ValidOptions);
+        using var host = builder.Build();
+
+        foreach (var toolType in GetRegisteredMcpToolTypes(builder.Services))
+            ActivatorUtilities.CreateInstance(host.Services, toolType).ShouldNotBeNull();
     }
 
     private static string RepositoryRoot()


### PR DESCRIPTION
Closes #140

Depends on #141.

## Summary

- removes `IServiceProvider` construction from the nine legacy MCP tool adapters named by #140
- gives each adapter an explicit typed constructor containing only its real dependencies
- moves reflection-based activation to the composition root and verifies every registered tool remains activatable
- keeps `CalendarExecutionPolicy` and host composition outside this debt scope

## Verification

- structural service-locator regression: 1/1
- host activation regression: 34/34
- full rootless gate on current main: Core 2376, MCP 1014, integration 112, strict-preconditions 11, alternate-time-zone 11; no skips
- coverage: 94.4% line, 85.8% branch
- Release build: 0 warnings/errors
- Slopwatch: 0 findings
- Standards review: 0 findings
- Spec review: 0 findings

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a></sub>