### PR TITLE
test: close HTTP fixtures once to avoid port reuse races

### DIFF
--- a/tests/DotnetAgents.CalDav.IntegrationTests/CalendarMcpRawStdioTests.cs
+++ b/tests/DotnetAgents.CalDav.IntegrationTests/CalendarMcpRawStdioTests.cs
@@ -1072,14 +1072,13 @@ public sealed class CalendarMcpRawStdioTests
         public async ValueTask DisposeAsync()
         {
             await _stopping.CancelAsync();
-            _listener.Stop();
+            _listener.Close();
             try
             {
                 await _serve;
             }
             finally
             {
-                _listener.Close();
                 _stopping.Dispose();
             }
         }
@@ -1195,14 +1194,13 @@ public sealed class CalendarMcpRawStdioTests
         public async ValueTask DisposeAsync()
         {
             await _stopping.CancelAsync();
-            _listener.Stop();
+            _listener.Close();
             try
             {
                 await _serve;
             }
             finally
             {
-                _listener.Close();
                 _stopping.Dispose();
             }
         }
@@ -1292,14 +1290,13 @@ public sealed class CalendarMcpRawStdioTests
         public async ValueTask DisposeAsync()
         {
             await _stopping.CancelAsync();
-            _listener.Stop();
+            _listener.Close();
             try
             {
                 await _serve;
             }
             finally
             {
-                _listener.Close();
                 _stopping.Dispose();
             }
         }

--- a/tests/DotnetAgents.CalDav.IntegrationTests/Fixtures/OtlpLoopbackReceiver.cs
+++ b/tests/DotnetAgents.CalDav.IntegrationTests/Fixtures/OtlpLoopbackReceiver.cs
@@ -58,7 +58,7 @@ internal sealed class OtlpLoopbackReceiver : IAsyncDisposable
     {
         await _shutdown.CancelAsync().ConfigureAwait(false);
         _shutdownSignal.TrySetResult();
-        _listener.Stop();
+        _listener.Close();
         try
         {
             await _pump.ConfigureAwait(false);
@@ -69,7 +69,6 @@ internal sealed class OtlpLoopbackReceiver : IAsyncDisposable
         {
             System.Diagnostics.Debug.Assert(_shutdown.IsCancellationRequested);
         }
-        _listener.Close();
         _requestSignal.Dispose();
         _shutdown.Dispose();
     }

--- a/tests/DotnetAgents.CalDav.IntegrationTests/OpenTelemetryStdioIntegrationTests.cs
+++ b/tests/DotnetAgents.CalDav.IntegrationTests/OpenTelemetryStdioIntegrationTests.cs
@@ -1809,7 +1809,7 @@ public sealed class OpenTelemetryStdioIntegrationTests
         public async ValueTask DisposeAsync()
         {
             await _stopping.CancelAsync();
-            _listener.Stop();
+            _listener.Close();
             try
             {
                 await _serve;
@@ -1819,7 +1819,6 @@ public sealed class OpenTelemetryStdioIntegrationTests
             {
                 System.Diagnostics.Debug.Assert(_stopping.IsCancellationRequested);
             }
-            _listener.Close();
             _stopping.Dispose();
         }
 
@@ -1976,7 +1975,7 @@ public sealed class OpenTelemetryStdioIntegrationTests
         public async ValueTask DisposeAsync()
         {
             await _stopping.CancelAsync();
-            _listener.Stop();
+            _listener.Close();
             try
             {
                 await _serve;
@@ -1986,7 +1985,6 @@ public sealed class OpenTelemetryStdioIntegrationTests
             {
                 System.Diagnostics.Debug.Assert(_stopping.IsCancellationRequested);
             }
-            _listener.Close();
             _stopping.Dispose();
         }
 
@@ -2130,7 +2128,7 @@ public sealed class OpenTelemetryStdioIntegrationTests
         public async ValueTask DisposeAsync()
         {
             await _stopping.CancelAsync();
-            _listener.Stop();
+            _listener.Close();
             try
             {
                 await _serve;
@@ -2140,7 +2138,6 @@ public sealed class OpenTelemetryStdioIntegrationTests
             {
                 System.Diagnostics.Debug.Assert(_stopping.IsCancellationRequested);
             }
-            _listener.Close();
             _stopping.Dispose();
         }
 
@@ -2338,7 +2335,7 @@ public sealed class OpenTelemetryStdioIntegrationTests
         {
             _releaseRequest.TrySetResult();
             await _stopping.CancelAsync();
-            _listener.Stop();
+            _listener.Close();
             try
             {
                 await _serve;
@@ -2348,7 +2345,6 @@ public sealed class OpenTelemetryStdioIntegrationTests
             {
                 System.Diagnostics.Debug.Assert(_stopping.IsCancellationRequested);
             }
-            _listener.Close();
             _stopping.Dispose();
         }
 


### PR DESCRIPTION
Fix an existing integration-test teardown race seen in the CI runs for #162 and #164. The OTLP receiver calls HttpListener.Stop(), awaits its pump, then calls Close(). On .NET 10/Linux, Close after Stop can try to bind the released port again and throw “Address already in use” if another socket has claimed it.

Close the receiver once before awaiting shutdown, and apply the same fix to the scripted HTTP servers in OpenTelemetryStdioIntegrationTests and CalendarMcpRawStdioTests. Keep their cancellation and request-pump cleanup. The raw TCP server retains its separate shutdown path.

Validation: reproduced the old Stop → bind the freed port → Close failure with a standalone .NET 10 program; confirmed a single Close releases the port and terminates a pending accept. Release build, all 16 OpenTelemetryStdioIntegrationTests and 48 CalendarMcpRawStdioTests, and Slopwatch pass locally.
