### PR TITLE
fix: handle comments and aliases in test trait policy

### DIFF
--- a/scripts/test-test-artifacts.sh
+++ b/scripts/test-test-artifacts.sh
@@ -413,6 +413,11 @@ policy_ok="$fixture_root/policy-ok"
 mkdir -p -- "$policy_ok/bin" "$policy_ok/obj"
 printf '%s\n' '// [Fact(Skip = "comment")]' 'var text = "Flaky Assert.Skip()";' 'var raw = """[Theory(SkipWhen = true)]""";' '[Fact] public void Passes() { }' > "$policy_ok/Ok.cs"
 printf '%s\n' '[Fact(Skip = "ignored output")]' > "$policy_ok/bin/Ignored.cs"
+printf '%s\n' \
+  'using Category = Xunit.TraitAttribute;' \
+  '[Trait("Category", "Unit" /* "Flaky" */)] [Fact] public void A() {}' \
+  '[Category("Category", "Unit" /* "Quarantined" */)] [Fact] public void B() {}' \
+  > "$policy_ok/Traits.cs"
 python3 "$source_policy" "$policy_ok"
 echo "PASS source policy ignores comments, literals, bin, and obj"
 
@@ -439,6 +444,9 @@ declare -a disabled_sources=(
   $'[Trait("Category", "Flaky")] [Fact] public void A() {}'
   $'[global::Xunit.TraitAttribute("Category", "Quarantined")] [Fact] public void A() {}'
   $'[Fact, Trait("Category", "Flaky")] public void A() {}'
+  $'using Category = Xunit.TraitAttribute; [Category("Category", "Flaky")] [Fact] public void A() {}'
+  $'using Category = global::Xunit.TraitAttribute; [Fact, Category("Category", "Quarantined")] public void A() {}'
+  $'using CategoryAttribute = Xunit.TraitAttribute; [Category("Category", "Flaky")] [Fact] public void A() {}'
   $'sealed class ConditionalFactAttribute : Xunit.FactAttribute { public ConditionalFactAttribute() { Skip = "reason"; } } [ConditionalFact] public void A() {}'
   $'using BaseFact = Xunit.FactAttribute; sealed class ConditionalFactAttribute : BaseFact { } [ConditionalFact] public void A() {}'
   $'[Fact] public void Quarantined_case() {}'

--- a/scripts/verify-test-source-policy.py
+++ b/scripts/verify-test-source-policy.py
@@ -19,14 +19,13 @@ DISABLING_OPTION = re.compile(
     r"\b(?:Skip|SkipWhen|SkipUnless|SkipExceptions|SkipTestWithoutData|Explicit)\s*=",
     re.DOTALL,
 )
-RUNTIME_SKIP = re.compile(r"\bAssert\s*\.\s*Skip\s*\(", re.DOTALL)
 NON_NORMATIVE = re.compile(r"\b(?:Quarantin(?:e|ed)|Flaky)", re.IGNORECASE)
 EXPLICIT_ATTRIBUTE = re.compile(
     r"\[\s*(?:global::)?(?:[A-Za-z_][\w]*\.)*Explicit(?:Attribute)?\s*(?:\([^]]*\))?\s*\]",
     re.DOTALL,
 )
-TRAIT_ATTRIBUTE = re.compile(
-    r"(?:^\[\s*|,\s*)(?:global::)?(?:[A-Za-z_][\w]*\.)*Trait(?:Attribute)?\s*\(",
+ATTRIBUTE_CALL = re.compile(
+    r"(?:^\[\s*|,\s*)(?:global::)?(?:[A-Za-z_][\w]*\.)*(?P<name>[A-Za-z_]\w*)\s*\(",
     re.DOTALL,
 )
 TRAIT_NON_NORMATIVE = re.compile(
@@ -124,13 +123,22 @@ def mask_comments_and_literals(source: str, *, mask_literals: bool) -> str:
 def violations(path: pathlib.Path) -> list[str]:
     source = path.read_text(encoding="utf-8")
     code = mask_comments_and_literals(source, mask_literals=True)
-    spans = [(code[start:end], source[start:end]) for start, end in attribute_ranges(code)]
+    uncommented = mask_comments_and_literals(source, mask_literals=False)
+    spans = [(code[start:end], uncommented[start:end]) for start, end in attribute_ranges(code)]
     found: list[str] = []
     if any(DISABLING_OPTION.search(masked) for masked, _ in spans):
         found.append("disabled test attribute option")
+    trait_aliases = re.findall(
+        r"\busing\s+([A-Za-z_]\w*)\s*=\s*(?:global::)?Xunit\.TraitAttribute\s*;",
+        code,
+    )
+    trait_names = {"Trait", "TraitAttribute", *trait_aliases}
+    trait_names.update(alias.removesuffix("Attribute") for alias in trait_aliases)
     trait_is_non_normative = False
     for masked, original in spans:
-        for match in TRAIT_ATTRIBUTE.finditer(masked):
+        for match in ATTRIBUTE_CALL.finditer(masked):
+            if match.group("name") not in trait_names:
+                continue
             closing = masked.find(")", match.end())
             closing = len(masked) if closing < 0 else closing + 1
             if TRAIT_NON_NORMATIVE.search(original[match.start():closing]):


### PR DESCRIPTION
The source-policy gate rejected a normal Unit trait if its comment mentioned "Flaky", while a local alias for Xunit.TraitAttribute could hide an actual Flaky or Quarantined trait. Inspect comment-masked literals and resolve same-file Trait aliases, matching the existing Assert/Fact alias handling. Remove the unused runtime-skip regex.

Regression cases cover harmless comments, aliases, global:: qualification, and Attribute suffix shorthand. This remains a lexical same-file check; runtime test-result validation also applies.

Validation: complete artifact/source-policy regression suite, repository test-source scan, shell syntax, and git diff --check.
