### PR TITLE
refactor: remove redundant validation and scope helpers

### DIFF
--- a/src/DotnetAgents.CalDav.Core/Internal/Ical/CalendarResourceMoveFidelity.cs
+++ b/src/DotnetAgents.CalDav.Core/Internal/Ical/CalendarResourceMoveFidelity.cs
@@ -169,13 +169,13 @@ internal static class CalendarResourceMoveFidelity
         CalendarParameter parameter,
         string value)
     {
-        if (!CalendarResourceProjector.IsKnownParameterApplicableForFidelity(property, parameter.Name))
+        if (!CalendarResourceProjector.IsKnownParameterApplicable(property, parameter.Name))
             return value;
         var special = CanonicalizeSpecialParameterValue(parameter.Name, value);
         if (special is not null)
             return special;
         if (ExtensibleTokenParameters.Contains(parameter.Name)
-            && CalendarResourceProjector.IsTokenForFidelity(value))
+            && CalendarResourceProjector.IsToken(value))
         {
             return value.ToUpperInvariant();
         }
@@ -210,7 +210,7 @@ internal static class CalendarResourceMoveFidelity
         {
             "DERIVED" or "RSVP" => IsOneOf(value, "TRUE", "FALSE"),
             "ENCODING" => IsOneOf(value, "8BIT", "BASE64"),
-            "LANGUAGE" => CalendarResourceProjector.HasValidLanguageTagForFidelity(value),
+            "LANGUAGE" => CalendarResourceProjector.HasValidLanguageTag(value),
             "RANGE" when property.Name.Equals("RECURRENCE-ID", StringComparison.OrdinalIgnoreCase) =>
                 value.Equals("THISANDFUTURE", StringComparison.OrdinalIgnoreCase),
             "RELATED" when property.Name.Equals("TRIGGER", StringComparison.OrdinalIgnoreCase) =>
@@ -261,7 +261,7 @@ internal static class CalendarResourceMoveFidelity
 
     private static bool IsTokenPropertyValue(string propertyName, string value) =>
         TokenValuedProperties.Contains(propertyName)
-        && CalendarResourceProjector.IsTokenForFidelity(value);
+        && CalendarResourceProjector.IsToken(value);
 
     private static string CanonicalizeTextList(CalendarContentProperty property)
     {

--- a/src/DotnetAgents.CalDav.Core/Internal/Ical/CalendarResourceProjector.cs
+++ b/src/DotnetAgents.CalDav.Core/Internal/Ical/CalendarResourceProjector.cs
@@ -223,14 +223,6 @@ internal static class CalendarResourceProjector
     internal static bool HasValidRegisteredPropertyGrammar(CalendarContentProperty property) =>
         !HasInvalidRegisteredGrammar(property);
 
-    internal static bool HasValidLanguageTagForFidelity(string value) => HasValidLanguageTag(value);
-
-    internal static bool IsKnownParameterApplicableForFidelity(
-        CalendarContentProperty property,
-        string parameterName) => IsKnownParameterApplicable(property, parameterName);
-
-    internal static bool IsTokenForFidelity(string value) => IsToken(value);
-
     private static bool HasValidExactPropertyShape(IReadOnlyList<CalendarContentProperty> properties) =>
         !HasRepeatedExactSingleton(properties)
         && HasValidStyledDescriptionCardinality(properties)
@@ -864,7 +856,7 @@ internal static class CalendarResourceProjector
         return values.Length == 1 ? values[0] : null;
     }
 
-    private static bool IsToken(string value) => value.Length > 0
+    internal static bool IsToken(string value) => value.Length > 0
         && value.All(character => character is >= 'A' and <= 'Z'
             or >= 'a' and <= 'z'
             or >= '0' and <= '9'
@@ -1233,7 +1225,7 @@ internal static class CalendarResourceProjector
         || !int.TryParse(parameter.Values[0], NumberStyles.None, CultureInfo.InvariantCulture, out var order)
         || order < 1;
 
-    private static bool IsKnownParameterApplicable(CalendarContentProperty property, string parameterName) =>
+    internal static bool IsKnownParameterApplicable(CalendarContentProperty property, string parameterName) =>
         parameterName.ToUpperInvariant() switch
         {
             "RSVP" or "CUTYPE" or "DELEGATED-FROM" or "DELEGATED-TO" or "MEMBER" or "PARTSTAT"
@@ -1286,7 +1278,7 @@ internal static class CalendarResourceProjector
         "zh-min", "zh-min-nan", "zh-xiang"
     };
 
-    private static bool HasValidLanguageTag(string value)
+    internal static bool HasValidLanguageTag(string value)
     {
         if (GrandfatheredLanguageTags.Contains(value))
             return true;

--- a/src/DotnetAgents.CalDav.Core/Services/CalendarService.cs
+++ b/src/DotnetAgents.CalDav.Core/Services/CalendarService.cs
@@ -14,7 +14,6 @@ internal sealed class CalendarService : ICalendarService
     private readonly ICalendarClient _calendarClient;
     private readonly CalendarOperationDiscovery _operationDiscovery;
     private readonly IOptions<CalDavOptions> _options;
-    private readonly ILogger<CalendarService> _logger;
     private readonly TimeProvider _timeProvider;
     private readonly ICalendarEntityIdentityGenerator _identityGenerator;
     private readonly CalendarDiscoveryPolicy _discoveryPolicy;
@@ -35,7 +34,6 @@ internal sealed class CalendarService : ICalendarService
         ICalendarEntityIdentityGenerator identityGenerator)
     {
         _options = options;
-        _logger = logger;
         _timeProvider = timeProvider;
         _identityGenerator = identityGenerator;
         _discoveryPolicy = new CalendarDiscoveryPolicy(options, logger);
@@ -258,7 +256,7 @@ internal sealed class CalendarService : ICalendarService
         _calendarClient,
         _options.Value,
         _timeProvider,
-        ApplyScope);
+        _discoveryPolicy.ApplyScope);
 
     private CalendarExactMoveModule ExactMoveModule() => new(
         new CalendarClientMoveTransport(_calendarClient),
@@ -333,7 +331,4 @@ internal sealed class CalendarService : ICalendarService
     private static bool HasEncodedPathSeparator(Uri uri) =>
         uri.AbsolutePath.Contains("%2F", StringComparison.OrdinalIgnoreCase)
         || uri.AbsolutePath.Contains("%5C", StringComparison.OrdinalIgnoreCase);
-
-    private CalendarDiscoveryResult ApplyScope(IReadOnlyList<CalendarDescriptor> discovered) =>
-        _discoveryPolicy.ApplyScope(discovered);
 }

--- a/src/DotnetAgents.CalDav.Mcp/Tools/CalendarEntityCreateArgumentParser.cs
+++ b/src/DotnetAgents.CalDav.Mcp/Tools/CalendarEntityCreateArgumentParser.cs
@@ -386,7 +386,7 @@ internal static class CalendarEntityCreateArgumentParser
                 && TryParseTemporalValue(end, out var parsedEnd)
                 && parsedEnd > parsedStart;
         }
-        return IsPositiveDateTimeDuration(duration!);
+        return CalendarDurationValidator.IsStrictlyPositive(duration!);
     }
 
     private static bool TryParseTemporalValue(CalendarTemporalValue value, out DateTime parsed)
@@ -400,9 +400,6 @@ internal static class CalendarEntityCreateArgumentParser
             DateTimeStyles.None,
             out parsed);
     }
-
-    private static bool IsPositiveDateTimeDuration(string duration)
-        => CalendarDurationValidator.IsStrictlyPositive(duration);
 
     private static bool TryParseEventRecurrenceOverride(
         JsonElement value,


### PR DESCRIPTION
Call the existing grammar validators, discovery scope policy, and public duration validator directly. Remove the three ForFidelity aliases, the service ApplyScope forwarding method, the parser duration alias, and an unused logger field.

The shared grammar methods remain inside an internal Core type; the public parser boundary and tool contracts are unchanged. Validation semantics and operation lifetimes are unchanged.

Validation: Release build with zero warnings, all 2,413 Core and 1,023 MCP unit tests, and Slopwatch pass.
