### PR TITLE
refactor: remove duplicate test-suite runner paths

### DIFF
--- a/scripts/test-suite-runner-lib.sh
+++ b/scripts/test-suite-runner-lib.sh
@@ -16,17 +16,6 @@ PY
 
 run_test_suite_manifest_phase() {
   local manifest=$1 phase=$2
-  if [[ $# -eq 3 ]]; then
-    local callback=$3
-    local row project trx prefix filter environment
-    local -a rows
-    mapfile -t rows < <(emit_test_suite_manifest_rows "$manifest" "$phase")
-    for row in "${rows[@]}"; do
-      IFS=$'\x1f' read -r project trx prefix filter environment <<< "$row"
-      "$callback" "$project" "$trx" "$prefix" "$filter" "$environment" </dev/null
-    done
-    return
-  fi
   if [[ $# -ne 4 || ! $3 =~ ^[1-9][0-9]*$ ]]; then
     echo "Usage: run_test_suite_manifest_phase <manifest> <phase> <worker-limit> <callback>" >&2
     return 64

--- a/scripts/test-test-artifacts.sh
+++ b/scripts/test-test-artifacts.sh
@@ -249,14 +249,14 @@ open(path, "w", encoding="utf-8").write(json.dumps(document))
 PY
 expect_rejected "manifest cannot replace the closed suite with a tiny project" python3 "$manifest_validator" "$bad_manifest"
 
-declare -a transported_trx=()
+transported_trx="$fixture_root/transported-trx"
 consume_stdin_and_record_trx() {
   local _project=$1 row_trx=$2 _prefix=$3 _filter=$4 _environment=$5
   cat >/dev/null
-  transported_trx+=("$row_trx")
+  printf '%s\n' "$row_trx" >> "$transported_trx"
 }
-run_test_suite_manifest_phase "$manifest" main consume_stdin_and_record_trx
-[[ "${transported_trx[*]}" == "main-core.trx main-mcp.trx main-integration.trx" ]] || {
+run_test_suite_manifest_phase "$manifest" main 1 consume_stdin_and_record_trx
+[[ "$(cat "$transported_trx")" == $'main-core.trx\nmain-mcp.trx\nmain-integration.trx' ]] || {
   echo "A child process consumed a pending manifest row." >&2
   exit 1
 }

--- a/scripts/verify-test-artifacts.sh
+++ b/scripts/verify-test-artifacts.sh
@@ -54,17 +54,7 @@ import xml.etree.ElementTree as ET
 manifest_path, artifact_text, phase = sys.argv[1:]
 artifact_directory = pathlib.Path(artifact_text)
 manifest = json.load(open(manifest_path, encoding="utf-8"))
-items = manifest.get("artifacts", [])
-if manifest.get("schemaVersion") != 1 or len(items) != 5:
-    raise SystemExit("Test-suite manifest must contain exactly five schema-v1 artifacts.")
-names = [item.get("name") for item in items]
-trx_names = [item.get("trx") for item in items]
-if len(set(names)) != 5 or len(set(trx_names)) != 5:
-    raise SystemExit("Test-suite manifest names and TRX paths must be unique.")
-if any(pathlib.PurePath(name).name != name or not name.endswith(".trx") for name in trx_names):
-    raise SystemExit("Test-suite manifest TRX paths must be safe basenames.")
-if sum(item.get("phase") == "main" for item in items) != 3 or sum(item.get("phase") == "complete" for item in items) != 2:
-    raise SystemExit("Test-suite manifest must contain three main and two complete artifacts.")
+items = manifest["artifacts"]
 selected = [item for item in items if item["phase"] == "main" or phase == "complete"]
 expected_names = {item["trx"] for item in selected}
 actual_names = {path.name for path in artifact_directory.glob("*.trx")}


### PR DESCRIPTION
Remove the test-suite runner's obsolete three-argument serial path. Its only caller was a self-test; production uses the worker-limited path. Run that stdin-consumption regression through the production path with one worker and record child results in a temporary file.

Remove the artifact verifier's duplicate manifest-shape checks after its call to validate-test-suite-manifest.py. The closed five-artifact validator and all TRX, coverage, source-policy, and cleanup checks remain in force.

Validation: bash scripts/test-test-artifacts.sh and git diff --check pass, including bounded concurrency, deterministic failure propagation, malformed evidence, and worktree/cleanup regressions.
