### PR TITLE
test: remove obsolete MOVE evidence compatibility mode

### DIFF
--- a/tests/DotnetAgents.CalDav.Core.Tests.Unit/Services/ExactMoveMrtrWorkEvidenceTests.cs
+++ b/tests/DotnetAgents.CalDav.Core.Tests.Unit/Services/ExactMoveMrtrWorkEvidenceTests.cs
@@ -1,7 +1,6 @@
 using System.Diagnostics;
 using System.Net;
 using System.Net.Http.Headers;
-using System.Reflection;
 using System.Security.Cryptography;
 using System.Text;
 using DotnetAgents.CalDav.Core.Abstractions;
@@ -24,65 +23,28 @@ public sealed class ExactMoveMrtrWorkEvidenceTests(ITestOutputHelper output)
     [InlineData(1)]
     [InlineData(50)]
     [InlineData(600)]
-    public async Task SameHttpCorpusObservesLegacyThreePreparationsAndChangedTwoRoundConstantWork(
+    public async Task ConfirmedMoveUsesTwoRoundsOfConstantHttpWork(
         int destinationCardinality)
     {
         using var handler = new ObservationHandler(destinationCardinality);
         using var httpClient = new HttpClient(handler);
-        var options = new CalDavOptions
-        {
-            BaseUrl = ObservationHandler.CalendarHomeHref,
-            Username = "user",
-            Password = "secret",
-            CalendarHrefs = $"{ObservationHandler.SourceCalendarHref},{ObservationHandler.DestinationCalendarHref}"
-        };
-        options.GetType().GetProperty("InteroperabilityProfile")?.SetValue(options, "radicale-3.7.8");
-        var mode = ResolveEvidenceMode(Environment.GetEnvironmentVariable("CALDAV_MOVE_EVIDENCE_MODE"));
-        ICalendarService CreateService() => new CalendarService(
-            new CalDavClient(
-                httpClient,
-                Options.Create(options),
-                Substitute.For<ILogger<CalDavClient>>()),
-            Options.Create(options),
-            Substitute.For<ILogger<CalendarService>>(),
-            TimeProvider.System,
-            Substitute.For<ICalendarEntityIdentityGenerator>());
-        var request = new CalendarExactMoveRequest(
-            new CalendarResourceRevisionReference(
-                ObservationHandler.SourceHref,
-                ObservationHandler.EntityUid,
-                CalendarEntityKind.Todo,
-                "\"r1\""),
-            ObservationHandler.DestinationHref);
+        var options = OptionsForEvidence();
+        ICalendarService CreateService() => CreateEvidenceService(httpClient, options);
+        var request = ExactMoveRequest();
         var started = Stopwatch.GetTimestamp();
 
-        var result = await ExecuteTwoRoundMrtrAsync(CreateService, request, mode, CancellationToken.None);
+        var result = await ExecuteTwoRoundMrtrAsync(CreateService, request, CancellationToken.None);
 
         var elapsed = Stopwatch.GetElapsedTime(started);
-        Property(result, "Code").ToString().ShouldBe("Success");
-        Property(result, "MutationState").ToString().ShouldBe("Committed");
-        var snapshot = Property(result, "Snapshot");
-        ((ReadOnlyMemory<byte>)Property(snapshot, "AuthoritativeUtf8")).Span
+        result.Code.ShouldBe(CalendarExactResourceCode.Success);
+        result.MutationState.ShouldBe(CalendarMutationState.Committed);
+        var snapshot = result.Snapshot.ShouldNotBeNull();
+        snapshot.AuthoritativeUtf8.Span
             .SequenceEqual(ObservationHandler.SourceContent)
             .ShouldBeTrue();
-        handler.PropFindCount.ShouldBe(4);
-        handler.SourceGetCount.ShouldBe(mode == "legacy-scan" ? 4 : 3);
-        handler.DestinationGetCount.ShouldBe(mode == "legacy-scan" ? 4 : 3);
-        handler.MoveCount.ShouldBe(1);
-        if (mode == "legacy-scan")
-        {
-            handler.ReportCount.ShouldBe(6);
-            handler.UnrelatedGetCount.ShouldBe(destinationCardinality * 3);
-            handler.RequestCount.ShouldBe((destinationCardinality * 3) + 19);
-        }
-        else
-        {
-            handler.ReportCount.ShouldBe(0);
-            handler.UnrelatedGetCount.ShouldBe(0);
-            handler.RequestCount.ShouldBe(11);
-        }
+        AssertConstantWorkTrace(handler);
         output.WriteLine(
-            $"exact-move-mrtr-observation implementation={mode} "
+            "exact-move-mrtr-observation implementation=server-authoritative "
             + $"destination_resources={destinationCardinality} duration_ms={elapsed.TotalMilliseconds:F3} "
             + $"requests={handler.RequestCount} propfind={handler.PropFindCount} report={handler.ReportCount} "
             + $"source_get={handler.SourceGetCount} destination_get={handler.DestinationGetCount} "
@@ -99,160 +61,60 @@ public sealed class ExactMoveMrtrWorkEvidenceTests(ITestOutputHelper output)
     [InlineData(1, "weak-etag")]
     [InlineData(50, "weak-etag")]
     [InlineData(600, "weak-etag")]
-    public async Task UnrelatedResourceShapeCannotAddChangedRevisionReads(
+    public async Task UnrelatedResourceShapeDoesNotAddRevisionReads(
         int destinationCardinality,
         string unrelatedShape)
     {
         using var handler = new ObservationHandler(destinationCardinality, unrelatedShape);
         using var httpClient = new HttpClient(handler);
         var options = OptionsForEvidence();
-        var mode = ResolveEvidenceMode(Environment.GetEnvironmentVariable("CALDAV_MOVE_EVIDENCE_MODE"));
         ICalendarService CreateService() => CreateEvidenceService(httpClient, options);
         var request = ExactMoveRequest();
 
-        var result = await ExecuteShapeScenarioAsync(
-            CreateService,
-            request,
-            mode,
-            unrelatedShape,
-            CancellationToken.None);
+        var result = await ExecuteTwoRoundMrtrAsync(CreateService, request, CancellationToken.None);
 
-        if (mode == "server-authoritative" || unrelatedShape == "opaque")
-        {
-            Property(result, "Code").ToString().ShouldBe("Success");
-            Property(result, "MutationState").ToString().ShouldBe("Committed");
-        }
-        else
-        {
-            Property(result, "Code").ToString().ShouldBe(
-                unrelatedShape == "oversized" ? "PayloadTooLarge" : "ConcurrencyUnavailable");
-            Property(result, "MutationState").ToString().ShouldBe("NotAttempted");
-        }
-        AssertShapeTrace(handler, mode, unrelatedShape, destinationCardinality);
+        result.Code.ShouldBe(CalendarExactResourceCode.Success);
+        result.MutationState.ShouldBe(CalendarMutationState.Committed);
+        AssertConstantWorkTrace(handler);
         output.WriteLine(
-            $"exact-move-mrtr-shape implementation={mode} shape={unrelatedShape} "
+            $"exact-move-mrtr-shape implementation=server-authoritative shape={unrelatedShape} "
             + $"destination_resources={destinationCardinality} requests={handler.RequestCount} "
             + $"propfind={handler.PropFindCount} report={handler.ReportCount} "
             + $"source_get={handler.SourceGetCount} destination_get={handler.DestinationGetCount} "
             + $"unrelated_get={handler.UnrelatedGetCount} move={handler.MoveCount}");
     }
 
-    [Fact]
-    public void EvidenceModeRejectsUnknownValues() => Should.Throw<ArgumentException>(() =>
-        ResolveEvidenceMode("unknown"));
-
-    private static async Task<object> ExecuteTwoRoundMrtrAsync(
+    private static async Task<CalendarExactResourceResult> ExecuteTwoRoundMrtrAsync(
         Func<ICalendarService> createService,
         CalendarExactMoveRequest request,
-        string mode,
         CancellationToken cancellationToken)
     {
-        var initialReview = await InvokeAsync(
-            createService(),
-            "ReviewExactMoveResourceAsync",
-            request,
-            cancellationToken);
-        OptionalProperty(initialReview, "Outcome").ShouldBeNull();
-
-        if (mode == "server-authoritative")
-        {
-            var binding = Property(initialReview, "Binding");
-            var digest = (ReadOnlyMemory<byte>)Property(binding, "SourceIntentDigest");
-            digest.Length.ShouldBe(SHA256.HashSizeInBytes);
-            return await InvokeAsync(
-                createService(),
-                "ExecuteConfirmedExactMoveResourceAsync",
-                request,
-                binding,
-                cancellationToken);
-        }
-
-        var initialDigest = (ReadOnlyMemory<byte>)Property(initialReview, "IntentDigest");
-        initialDigest.Length.ShouldBe(SHA256.HashSizeInBytes);
-        Property(initialReview, "BindingRevision").ShouldNotBeNull();
-        var confirmedService = createService();
-        var confirmedReview = await InvokeAsync(
-            confirmedService,
-            "ReviewExactMoveResourceAsync",
-            request,
-            cancellationToken);
-        OptionalProperty(confirmedReview, "Outcome").ShouldBeNull();
-        var confirmedDigest = (ReadOnlyMemory<byte>)Property(confirmedReview, "IntentDigest");
-        confirmedDigest.Length.ShouldBe(SHA256.HashSizeInBytes);
-        CryptographicOperations.FixedTimeEquals(initialDigest.Span, confirmedDigest.Span).ShouldBeTrue();
-        return await InvokeAsync(
-            confirmedService,
-            "ExactMoveResourceAsync",
-            request,
-            cancellationToken);
+        var initialReview = await createService().ReviewExactMoveResourceAsync(request, cancellationToken);
+        initialReview.Outcome.ShouldBeNull();
+        var binding = initialReview.Binding.ShouldNotBeNull();
+        binding.SourceIntentDigest.Length.ShouldBe(SHA256.HashSizeInBytes);
+        return await createService().ExecuteConfirmedExactMoveResourceAsync(request, binding, cancellationToken);
     }
 
-    private static async Task<object> ExecuteShapeScenarioAsync(
-        Func<ICalendarService> createService,
-        CalendarExactMoveRequest request,
-        string mode,
-        string unrelatedShape,
-        CancellationToken cancellationToken)
+    private static void AssertConstantWorkTrace(ObservationHandler handler)
     {
-        if (mode == "server-authoritative" || unrelatedShape == "opaque")
-            return await ExecuteTwoRoundMrtrAsync(createService, request, mode, cancellationToken);
-        var review = await InvokeAsync(
-            createService(),
-            "ReviewExactMoveResourceAsync",
-            request,
-            cancellationToken);
-        return Property(review, "Outcome");
+        handler.PropFindCount.ShouldBe(4);
+        handler.ReportCount.ShouldBe(0);
+        handler.SourceGetCount.ShouldBe(3);
+        handler.DestinationGetCount.ShouldBe(3);
+        handler.UnrelatedGetCount.ShouldBe(0);
+        handler.MoveCount.ShouldBe(1);
+        handler.RequestCount.ShouldBe(11);
     }
 
-    private static void AssertShapeTrace(
-        ObservationHandler handler,
-        string mode,
-        string unrelatedShape,
-        int destinationCardinality)
+    private static CalDavOptions OptionsForEvidence() => new()
     {
-        if (mode == "server-authoritative")
-        {
-            handler.PropFindCount.ShouldBe(4);
-            handler.ReportCount.ShouldBe(0);
-            handler.SourceGetCount.ShouldBe(3);
-            handler.DestinationGetCount.ShouldBe(3);
-            handler.UnrelatedGetCount.ShouldBe(0);
-            handler.MoveCount.ShouldBe(1);
-            handler.RequestCount.ShouldBe(11);
-            return;
-        }
-        if (unrelatedShape == "opaque")
-        {
-            handler.PropFindCount.ShouldBe(4);
-            handler.ReportCount.ShouldBe(6);
-            handler.SourceGetCount.ShouldBe(4);
-            handler.DestinationGetCount.ShouldBe(4);
-            handler.UnrelatedGetCount.ShouldBe(destinationCardinality * 3);
-            handler.MoveCount.ShouldBe(1);
-            handler.RequestCount.ShouldBe((destinationCardinality * 3) + 19);
-            return;
-        }
-        handler.PropFindCount.ShouldBe(2);
-        handler.ReportCount.ShouldBe(2);
-        handler.SourceGetCount.ShouldBe(1);
-        handler.DestinationGetCount.ShouldBe(1);
-        handler.UnrelatedGetCount.ShouldBe(1);
-        handler.MoveCount.ShouldBe(0);
-        handler.RequestCount.ShouldBe(7);
-    }
-
-    private static CalDavOptions OptionsForEvidence()
-    {
-        var options = new CalDavOptions
-        {
-            BaseUrl = ObservationHandler.CalendarHomeHref,
-            Username = "user",
-            Password = "secret",
-            CalendarHrefs = $"{ObservationHandler.SourceCalendarHref},{ObservationHandler.DestinationCalendarHref}"
-        };
-        options.GetType().GetProperty("InteroperabilityProfile")?.SetValue(options, "radicale-3.7.8");
-        return options;
-    }
+        BaseUrl = ObservationHandler.CalendarHomeHref,
+        Username = "user",
+        Password = "secret",
+        CalendarHrefs = $"{ObservationHandler.SourceCalendarHref},{ObservationHandler.DestinationCalendarHref}",
+        InteroperabilityProfile = "radicale-3.7.8"
+    };
 
     private static ICalendarService CreateEvidenceService(HttpClient httpClient, CalDavOptions options) =>
         new CalendarService(
@@ -272,32 +134,6 @@ public sealed class ExactMoveMrtrWorkEvidenceTests(ITestOutputHelper output)
             CalendarEntityKind.Todo,
             "\"r1\""),
         ObservationHandler.DestinationHref);
-
-    private static async Task<object> InvokeAsync(object target, string methodName, params object[] arguments)
-    {
-        var method = target.GetType().GetMethods(BindingFlags.Instance | BindingFlags.Public)
-            .SingleOrDefault(candidate => candidate.Name == methodName
-                && candidate.GetParameters().Length == arguments.Length);
-        if (method is null)
-            throw new InvalidOperationException($"{methodName} must exist for the selected evidence mode.");
-        if (method.Invoke(target, arguments) is not Task task)
-            throw new InvalidOperationException($"{methodName} must return Task.");
-        await task;
-        return Property(task, "Result");
-    }
-
-    private static object Property(object target, string propertyName) =>
-        OptionalProperty(target, propertyName).ShouldNotBeNull($"{propertyName} must be present.");
-
-    private static object? OptionalProperty(object target, string propertyName) =>
-        target.GetType().GetProperty(propertyName, BindingFlags.Instance | BindingFlags.Public)?.GetValue(target);
-
-    private static string ResolveEvidenceMode(string? configured) => configured switch
-    {
-        null or "" => "server-authoritative",
-        "legacy-scan" or "server-authoritative" => configured,
-        _ => throw new ArgumentException("CALDAV_MOVE_EVIDENCE_MODE is not recognized.", nameof(configured))
-    };
 
     private sealed class ObservationHandler : HttpMessageHandler
     {

--- a/tests/DotnetAgents.CalDav.Core.Tests.Unit/Services/SemanticMoveWorkEvidenceTests.cs
+++ b/tests/DotnetAgents.CalDav.Core.Tests.Unit/Services/SemanticMoveWorkEvidenceTests.cs
@@ -22,7 +22,7 @@ public sealed class SemanticMoveWorkEvidenceTests(ITestOutputHelper output)
     [InlineData(1)]
     [InlineData(50)]
     [InlineData(600)]
-    public async Task SameHttpCorpusObservesBaselineScanAndChangedConstantWork(int destinationCardinality)
+    public async Task MoveUsesConstantHttpWorkRegardlessOfDestinationSize(int destinationCardinality)
     {
         using var handler = new ObservationHandler(destinationCardinality);
         var options = new CalDavOptions
@@ -30,11 +30,9 @@ public sealed class SemanticMoveWorkEvidenceTests(ITestOutputHelper output)
             BaseUrl = ObservationHandler.CalendarHomeHref,
             Username = "user",
             Password = "secret",
-            CalendarHrefs = $"{ObservationHandler.SourceCalendarHref},{ObservationHandler.DestinationCalendarHref}"
+            CalendarHrefs = $"{ObservationHandler.SourceCalendarHref},{ObservationHandler.DestinationCalendarHref}",
+            InteroperabilityProfile = "radicale-3.7.8"
         };
-        var profileProperty = typeof(CalDavOptions).GetProperty("InteroperabilityProfile");
-        profileProperty?.SetValue(options, "radicale-3.7.8");
-        var evidenceMode = ResolveEvidenceMode(Environment.GetEnvironmentVariable("CALDAV_MOVE_EVIDENCE_MODE"));
         using var httpClient = new HttpClient(handler);
         var client = new CalDavClient(
             httpClient,
@@ -66,37 +64,16 @@ public sealed class SemanticMoveWorkEvidenceTests(ITestOutputHelper output)
         handler.SourceGetCount.ShouldBe(2);
         handler.DestinationGetCount.ShouldBe(2);
         handler.MoveCount.ShouldBe(1);
-        if (evidenceMode == "legacy-scan")
-        {
-            handler.ReportCount.ShouldBe(2);
-            handler.UnrelatedGetCount.ShouldBe(destinationCardinality);
-            handler.GetCount.ShouldBe(destinationCardinality + 4);
-            handler.RequestCount.ShouldBe(destinationCardinality + 9);
-        }
-        else
-        {
-            handler.ReportCount.ShouldBe(0);
-            handler.UnrelatedGetCount.ShouldBe(0);
-            handler.GetCount.ShouldBe(4);
-            handler.RequestCount.ShouldBe(7);
-        }
+        handler.ReportCount.ShouldBe(0);
+        handler.UnrelatedGetCount.ShouldBe(0);
+        handler.GetCount.ShouldBe(4);
+        handler.RequestCount.ShouldBe(7);
         output.WriteLine(
-            $"semantic-move-observation implementation={evidenceMode} "
+            "semantic-move-observation implementation=server-authoritative "
             + $"destination_resources={destinationCardinality} duration_ms={elapsed.TotalMilliseconds:F3} "
             + $"requests={handler.RequestCount} propfind={handler.PropFindCount} report={handler.ReportCount} "
             + $"get={handler.GetCount} unrelated_get={handler.UnrelatedGetCount} move={handler.MoveCount}");
     }
-
-    [Fact]
-    public void EvidenceModeRejectsUnknownValues() => Should.Throw<ArgumentException>(() =>
-        ResolveEvidenceMode("unknown"));
-
-    private static string ResolveEvidenceMode(string? configured) => configured switch
-    {
-        null or "" => "server-authoritative",
-        "legacy-scan" or "server-authoritative" => configured,
-        _ => throw new ArgumentException("CALDAV_MOVE_EVIDENCE_MODE is not recognized.", nameof(configured))
-    };
 
     private sealed class ObservationHandler : HttpMessageHandler
     {

--- a/tests/DotnetAgents.CalDav.IntegrationTests/ExactMoveMrtrRadicaleSizeEvidenceTests.cs
+++ b/tests/DotnetAgents.CalDav.IntegrationTests/ExactMoveMrtrRadicaleSizeEvidenceTests.cs
@@ -1,7 +1,6 @@
 using System.Diagnostics;
 using System.Net;
 using System.Net.Http.Headers;
-using System.Reflection;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
@@ -28,7 +27,6 @@ public sealed class ExactMoveMrtrRadicaleSizeEvidenceTests(
     [Fact]
     public async Task PinnedRadicaleObservesExactMoveMrtrWorkAtOneFiftyAndSixHundredResources()
     {
-        var mode = ResolveEvidenceMode(Environment.GetEnvironmentVariable("CALDAV_MOVE_EVIDENCE_MODE"));
         using var probe = CreateProbeClient();
         var sourceCalendar = new Uri(fixture.BaseUrl + "/conformance/exact-move-mrtr-source/", UriKind.Absolute);
         var destinationCalendar = new Uri(
@@ -81,32 +79,15 @@ public sealed class ExactMoveMrtrRadicaleSizeEvidenceTests(
                     $"{sourceCalendar.AbsoluteUri},{destinationCalendar.AbsoluteUri}",
                     wire,
                     request,
-                    mode,
                     TestContext.Current.CancellationToken);
 
                 var elapsed = Stopwatch.GetElapsedTime(started);
-                Property(result, "Code").ToString().ShouldBe("Success");
-                Property(result, "MutationState").ToString().ShouldBe("Committed");
-                var snapshot = Property(result, "Snapshot");
-                var observedContent = (ReadOnlyMemory<byte>)Property(snapshot, "AuthoritativeUtf8");
+                result.Code.ShouldBe(CalendarExactResourceCode.Success);
+                result.MutationState.ShouldBe(CalendarMutationState.Committed);
+                var snapshot = result.Snapshot.ShouldNotBeNull();
+                var observedContent = snapshot.AuthoritativeUtf8;
                 observedContent.Span.SequenceEqual(source.AuthoritativeUtf8.Span).ShouldBeTrue();
-                wire.PropFindCount.ShouldBe(10);
-                wire.SourceGetCount.ShouldBe(mode == "legacy-scan" ? 4 : 3);
-                wire.DestinationGetCount.ShouldBe(mode == "legacy-scan" ? 4 : 3);
-                wire.MoveCount.ShouldBe(1);
-                wire.MultigetCount.ShouldBe(0);
-                if (mode == "legacy-scan")
-                {
-                    wire.ReportCount.ShouldBe(6);
-                    wire.UnrelatedGetCount.ShouldBe(destinationCardinality * 3);
-                    wire.RequestCount.ShouldBe((destinationCardinality * 3) + 25);
-                }
-                else
-                {
-                    wire.ReportCount.ShouldBe(0);
-                    wire.UnrelatedGetCount.ShouldBe(0);
-                    wire.RequestCount.ShouldBe(17);
-                }
+                AssertConstantWorkTrace(wire);
                 foreach (var index in new[] { 0, destinationCardinality / 2, destinationCardinality - 1 }.Distinct())
                 {
                     var observed = await SendAsync(
@@ -116,8 +97,8 @@ public sealed class ExactMoveMrtrRadicaleSizeEvidenceTests(
                     observed.Status.ShouldBe(HttpStatusCode.OK);
                     observed.EntityTag.ShouldNotBeNull();
                 }
-                var movedHref = new Uri((string)Property(snapshot, "ResourceHref"), UriKind.Absolute);
-                var movedEntityTag = (string)Property(snapshot, "EntityTag");
+                var movedHref = new Uri(snapshot.ResourceHref, UriKind.Absolute);
+                var movedEntityTag = snapshot.EntityTag;
                 (await SendAsync(
                     probe,
                     HttpMethod.Delete,
@@ -128,7 +109,7 @@ public sealed class ExactMoveMrtrRadicaleSizeEvidenceTests(
                 {
                     Evidence = "CAL-EVIDENCE-013",
                     Operation = "exact-move-mrtr",
-                    Implementation = mode,
+                    Implementation = "server-authoritative",
                     DestinationResources = destinationCardinality,
                     DurationMilliseconds = elapsed.TotalMilliseconds,
                     Requests = wire.RequestCount,
@@ -154,8 +135,7 @@ public sealed class ExactMoveMrtrRadicaleSizeEvidenceTests(
                     probe,
                     sourceCalendar,
                     destinationCalendar,
-                    destinationCardinality,
-                    mode);
+                    destinationCardinality);
             }
         }
         finally
@@ -173,16 +153,11 @@ public sealed class ExactMoveMrtrRadicaleSizeEvidenceTests(
         }
     }
 
-    [Fact]
-    public void EvidenceModeRejectsUnknownValues() => Should.Throw<ArgumentException>(() =>
-        ResolveEvidenceMode("unknown"));
-
     private async Task ObserveOpaqueOversizedCorpusAsync(
         HttpClient probe,
         Uri sourceCalendar,
         Uri destinationCalendar,
-        int destinationCardinality,
-        string mode)
+        int destinationCardinality)
     {
         var ordinaryHref = new Uri(destinationCalendar, "unrelated-0.ics");
         var ordinary = await SendAsync(probe, HttpMethod.Get, ordinaryHref);
@@ -221,28 +196,18 @@ public sealed class ExactMoveMrtrRadicaleSizeEvidenceTests(
         string? movedEntityTag = null;
         try
         {
-            var result = await ExecuteOpaqueOversizedScenarioAsync(
+            var result = await ExecuteTwoRoundMrtrAsync(
                 fixture.BaseUrl,
                 $"{sourceCalendar.AbsoluteUri},{destinationCalendar.AbsoluteUri}",
                 wire,
                 request,
-                mode,
                 TestContext.Current.CancellationToken);
             var elapsed = Stopwatch.GetElapsedTime(started);
-            if (mode == "server-authoritative")
-            {
-                Property(result, "Code").ToString().ShouldBe("Success");
-                Property(result, "MutationState").ToString().ShouldBe("Committed");
-                movedEntityTag = (string)Property(Property(result, "Snapshot"), "EntityTag");
-                AssertChangedOpaqueOversizedTrace(wire);
-            }
-            else
-            {
-                Property(result, "Code").ToString().ShouldBe("PayloadTooLarge");
-                Property(result, "MutationState").ToString().ShouldBe("NotAttempted");
-                AssertLegacyOpaqueOversizedTrace(wire);
-            }
-            WriteOpaqueOversizedObservation(mode, destinationCardinality, elapsed, wire);
+            result.Code.ShouldBe(CalendarExactResourceCode.Success);
+            result.MutationState.ShouldBe(CalendarMutationState.Committed);
+            movedEntityTag = result.Snapshot.ShouldNotBeNull().EntityTag;
+            AssertConstantWorkTrace(wire);
+            WriteOpaqueOversizedObservation(destinationCardinality, elapsed, wire);
         }
         finally
         {
@@ -282,33 +247,6 @@ public sealed class ExactMoveMrtrRadicaleSizeEvidenceTests(
         }
     }
 
-    private static async Task<object> ExecuteOpaqueOversizedScenarioAsync(
-        string baseUrl,
-        string calendarHrefs,
-        ExactMoveTraceFilter wire,
-        CalendarExactMoveRequest request,
-        string mode,
-        CancellationToken cancellationToken)
-    {
-        await using var initialProvider = CreateProvider(baseUrl, calendarHrefs, wire);
-        var initialReview = await InvokeAsync(
-            initialProvider.GetRequiredService<ICalendarService>(),
-            "ReviewExactMoveResourceAsync",
-            request,
-            cancellationToken);
-        if (mode == "legacy-scan")
-            return Property(initialReview, "Outcome");
-        OptionalProperty(initialReview, "Outcome").ShouldBeNull();
-        await using var confirmedProvider = CreateProvider(baseUrl, calendarHrefs, wire);
-        var binding = Property(initialReview, "Binding");
-        return await InvokeAsync(
-            confirmedProvider.GetRequiredService<ICalendarService>(),
-            "ExecuteConfirmedExactMoveResourceAsync",
-            request,
-            binding,
-            cancellationToken);
-    }
-
     private static async Task AssertServerAcceptedOpaqueGrammarAsync(
         HttpClient probe,
         Uri sourceCalendar,
@@ -340,7 +278,7 @@ public sealed class ExactMoveMrtrRadicaleSizeEvidenceTests(
         }
     }
 
-    private static void AssertChangedOpaqueOversizedTrace(ExactMoveTraceFilter wire)
+    private static void AssertConstantWorkTrace(ExactMoveTraceFilter wire)
     {
         wire.PropFindCount.ShouldBe(10);
         wire.ReportCount.ShouldBe(0);
@@ -352,20 +290,7 @@ public sealed class ExactMoveMrtrRadicaleSizeEvidenceTests(
         wire.RequestCount.ShouldBe(17);
     }
 
-    private static void AssertLegacyOpaqueOversizedTrace(ExactMoveTraceFilter wire)
-    {
-        wire.PropFindCount.ShouldBe(5);
-        wire.ReportCount.ShouldBe(2);
-        wire.MultigetCount.ShouldBe(0);
-        wire.SourceGetCount.ShouldBe(1);
-        wire.DestinationGetCount.ShouldBe(1);
-        wire.UnrelatedGetCount.ShouldBe(1);
-        wire.MoveCount.ShouldBe(0);
-        wire.RequestCount.ShouldBe(10);
-    }
-
     private void WriteOpaqueOversizedObservation(
-        string mode,
         int destinationCardinality,
         TimeSpan elapsed,
         ExactMoveTraceFilter wire) => output.WriteLine(JsonSerializer.Serialize(new
@@ -373,7 +298,7 @@ public sealed class ExactMoveMrtrRadicaleSizeEvidenceTests(
             Evidence = "CAL-EVIDENCE-013",
             Operation = "exact-move-mrtr",
             Corpus = "opaque-oversized",
-            Implementation = mode,
+            Implementation = "server-authoritative",
             DestinationResources = destinationCardinality,
             DurationMilliseconds = elapsed.TotalMilliseconds,
             Requests = wire.RequestCount,
@@ -396,54 +321,23 @@ public sealed class ExactMoveMrtrRadicaleSizeEvidenceTests(
             fixture.Runtime.RuntimeTimeZone
         }));
 
-    private static async Task<object> ExecuteTwoRoundMrtrAsync(
+    private static async Task<CalendarExactResourceResult> ExecuteTwoRoundMrtrAsync(
         string baseUrl,
         string calendarHrefs,
         ExactMoveTraceFilter wire,
         CalendarExactMoveRequest request,
-        string mode,
         CancellationToken cancellationToken)
     {
         await using var initialProvider = CreateProvider(baseUrl, calendarHrefs, wire);
-        var initialReview = await InvokeAsync(
-            initialProvider.GetRequiredService<ICalendarService>(),
-            "ReviewExactMoveResourceAsync",
-            request,
-            cancellationToken);
-        OptionalProperty(initialReview, "Outcome").ShouldBeNull();
+        var initialReview = await initialProvider.GetRequiredService<ICalendarService>()
+            .ReviewExactMoveResourceAsync(request, cancellationToken);
+        initialReview.Outcome.ShouldBeNull();
+        var binding = initialReview.Binding.ShouldNotBeNull();
+        binding.SourceIntentDigest.Length.ShouldBe(SHA256.HashSizeInBytes);
 
         await using var confirmedProvider = CreateProvider(baseUrl, calendarHrefs, wire);
-        var confirmedService = confirmedProvider.GetRequiredService<ICalendarService>();
-        if (mode == "server-authoritative")
-        {
-            var binding = Property(initialReview, "Binding");
-            var digest = (ReadOnlyMemory<byte>)Property(binding, "SourceIntentDigest");
-            digest.Length.ShouldBe(SHA256.HashSizeInBytes);
-            return await InvokeAsync(
-                confirmedService,
-                "ExecuteConfirmedExactMoveResourceAsync",
-                request,
-                binding,
-                cancellationToken);
-        }
-
-        var initialDigest = (ReadOnlyMemory<byte>)Property(initialReview, "IntentDigest");
-        initialDigest.Length.ShouldBe(SHA256.HashSizeInBytes);
-        Property(initialReview, "BindingRevision").ShouldNotBeNull();
-        var confirmedReview = await InvokeAsync(
-            confirmedService,
-            "ReviewExactMoveResourceAsync",
-            request,
-            cancellationToken);
-        OptionalProperty(confirmedReview, "Outcome").ShouldBeNull();
-        var confirmedDigest = (ReadOnlyMemory<byte>)Property(confirmedReview, "IntentDigest");
-        confirmedDigest.Length.ShouldBe(SHA256.HashSizeInBytes);
-        CryptographicOperations.FixedTimeEquals(initialDigest.Span, confirmedDigest.Span).ShouldBeTrue();
-        return await InvokeAsync(
-            confirmedService,
-            "ExactMoveResourceAsync",
-            request,
-            cancellationToken);
+        return await confirmedProvider.GetRequiredService<ICalendarService>()
+            .ExecuteConfirmedExactMoveResourceAsync(request, binding, cancellationToken);
     }
 
     private static ServiceProvider CreateProvider(
@@ -459,7 +353,7 @@ public sealed class ExactMoveMrtrRadicaleSizeEvidenceTests(
             options.CalendarHrefs = calendarHrefs;
             options.Username = RadicaleConformanceFixture.Username;
             options.Password = RadicaleConformanceFixture.Password;
-            options.GetType().GetProperty("InteroperabilityProfile")?.SetValue(options, "radicale-3.7.8");
+            options.InteroperabilityProfile = "radicale-3.7.8";
         });
         services.AddSingleton<IHttpMessageHandlerBuilderFilter>(wire);
         return services.BuildServiceProvider();
@@ -564,32 +458,6 @@ public sealed class ExactMoveMrtrRadicaleSizeEvidenceTests(
         + "DTSTART:20260824T120000Z\r\nX-EVIDENCE-PADDING:"
         + new string('x', paddingLength)
         + "\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n";
-
-    private static async Task<object> InvokeAsync(object target, string methodName, params object[] arguments)
-    {
-        var method = target.GetType().GetMethods(BindingFlags.Instance | BindingFlags.Public)
-            .SingleOrDefault(candidate => candidate.Name == methodName
-                && candidate.GetParameters().Length == arguments.Length);
-        if (method is null)
-            throw new InvalidOperationException($"{methodName} must exist for the selected evidence mode.");
-        if (method.Invoke(target, arguments) is not Task task)
-            throw new InvalidOperationException($"{methodName} must return Task.");
-        await task;
-        return Property(task, "Result");
-    }
-
-    private static object Property(object target, string propertyName) =>
-        OptionalProperty(target, propertyName).ShouldNotBeNull($"{propertyName} must be present.");
-
-    private static object? OptionalProperty(object target, string propertyName) =>
-        target.GetType().GetProperty(propertyName, BindingFlags.Instance | BindingFlags.Public)?.GetValue(target);
-
-    private static string ResolveEvidenceMode(string? configured) => configured switch
-    {
-        null or "" => "server-authoritative",
-        "legacy-scan" or "server-authoritative" => configured,
-        _ => throw new ArgumentException("CALDAV_MOVE_EVIDENCE_MODE is not recognized.", nameof(configured))
-    };
 
     private sealed record SeededResource(Uri Href, string EntityTag, ReadOnlyMemory<byte> AuthoritativeUtf8);
 

--- a/tests/DotnetAgents.CalDav.IntegrationTests/SemanticMoveRadicaleSizeEvidenceTests.cs
+++ b/tests/DotnetAgents.CalDav.IntegrationTests/SemanticMoveRadicaleSizeEvidenceTests.cs
@@ -81,24 +81,14 @@ public sealed class SemanticMoveRadicaleSizeEvidenceTests(
                 var elapsed = Stopwatch.GetElapsedTime(started);
                 result.Code.ShouldBe(CalendarResourceMoveCode.Success);
                 result.MutationState.ShouldBe(CalendarMutationState.Committed);
-                var mode = ResolveEvidenceMode(Environment.GetEnvironmentVariable("CALDAV_MOVE_EVIDENCE_MODE"));
                 wire.PropFindCount.ShouldBe(5);
                 wire.SourceGetCount.ShouldBe(2);
                 wire.DestinationGetCount.ShouldBe(2);
                 wire.MoveCount.ShouldBe(1);
                 wire.MultigetCount.ShouldBe(0);
-                if (mode == "legacy-scan")
-                {
-                    wire.ReportCount.ShouldBe(2);
-                    wire.UnrelatedGetCount.ShouldBe(destinationCardinality);
-                    wire.RequestCount.ShouldBe(destinationCardinality + 12);
-                }
-                else
-                {
-                    wire.ReportCount.ShouldBe(0);
-                    wire.UnrelatedGetCount.ShouldBe(0);
-                    wire.RequestCount.ShouldBe(10);
-                }
+                wire.ReportCount.ShouldBe(0);
+                wire.UnrelatedGetCount.ShouldBe(0);
+                wire.RequestCount.ShouldBe(10);
                 foreach (var index in new[] { 0, destinationCardinality / 2, destinationCardinality - 1 }.Distinct())
                 {
                     var observed = await SendAsync(
@@ -118,7 +108,7 @@ public sealed class SemanticMoveRadicaleSizeEvidenceTests(
                 output.WriteLine(JsonSerializer.Serialize(new
                 {
                     Evidence = "CAL-EVIDENCE-013",
-                    Implementation = mode,
+                    Implementation = "server-authoritative",
                     DestinationResources = destinationCardinality,
                     DurationMilliseconds = elapsed.TotalMilliseconds,
                     Requests = wire.RequestCount,
@@ -170,7 +160,7 @@ public sealed class SemanticMoveRadicaleSizeEvidenceTests(
             options.CalendarHrefs = calendarHrefs;
             options.Username = RadicaleConformanceFixture.Username;
             options.Password = RadicaleConformanceFixture.Password;
-            options.GetType().GetProperty("InteroperabilityProfile")?.SetValue(options, "radicale-3.7.8");
+            options.InteroperabilityProfile = "radicale-3.7.8";
         });
         services.AddSingleton<IHttpMessageHandlerBuilderFilter>(wire);
         return services.BuildServiceProvider();
@@ -270,13 +260,6 @@ public sealed class SemanticMoveRadicaleSizeEvidenceTests(
         $"BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Move Evidence//EN\r\nBEGIN:VTODO\r\n"
         + $"UID:unrelated-{index}\r\nDTSTAMP:20260823T120000Z\r\nSUMMARY:unrelated {index}\r\n"
         + $"X-PRIVATE-{index}:opaque-value-{index}\r\nEND:VTODO\r\nEND:VCALENDAR\r\n";
-
-    private static string ResolveEvidenceMode(string? configured) => configured switch
-    {
-        null or "" => "server-authoritative",
-        "legacy-scan" or "server-authoritative" => configured,
-        _ => throw new ArgumentException("CALDAV_MOVE_EVIDENCE_MODE is not recognized.", nameof(configured))
-    };
 
     private sealed record SeededResource(Uri Href, string EntityTag);
 


### PR DESCRIPTION
The MOVE regression tests still supported a legacy-scan mode for replaying an old implementation, including reflection wrappers for APIs that no longer exist and three tests of the mode parser itself. Replace those paths with direct calls to the current typed API and unconditional current protocol assertions.

Keep the 1/50/600-resource scenarios, oversized and malformed resources, weak ETags, authoritative bytes, confirmation bindings, and constant HTTP work checks. Historical reports retain their pinned revision reproduction instructions.

Validation on the combined audit checkout: Release build (zero warnings), full scripts/run-test-suite.sh (3,569 passed, zero skipped; baseline, strict-preconditions and alternate-time-zone Radicale), 94.5% line / 86.0% branch coverage, and Slopwatch (zero findings). This PR contains only this topic and targets main.
