### PR TITLE
test: remove private layout and migration assertions

### DIFF
--- a/tests/DotnetAgents.CalDav.Core.Tests.Unit/Internal/CalDavClientTests.cs
+++ b/tests/DotnetAgents.CalDav.Core.Tests.Unit/Internal/CalDavClientTests.cs
@@ -1855,20 +1855,6 @@ public class CalDavClientTests
     }
 
     [Fact]
-    public void MovePresenceTransport_HasNoUnscopedProductionSeam()
-    {
-        typeof(CalDavClient).Assembly.GetType(
-                "DotnetAgents.CalDav.Core.Internal.ICalendarResourcePresenceTransport")
-            .ShouldBeNull();
-        typeof(CalDavClient).GetMethod(
-                "ProbeCalendarResourcePresenceAsync",
-                System.Reflection.BindingFlags.Instance
-                | System.Reflection.BindingFlags.Public
-                | System.Reflection.BindingFlags.NonPublic)
-            .ShouldBeNull();
-    }
-
-    [Fact]
     public async Task ProbeCalendarResourceAbsenceAsync_PreservesPurposeThroughDecoratorDefault()
     {
         CalendarHttpRequestPurpose? purpose = null;

--- a/tests/DotnetAgents.CalDav.Core.Tests.Unit/Services/CalendarOccurrenceQueryModuleTests.cs
+++ b/tests/DotnetAgents.CalDav.Core.Tests.Unit/Services/CalendarOccurrenceQueryModuleTests.cs
@@ -17,27 +17,6 @@ public sealed class CalendarOccurrenceQueryModuleTests
     private static readonly DateTimeOffset From = new(2026, 8, 23, 0, 0, 0, TimeSpan.Zero);
     private static readonly DateTimeOffset To = From.AddDays(3);
 
-    [Fact]
-    public void StartExecutorsDependOnNeutralAcquisitionAndTemporalCollaborators()
-    {
-        var occurrenceConstructorTypes = ConstructorTypes(typeof(CalendarOccurrenceQueryStartExecutor));
-        var entityConstructorTypes = ConstructorTypes(typeof(CalendarEntityQueryStartExecutor));
-
-        occurrenceConstructorTypes.ShouldContain(typeof(CalendarQueryAcquisitionExecutor));
-        occurrenceConstructorTypes.ShouldContain(typeof(CalendarTemporalContextResolver));
-        occurrenceConstructorTypes.ShouldNotContain(typeof(CalendarEntityQueryStartExecutor));
-        entityConstructorTypes.ShouldContain(typeof(CalendarQueryAcquisitionExecutor));
-        entityConstructorTypes.ShouldContain(typeof(CalendarTemporalContextResolver));
-        entityConstructorTypes.ShouldNotContain(typeof(Func<ICalendarQueryTransport>));
-        entityConstructorTypes.ShouldNotContain(typeof(CalendarQueryResourceRetriever));
-    }
-
-    private static Type[] ConstructorTypes(Type type) => type.GetConstructors(
-                System.Reflection.BindingFlags.Instance
-                | System.Reflection.BindingFlags.Public
-                | System.Reflection.BindingFlags.NonPublic)
-            .ShouldHaveSingleItem().GetParameters().Select(parameter => parameter.ParameterType).ToArray();
-
     [Theory]
     [InlineData(false, 0)]
     [InlineData(true, 1)]

--- a/tests/DotnetAgents.CalDav.Core.Tests.Unit/Services/CalendarOperationProgressTests.cs
+++ b/tests/DotnetAgents.CalDav.Core.Tests.Unit/Services/CalendarOperationProgressTests.cs
@@ -1,4 +1,3 @@
-using System.Reflection;
 using DotnetAgents.CalDav.Core.Services;
 using Shouldly;
 using Xunit;
@@ -48,23 +47,6 @@ public sealed class CalendarOperationProgressTests
             dispatch,
             CalendarMoveCollisionClassification.None,
             CalendarMoveReconciliationClassification.ObservationUnavailable));
-    }
-
-    [Fact]
-    public void MoveDispatchBoundaryExposesOnlyClosedParameterlessTransitions()
-    {
-        var setters = typeof(CalendarOperationProgress)
-            .GetMethods(BindingFlags.Static | BindingFlags.NonPublic)
-            .Where(method => method.Name is "SetMoveDispatched" or "SetMovePossiblyDispatched")
-            .OrderBy(method => method.Name, StringComparer.Ordinal)
-            .ToArray();
-
-        setters.Select(method => method.Name).ShouldBe(
-        [
-            "SetMoveDispatched",
-            "SetMovePossiblyDispatched"
-        ]);
-        setters.ShouldAllBe(method => method.GetParameters().Length == 0);
     }
 
     [Fact]

--- a/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/CalendarExecutionPolicyTests.cs
+++ b/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/CalendarExecutionPolicyTests.cs
@@ -470,67 +470,6 @@ public sealed class CalendarExecutionPolicyTests
         operations[4].GetTagItem("caldav.mutation.state").ShouldBe("unknown");
     }
 
-    [Fact]
-    public void PublicToolFilter_HasNoJsonTelemetryTruthReconstructionHelpers()
-    {
-        var helperNames = typeof(CalendarExecutionPolicy)
-            .GetMethods(BindingFlags.Static | BindingFlags.NonPublic)
-            .Select(method => method.Name)
-            .ToArray();
-
-        helperNames.ShouldNotContain("StringProperty");
-        helperNames.ShouldNotContain("SafeMutationState");
-        helperNames.ShouldNotContain("SafeBoolean");
-        typeof(TelemetryActivityAllowlistProcessor)
-            .GetMethod("ClassifyHttpObservation", BindingFlags.Static | BindingFlags.NonPublic)
-            .ShouldBeNull();
-        var processorHelpers = typeof(TelemetryActivityAllowlistProcessor)
-            .GetMethods(BindingFlags.Static | BindingFlags.NonPublic)
-            .Select(method => method.Name)
-            .ToArray();
-        processorHelpers.ShouldNotContain("ObserveRetry");
-        processorHelpers.ShouldNotContain("FindOperation");
-        processorHelpers.ShouldNotContain("GetRetryAggregation");
-        processorHelpers.ShouldNotContain("ApplyRetryAggregation");
-        typeof(TelemetryActivityAllowlistProcessor)
-            .GetNestedTypes(BindingFlags.NonPublic)
-            .Select(type => type.Name)
-            .ShouldNotContain(name => name.Contains("RetryAggregation", StringComparison.Ordinal));
-        foreach (var queryTool in new[]
-                 {
-                     typeof(CalendarEntityTools),
-                     typeof(CalendarOccurrenceTools),
-                     typeof(CalendarTodoTools)
-                 })
-        {
-            var queryHelpers = queryTool
-                .GetMethods(BindingFlags.Static | BindingFlags.NonPublic)
-                .Select(method => method.Name)
-                .ToArray();
-            queryHelpers.ShouldNotContain("Code");
-            queryHelpers.ShouldNotContain("Category");
-            queryHelpers.ShouldNotContain("Phase");
-            queryHelpers.ShouldNotContain("ErrorWithoutBounding");
-            queryHelpers.ShouldNotContain("CreatePayloadLimitError");
-        }
-        var exactWriteHelpers = typeof(ExactCalendarResourceWriteTools)
-            .GetMethods(BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public)
-            .Select(method => method.Name)
-            .ToArray();
-        exactWriteHelpers.ShouldNotContain("EnsureBoundedResult");
-        exactWriteHelpers.ShouldNotContain("Phase");
-        var collectionHelpers = typeof(CalendarCollectionTools)
-            .GetMethods(BindingFlags.Static | BindingFlags.NonPublic)
-            .Select(method => method.Name)
-            .ToArray();
-        collectionHelpers.ShouldNotContain("Describe");
-        collectionHelpers.ShouldNotContain("MapHttpCode");
-        collectionHelpers.ShouldNotContain("MutationState");
-        typeof(CalendarResourceTools)
-            .GetMethod("CreateBoundedSuccess", BindingFlags.Static | BindingFlags.NonPublic)
-            .ShouldBeNull();
-    }
-
     [Theory]
     [InlineData("calendars.list")]
     [InlineData("calendar_resources.get")]


### PR DESCRIPTION
Delete four tests that assert private constructor parameters, removed helper names, or private method signatures. These checks freeze past refactors without exercising the behavior they describe.

Keep the adjacent tests for immutable query replay, typed telemetry, atomic MOVE state transitions, and scoped wire probes, plus the public contract and catalog checks.

Validation: Release build with zero warnings, all 2,410 remaining Core and 1,022 remaining MCP unit tests, and Slopwatch pass. Production code is unchanged.

An initial CI run hit the existing HTTP listener teardown race on main. The independent fix is in #167.
