### PR TITLE
fix: run CI for complexity analyzer configuration changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,6 @@ on:
     branches: [main]
     paths-ignore:
       - "**/*.md"
-      - "**/*.txt"
 
 permissions:
   contents: read


### PR DESCRIPTION
The CI paths-ignore rule skipped every .txt file, including CodeMetricsConfig.txt. Directory.Build.props passes this file to the analyzer, so a complexity-gate change could avoid the build that validates it. Remove the .txt exclusion; retain the documentation exclusion.

Validation: checked the tracked .txt inventory and the analyzer AdditionalFiles reference.
