### PR TITLE
ci: validate Markdown changes shipped in the package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,6 @@ name: CI
 on:
   pull_request:
     branches: [main]
-    paths-ignore:
-      - "**/*.md"
 
 permissions:
   contents: read


### PR DESCRIPTION
Run CI for all pull requests targeting main. The blanket Markdown exclusion also skips README.md and skills/caldav-calendars/SKILL.md, both shipped in the NuGet package, so changes to package content can bypass its tests.

Removing the path filter also gives documentation-only pull requests a CI result. The existing build, test, coverage, and Slopwatch steps remain the validation path.

Validation: inspected the package inputs and workflow trigger; git diff --check passes. This PR exercises the unchanged CI job.
