### PR TITLE
build: remove unused test dependencies and coverage tool

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -15,13 +15,6 @@
         "reportgenerator"
       ],
       "rollForward": false
-    },
-    "dotnet-coverage": {
-      "version": "18.6.2",
-      "commands": [
-        "dotnet-coverage"
-      ],
-      "rollForward": false
     }
   }
 }

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,8 +6,6 @@
   <PropertyGroup Label="SharedVersions">
     <McpSdkVersion>2.2.0</McpSdkVersion>
     <IcalNetVersion>5.2.3</IcalNetVersion>
-    <AutoFixtureVersion>5.0.0-rc.1</AutoFixtureVersion>
-    <TestContainersVersion>4.11.0</TestContainersVersion>
     <MicrosoftExtensionsVersion>10.0.11</MicrosoftExtensionsVersion>
   </PropertyGroup>
   <!-- MCP SDK -->
@@ -17,7 +15,6 @@
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.18.0" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.18.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.18.0" />
-    <PackageVersion Include="SSH.NET" Version="2026.0.0" />
   </ItemGroup>
   <!-- Core Dependencies -->
   <ItemGroup Label="Core">
@@ -25,7 +22,6 @@
     <PackageVersion Include="Microsoft.Extensions.Http" Version="$(MicrosoftExtensionsVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.9.0" />
     <PackageVersion Include="Microsoft.Extensions.Options" Version="$(MicrosoftExtensionsVersion)" />
-    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="$(MicrosoftExtensionsVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftExtensionsVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="$(MicrosoftExtensionsVersion)" />
   </ItemGroup>
@@ -41,12 +37,7 @@
     <PackageVersion Include="xunit.v3" Version="4.0.0" />
     <PackageVersion Include="NSubstitute" Version="6.2.0" />
     <PackageVersion Include="NSubstitute.Analyzers.CSharp" Version="1.0.17" />
-    <PackageVersion Include="AutoFixture" Version="$(AutoFixtureVersion)" />
-    <PackageVersion Include="AutoFixture.AutoNSubstitute" Version="$(AutoFixtureVersion)" />
     <PackageVersion Include="Shouldly" Version="4.3.0" />
-    <PackageVersion Include="Verify.XunitV3" Version="31.28.0" />
-    <PackageVersion Include="RichardSzalay.MockHttp" Version="7.1.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="$(MicrosoftExtensionsVersion)" />
   </ItemGroup>
   <!-- Integration Testing -->
   <ItemGroup Label="Integration Testing">

--- a/tests/DotnetAgents.CalDav.Core.Tests.Unit/DotnetAgents.CalDav.Core.Tests.Unit.csproj
+++ b/tests/DotnetAgents.CalDav.Core.Tests.Unit/DotnetAgents.CalDav.Core.Tests.Unit.csproj
@@ -14,8 +14,6 @@
     <PackageReference Include="xunit.v3" />
     <PackageReference Include="NSubstitute" />
     <PackageReference Include="NSubstitute.Analyzers.CSharp" />
-    <PackageReference Include="AutoFixture" />
-    <PackageReference Include="AutoFixture.AutoNSubstitute" />
     <PackageReference Include="Shouldly" />
   </ItemGroup>
 

--- a/tests/DotnetAgents.CalDav.IntegrationTests/DotnetAgents.CalDav.IntegrationTests.csproj
+++ b/tests/DotnetAgents.CalDav.IntegrationTests/DotnetAgents.CalDav.IntegrationTests.csproj
@@ -11,14 +11,10 @@
   <ItemGroup>
     <PackageReference Include="coverlet.MTP" />
     <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" />
-    <PackageReference Include="SSH.NET" />
     <PackageReference Include="xunit.v3" />
     <PackageReference Include="NSubstitute" />
     <PackageReference Include="NSubstitute.Analyzers.CSharp" />
-    <PackageReference Include="AutoFixture" />
-    <PackageReference Include="AutoFixture.AutoNSubstitute" />
     <PackageReference Include="Shouldly" />
-    <PackageReference Include="RichardSzalay.MockHttp" />
     <PackageReference Include="Testcontainers" />
     <PackageReference Include="Microsoft.Extensions.Logging" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" />

--- a/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/DotnetAgents.CalDav.Mcp.Tests.Unit.csproj
+++ b/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/DotnetAgents.CalDav.Mcp.Tests.Unit.csproj
@@ -15,8 +15,6 @@
     <PackageReference Include="xunit.v3" />
     <PackageReference Include="NSubstitute" />
     <PackageReference Include="NSubstitute.Analyzers.CSharp" />
-    <PackageReference Include="AutoFixture" />
-    <PackageReference Include="AutoFixture.AutoNSubstitute" />
     <PackageReference Include="Shouldly" />
     <PackageReference Include="Microsoft.Extensions.Hosting" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" />


### PR DESCRIPTION
Remove unused AutoFixture, AutoFixture.AutoNSubstitute, SSH.NET, and MockHttp references from the test projects. Remove their central versions, other unreferenced central entries, stale version variables, and the unused dotnet-coverage tool. The suite uses Coverlet and ReportGenerator for coverage.

Validation: local tool/package restore, Release build with zero warnings, all 2,413 Core and 1,023 MCP unit tests, and Slopwatch pass. The full CI suite continues to enforce integration, conformance, and coverage gates.
