### PR TITLE
chore: update NuGet packages

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,7 +6,7 @@
   <PropertyGroup Label="SharedVersions">
     <McpSdkVersion>2.2.0</McpSdkVersion>
     <IcalNetVersion>5.2.3</IcalNetVersion>
-    <AutoFixtureVersion>4.18.1</AutoFixtureVersion>
+    <AutoFixtureVersion>5.0.0-rc.1</AutoFixtureVersion>
     <TestContainersVersion>4.11.0</TestContainersVersion>
     <MicrosoftExtensionsVersion>10.0.11</MicrosoftExtensionsVersion>
   </PropertyGroup>
@@ -14,9 +14,9 @@
   <ItemGroup Label="MCP">
     <PackageVersion Include="JsonSchema.Net" Version="9.4.0" />
     <PackageVersion Include="ModelContextProtocol" Version="$(McpSdkVersion)" />
-    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.17.0" />
-    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.17.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.17.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.18.0" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.18.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.18.0" />
     <PackageVersion Include="SSH.NET" Version="2026.0.0" />
   </ItemGroup>
   <!-- Core Dependencies -->
@@ -39,7 +39,7 @@
     <PackageVersion Include="coverlet.MTP" Version="10.0.1" />
     <PackageVersion Include="Microsoft.Testing.Extensions.TrxReport" Version="2.3.3" />
     <PackageVersion Include="xunit.v3" Version="4.0.0" />
-    <PackageVersion Include="NSubstitute" Version="5.3.0" />
+    <PackageVersion Include="NSubstitute" Version="6.2.0" />
     <PackageVersion Include="NSubstitute.Analyzers.CSharp" Version="1.0.17" />
     <PackageVersion Include="AutoFixture" Version="$(AutoFixtureVersion)" />
     <PackageVersion Include="AutoFixture.AutoNSubstitute" Version="$(AutoFixtureVersion)" />


### PR DESCRIPTION
## Summary

- Upgrade AutoFixture and AutoFixture.AutoNSubstitute to `5.0.0-rc.1`.
- Upgrade NSubstitute to `6.2.0`.
- Upgrade the three directly managed OpenTelemetry packages to `1.18.0`.

## Validation

- `dotnet outdated` with major upgrades enabled: no remaining direct updates.
- `dotnet restore`: passed.
- `dotnet build -c Release --no-restore`: passed with 0 warnings and 0 errors.
- Core unit tests: 2,376 passed.
- MCP unit tests: 1,014 passed.
- Slopwatch: 0 issues.
- NuGet vulnerability audit: no vulnerable packages reported.

The full suite's Core and MCP runs passed. Integration tests were attempted, but 62 failed during Docker/Testcontainers fixture startup because created containers disappeared before readiness checks; this is an environment limitation, not a package restore or compilation failure.
