### PR TITLE
refactor: simplify operation-local discovery memoization

### DIFF
--- a/src/DotnetAgents.CalDav.Core/DependencyInjection/CalDavServiceCollectionExtensions.cs
+++ b/src/DotnetAgents.CalDav.Core/DependencyInjection/CalDavServiceCollectionExtensions.cs
@@ -145,7 +145,6 @@ public static class CalDavServiceCollectionExtensions
             var policy = serviceProvider.GetRequiredService<CalendarDiscoveryPolicy>();
             return new CalendarOperationDiscovery(
                 new CalendarClientDiscoveryTransport(serviceProvider.GetRequiredService<ICalendarClient>()),
-                serviceProvider.GetRequiredService<IOptions<CalDavOptions>>(),
                 policy.ApplyScope,
                 policy.ResolveDefault);
         });

--- a/src/DotnetAgents.CalDav.Core/Internal/CalendarOperationDiscovery.cs
+++ b/src/DotnetAgents.CalDav.Core/Internal/CalendarOperationDiscovery.cs
@@ -1,9 +1,6 @@
-using System.Collections.Concurrent;
 using System.Collections.Immutable;
 using DotnetAgents.CalDav.Core.Abstractions;
-using DotnetAgents.CalDav.Core.Configuration;
 using DotnetAgents.CalDav.Core.Models;
-using Microsoft.Extensions.Options;
 
 namespace DotnetAgents.CalDav.Core.Internal;
 
@@ -20,19 +17,17 @@ internal sealed class CalendarClientDiscoveryTransport(ICalendarClient client) :
         client.GetCalendarsAsync(cancellationToken);
 }
 
-/// <summary>Coordinates one immutable CalDAV discovery acquisition per authorization-bound key and operation.</summary>
+/// <summary>Coordinates one immutable CalDAV discovery acquisition per operation.</summary>
 internal sealed class CalendarOperationDiscovery
 {
     private readonly ICalendarDiscoveryTransport _transport;
     private readonly Func<IReadOnlyList<CalendarDescriptor>, CalendarDiscoveryResult> _applyScope;
     private readonly Func<CalendarEntityKind, IReadOnlyList<CalendarDescriptor>, IReadOnlyList<CalendarDescriptor>, CalendarSelectionResult>
         _resolveDefault;
-    private readonly CalendarDiscoveryKey _key;
-    private readonly ConcurrentDictionary<CalendarDiscoveryKey, Lazy<Task<CalendarOperationDiscoveryResult>>> _results = new();
+    private Lazy<Task<CalendarOperationDiscoveryResult>>? _acquisition;
 
     public CalendarOperationDiscovery(
         ICalendarDiscoveryTransport transport,
-        IOptions<CalDavOptions> options,
         Func<IReadOnlyList<CalendarDescriptor>, CalendarDiscoveryResult> applyScope,
         Func<CalendarEntityKind, IReadOnlyList<CalendarDescriptor>, IReadOnlyList<CalendarDescriptor>, CalendarSelectionResult>
             resolveDefault)
@@ -40,14 +35,16 @@ internal sealed class CalendarOperationDiscovery
         _transport = transport;
         _applyScope = applyScope;
         _resolveDefault = resolveDefault;
-        _key = CalendarDiscoveryKey.Create(options.Value, CalendarOperationContextGeneration.Create());
     }
 
     public Task<CalendarOperationDiscoveryResult> DiscoverAsync(CancellationToken cancellationToken) =>
-        GetResultAsync(cancellationToken);
+        LazyInitializer.EnsureInitialized(
+            ref _acquisition,
+            () => new Lazy<Task<CalendarOperationDiscoveryResult>>(
+                () => AcquireAsync(cancellationToken),
+                LazyThreadSafetyMode.ExecutionAndPublication)).Value;
 
     private async Task<CalendarOperationDiscoveryResult> AcquireAsync(
-        CalendarDiscoveryKey key,
         CancellationToken cancellationToken)
     {
         var calendars = await _transport.DiscoverAsync(cancellationToken).ConfigureAwait(false);
@@ -57,20 +54,9 @@ internal sealed class CalendarOperationDiscovery
             frozenItems,
             scoped.Diagnostics.ToImmutableArray());
         return new CalendarOperationDiscoveryResult(
-            key,
             frozenDiscovery,
             FreezeSelection(_resolveDefault(CalendarEntityKind.Event, calendars, frozenItems)),
             FreezeSelection(_resolveDefault(CalendarEntityKind.Todo, calendars, frozenItems)));
-    }
-
-    private Task<CalendarOperationDiscoveryResult> GetResultAsync(CancellationToken cancellationToken)
-    {
-        var acquisition = _results.GetOrAdd(
-            _key,
-            key => new Lazy<Task<CalendarOperationDiscoveryResult>>(
-                () => AcquireAsync(key, cancellationToken),
-                LazyThreadSafetyMode.ExecutionAndPublication));
-        return acquisition.Value;
     }
 
     private static CalendarDescriptor Freeze(CalendarDescriptor calendar) => calendar with
@@ -89,7 +75,6 @@ internal sealed class CalendarOperationDiscovery
 }
 
 internal sealed record CalendarOperationDiscoveryResult(
-    CalendarDiscoveryKey Key,
     CalendarDiscoveryResult Discovery,
     CalendarSelectionResult EventDefault,
     CalendarSelectionResult TodoDefault)
@@ -100,45 +85,4 @@ internal sealed record CalendarOperationDiscoveryResult(
         CalendarEntityKind.Todo => TodoDefault,
         _ => CalendarSelectionResult.Failure(CalendarSelectionCode.NotFound)
     };
-}
-
-internal readonly record struct CalendarDiscoveryKey(
-    string Origin,
-    string PrincipalIdentity,
-    CalendarOperationContextGeneration OperationContextGeneration,
-    string DiscoveryEndpoint,
-    string CalendarScope,
-    string DefaultEventCalendarName,
-    string DefaultTodoCalendarName,
-    long RequestTimeoutTicks)
-{
-    public static CalendarDiscoveryKey Create(
-        CalDavOptions options,
-        CalendarOperationContextGeneration operationContextGeneration)
-    {
-        var endpoint = new Uri(options.BaseUrl, UriKind.Absolute);
-        var origin = endpoint.GetLeftPart(UriPartial.Authority);
-        var scope = string.Join(',', (options.CalendarHrefs ?? string.Empty)
-            .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
-            .Distinct(StringComparer.Ordinal)
-            .Order(StringComparer.Ordinal));
-        return new CalendarDiscoveryKey(
-            origin,
-            options.Username,
-            operationContextGeneration,
-            endpoint.AbsoluteUri,
-            scope,
-            options.DefaultEventCalendarName?.Trim() ?? string.Empty,
-            options.DefaultTodoCalendarName?.Trim() ?? string.Empty,
-            options.RequestTimeout.Ticks);
-    }
-}
-
-internal sealed class CalendarOperationContextGeneration
-{
-    private CalendarOperationContextGeneration()
-    {
-    }
-
-    public static CalendarOperationContextGeneration Create() => new();
 }

--- a/src/DotnetAgents.CalDav.Core/Services/CalendarQueryAcquisitionExecutor.cs
+++ b/src/DotnetAgents.CalDav.Core/Services/CalendarQueryAcquisitionExecutor.cs
@@ -236,7 +236,6 @@ internal sealed class CalendarQueryAcquisitionExecutor(
         var frozen = items.OrderBy(calendar => calendar.Href, StringComparer.Ordinal).Select(Freeze).ToArray();
         var byHref = frozen.ToDictionary(calendar => calendar.Href, StringComparer.Ordinal);
         return new CalendarOperationDiscoveryResult(
-            discovery.Key,
             new CalendarDiscoveryResult(
                 frozen,
                 discovery.Discovery.Diagnostics.Select(FreezeDiagnostic).ToArray()),

--- a/src/DotnetAgents.CalDav.Core/Services/CalendarService.cs
+++ b/src/DotnetAgents.CalDav.Core/Services/CalendarService.cs
@@ -41,7 +41,6 @@ internal sealed class CalendarService : ICalendarService
         _discoveryPolicy = new CalendarDiscoveryPolicy(options, logger);
         _operationDiscovery = new CalendarOperationDiscovery(
             new CalendarClientDiscoveryTransport(calendarClient),
-            options,
             _discoveryPolicy.ApplyScope,
             _discoveryPolicy.ResolveDefault);
         _calendarClient = calendarClient;
@@ -266,7 +265,6 @@ internal sealed class CalendarService : ICalendarService
         new CalendarMoveAuthorization(
             new CalendarOperationDiscovery(
                 new CalendarClientDiscoveryTransport(_calendarClient),
-                _options,
                 _discoveryPolicy.ApplyScope,
                 _discoveryPolicy.ResolveDefault),
             _options.Value),

--- a/tests/DotnetAgents.CalDav.Core.Tests.Unit/Internal/CalendarMoveAuthorizationTests.cs
+++ b/tests/DotnetAgents.CalDav.Core.Tests.Unit/Internal/CalendarMoveAuthorizationTests.cs
@@ -377,7 +377,6 @@ public sealed class CalendarMoveAuthorizationTests
         var transport = new FixedDiscoveryTransport(calendars);
         var discovery = new CalendarOperationDiscovery(
             transport,
-            Microsoft.Extensions.Options.Options.Create(options),
             discovered => new CalendarDiscoveryResult(discovered, []),
             (kind, _, _) => kind == CalendarEntityKind.Todo
                 ? todoDefault

--- a/tests/DotnetAgents.CalDav.Core.Tests.Unit/Internal/CalendarOperationDiscoveryResultFactory.cs
+++ b/tests/DotnetAgents.CalDav.Core.Tests.Unit/Internal/CalendarOperationDiscoveryResultFactory.cs
@@ -1,4 +1,3 @@
-using DotnetAgents.CalDav.Core.Configuration;
 using DotnetAgents.CalDav.Core.Internal;
 using DotnetAgents.CalDav.Core.Models;
 
@@ -10,13 +9,6 @@ internal static class CalendarOperationDiscoveryResultFactory
         CalendarDiscoveryResult discovery,
         CalendarSelectionResult eventDefault,
         CalendarSelectionResult todoDefault) => new(
-            CalendarDiscoveryKey.Create(
-                new CalDavOptions
-                {
-                    BaseUrl = "https://cal.example/",
-                    Username = "scripted-principal"
-                },
-                CalendarOperationContextGeneration.Create()),
             discovery,
             eventDefault,
             todoDefault);

--- a/tests/DotnetAgents.CalDav.Core.Tests.Unit/Internal/CalendarOperationDiscoveryTests.cs
+++ b/tests/DotnetAgents.CalDav.Core.Tests.Unit/Internal/CalendarOperationDiscoveryTests.cs
@@ -1,7 +1,5 @@
-using DotnetAgents.CalDav.Core.Configuration;
 using DotnetAgents.CalDav.Core.Internal;
 using DotnetAgents.CalDav.Core.Models;
-using Microsoft.Extensions.Options;
 using NSubstitute;
 using Shouldly;
 using Xunit;
@@ -21,11 +19,6 @@ public sealed class CalendarOperationDiscoveryTests
         ]);
         var sut = new CalendarOperationDiscovery(
             transport,
-            Options.Create(new CalDavOptions
-            {
-                BaseUrl = "https://cal.example/",
-                Username = "principal"
-            }),
             calendars => new CalendarDiscoveryResult(calendars, []),
             static (kind, discovered, authorized) => CalendarSelectionResult.Success(
                 authorized.Single(calendar => kind == CalendarEntityKind.Event

--- a/tests/DotnetAgents.CalDav.Core.Tests.Unit/Services/CalendarMoveModuleTests.cs
+++ b/tests/DotnetAgents.CalDav.Core.Tests.Unit/Services/CalendarMoveModuleTests.cs
@@ -602,7 +602,6 @@ public sealed class CalendarMoveModuleTests
         };
         var operationDiscovery = new CalendarOperationDiscovery(
             new ScriptedDiscoveryTransport(transport),
-            Microsoft.Extensions.Options.Options.Create(options),
             _ => transport.Discovery.Discovery,
             (kind, _, _) => transport.Discovery.Default(kind));
         return new CalendarMoveModule(

--- a/tests/DotnetAgents.CalDav.Core.Tests.Unit/Services/CalendarServiceTests.cs
+++ b/tests/DotnetAgents.CalDav.Core.Tests.Unit/Services/CalendarServiceTests.cs
@@ -27,16 +27,23 @@ public sealed class CalendarServiceTests
         client.GetCalendarsAsync(Arg.Any<CancellationToken>()).Returns(acquisition.Task);
         var sut = Discovery(client);
 
-        var first = sut.DiscoverAsync(CancellationToken.None);
-        var second = sut.DiscoverAsync(CancellationToken.None);
+        var start = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var consumers = Enumerable.Range(0, 16).Select(_ => Task.Run(async () =>
+        {
+            await start.Task;
+            return await sut.DiscoverAsync(CancellationToken.None);
+        })).ToArray();
+        start.SetResult();
         acquisition.SetResult([EntityCalendar(
             "https://cal.example/events/",
             "Events",
             EntityKindSupport.Advertised,
             EntityKindSupport.NotAdvertised)]);
 
-        (await first).Discovery.Items.ShouldHaveSingleItem();
-        (await second).Discovery.Items.ShouldHaveSingleItem();
+        var results = await Task.WhenAll(consumers);
+        results[0].Discovery.Items.ShouldHaveSingleItem();
+        foreach (var result in results)
+            result.ShouldBeSameAs(results[0]);
         await client.Received(1).GetCalendarsAsync(Arg.Any<CancellationToken>());
     }
 
@@ -84,7 +91,7 @@ public sealed class CalendarServiceTests
     }
 
     [Fact]
-    public async Task DiscoverAsync_LaterSameKeyTokenDoesNotOverrideTheOperationToken()
+    public async Task DiscoverAsync_LaterConsumerTokenDoesNotOverrideTheOperationToken()
     {
         var client = Substitute.For<ICalendarClient>();
         var acquisition = new TaskCompletionSource<IReadOnlyList<CalendarDescriptor>>(
@@ -109,7 +116,7 @@ public sealed class CalendarServiceTests
     }
 
     [Fact]
-    public async Task DiscoverAsync_OperationCancellationIsTheSharedSameKeyOutcome()
+    public async Task DiscoverAsync_OperationCancellationIsTheSharedOutcome()
     {
         var client = Substitute.For<ICalendarClient>();
         var acquisition = new TaskCompletionSource<IReadOnlyList<CalendarDescriptor>>(
@@ -198,7 +205,7 @@ public sealed class CalendarServiceTests
     }
 
     [Fact]
-    public async Task GetCalendarsAsync_OperationContextIsOpaqueAndIsolatesCredentialRotation()
+    public async Task GetCalendarsAsync_SeparateOperationsRediscoverAfterCredentialRotation()
     {
         var client = Substitute.For<ICalendarClient>();
         client.GetCalendarsAsync(Arg.Any<CancellationToken>()).Returns([]);
@@ -220,71 +227,10 @@ public sealed class CalendarServiceTests
             CalendarHrefs = firstContext.CalendarHrefs,
             DefaultEventCalendarName = firstContext.DefaultEventCalendarName
         };
-        var firstGeneration = CalendarOperationContextGeneration.Create();
-        var secondGeneration = CalendarOperationContextGeneration.Create();
-
-        var firstKey = CalendarDiscoveryKey.Create(firstContext, firstGeneration);
-        var secondKey = CalendarDiscoveryKey.Create(secondContext, secondGeneration);
         await Service(client, Options.Create(firstContext)).GetCalendarsAsync(CancellationToken.None);
         await Service(client, Options.Create(secondContext)).GetCalendarsAsync(CancellationToken.None);
 
-        firstKey.ShouldNotBe(secondKey);
-        firstKey.ToString().ShouldNotContain(firstCredential);
-        secondKey.ToString().ShouldNotContain(secondCredential);
         await client.Received(2).GetCalendarsAsync(Arg.Any<CancellationToken>());
-    }
-
-    [Theory]
-    [InlineData("principal")]
-    [InlineData("origin")]
-    [InlineData("endpoint")]
-    [InlineData("scope")]
-    [InlineData("event-default")]
-    [InlineData("todo-default")]
-    [InlineData("timeout")]
-    public void CalendarDiscoveryKey_RelevantConfigurationChangesAreDistinct(string change)
-    {
-        var context = new CalDavOptions
-        {
-            BaseUrl = "https://cal.example/server/",
-            Username = "principal-a",
-            Password = "private-password",
-            CalendarHrefs = "https://cal.example/a/",
-            DefaultEventCalendarName = "Events",
-            DefaultTodoCalendarName = "Tasks",
-            RequestTimeout = TimeSpan.FromSeconds(30)
-        };
-        var generation = CalendarOperationContextGeneration.Create();
-        var baseline = CalendarDiscoveryKey.Create(context, generation);
-
-        switch (change)
-        {
-            case "principal":
-                context.Username = "principal-b";
-                break;
-            case "origin":
-                context.BaseUrl = "https://other.example/server/";
-                break;
-            case "endpoint":
-                context.BaseUrl = "https://cal.example/other/";
-                break;
-            case "scope":
-                context.CalendarHrefs = "https://cal.example/b/";
-                break;
-            case "event-default":
-                context.DefaultEventCalendarName = "Archive";
-                break;
-            case "todo-default":
-                context.DefaultTodoCalendarName = "Backlog";
-                break;
-            case "timeout":
-                context.RequestTimeout = TimeSpan.FromSeconds(15);
-                break;
-            default:
-                throw new ArgumentOutOfRangeException(nameof(change), change, null);
-        }
-
-        CalendarDiscoveryKey.Create(context, generation).ShouldNotBe(baseline);
     }
 
     [Fact]
@@ -754,7 +700,6 @@ public sealed class CalendarServiceTests
         var policy = new CalendarDiscoveryPolicy(configured, Substitute.For<ILogger<CalendarService>>());
         return new CalendarOperationDiscovery(
             new CalendarClientDiscoveryTransport(client),
-            configured,
             policy.ApplyScope,
             policy.ResolveDefault);
     }


### PR DESCRIPTION
Each CalendarOperationDiscovery instance stored a ConcurrentDictionary that could only receive its own readonly key. The key carried configuration and an opaque generation token, but no production decision inspected it. Replace the dictionary with one thread-safe lazy acquisition and remove the key, generation type, forwarding method, and options argument used only to construct the key.

Keep operation-local isolation, memoized failures, the first caller cancellation token, and immutable discovery results. Strengthen the concurrency test with 16 consumers and retain cancellation, fresh-operation discovery, scope and MOVE authorization tests. Remove key-equality tests tied to the deleted bookkeeping.

Validation on the combined audit checkout: Release build (zero warnings), full scripts/run-test-suite.sh (3,569 passed, zero skipped; baseline, strict-preconditions and alternate-time-zone Radicale), 94.5% line / 86.0% branch coverage, and Slopwatch (zero findings). This PR contains only this topic and targets main.
