### PR TITLE
perf: avoid discarded schema evaluation diagnostics

### DIFF
--- a/docs/performance-checkpoint-2026-09-05.md
+++ b/docs/performance-checkpoint-2026-09-05.md
@@ -1,0 +1,154 @@
+# Checkpoint de performance, 2026-09-05
+
+## Plano e estado
+
+1. Ambiente, corpus e baseline: concluído.
+2. Hipóteses, alteração e comparação estatística: concluído.
+3. Matriz funcional, Hermes, gates e pacote: concluído; MRTR Hermes bloqueado e documentado.
+4. Relatório, evidências e limpeza: concluído.
+
+Checkout inicialmente limpo em `37cdba56f3c957ee8f241eadf1e55b883e950458`.
+Objetivo integral: arquivo de anexo `goal-objective.md` desta tarefa.
+Evidências completas e builds isolados: `/tmp/caldav-perf-20260905`.
+Nenhum container preexistente pertence à tarefa.
+
+Ambiente observado: SDK 10.0.100, runtime 10.0.0, Linux x64
+7.2.2-1-cachyos, Ryzen 7 7735HS (8 núcleos/16 threads), 30 GiB RAM,
+Docker rootless 29.7.2, Hermes 0.21.0 (`b0ab2e16`), Aspire CLI 13.5.1.
+Restore de ferramentas, restore NuGet e build Release concluíram sem erros ou warnings.
+Baseline preservado como cópia integral do diretório Release antes de qualquer alteração.
+SHA256 MCP: `e1244b5028bd678066f5a5457b807ba16de75fa7b8937d075c48190fb337ee81`.
+SHA256 Core: `ffec80c4405ca21a7d36abd71f0b4cc00f225b91975781acfaf3651a108ef5e2`.
+
+## Decisões anteriores à comparação
+
+Percentis por nearest rank (`ceil(p*N)`), com p50/p95 e dispersão por bloco.
+P99 será descritivo, sem alegação de robustez com apenas 300 amostras.
+Cinco aquecimentos por processo, três blocos de 100 amostras nos cenários
+prioritários. Alternância baseline/candidato em coortes dentro dos blocos.
+O store permite apenas 16 snapshots por dez minutos. Cada processo executará
+cinco Starts de aquecimento e até dez Starts medidos; reinicialização entre
+coortes fica fora da latência aquecida e será registrada separadamente.
+Continue mantém o processo e o snapshot do Start correspondente.
+Não alterar o limite nem introduzir mecanismo privado de limpeza no produto.
+O harness usará somente fixtures próprias e relógio/janela/seed fixos.
+
+Hipóteses ainda sem diagnóstico: rodadas multiget sequenciais; parsing/expansão;
+validação de output no adaptador; serialização e montagem de páginas.
+Os ganhos históricos de discovery, snapshots e Move não pertencem a esta tarefa.
+
+## Checkpoint após piloto
+
+Infraestrutura própria: `caldav-perf-3f20bb0e-radicale` e
+`caldav-perf-3f20bb0e-dashboard`, 4 CPUs e 2 GiB por container, portas dinâmicas
+em loopback. Manifesto privado no diretório externo de evidências; contém
+credenciais descartáveis e chave da API, não copiar ao Git.
+Corpus autoritativo: 600/600/0; `corpus.json` contém hash e janela fixa.
+Catálogo padrão observado: 19 ferramentas. Assembly carregado confirmado por
+`/proc/<pid>/maps`, command line e hashes.
+
+Piloto `pilot.json`, `pilot-spans.json`, `pilot-traces.json`, `pilot.zip`:
+Continue 200 de entidades e ocorrências custa 498/707 ms no cliente,
+mas só 25/18 ms em `caldav.operation`. Não há HTTP nesses Continues.
+Perfil EventPipe `baseline.nettrace` identifica `CalendarOutputSchemaGuard.Validate`
+e `JsonSchema.Evaluate` no trabalho restante. `baseline-start.nettrace` cobre Start.
+Os percentuais de `dotnet-sampled-thread-time` incluem threads em espera;
+não interpretar como percentuais de CPU.
+
+Candidata: `OutputFormat.Flag` em lugar de `List`, pois o guard só consome
+`IsValid`. Preserva schemas, validação e erro público. Piloto após JIT: ~102 ms
+contra ~370 ms em Continue de ocorrências; não é ainda prova por percentis.
+Experimento de multiget em ondas de quatro não melhorou Start (~2,0 s) e foi
+removido. Evidência: `multiget-check.json`, builds `flag-candidate` e
+`multiget-candidate`; o último é experimento descartado, não produto final.
+
+Amostragem fixada antes da comparação principal: Continue prioritário, três
+blocos de 100 por tamanho 1/5/200 e família; 20 aquecimentos de Continue porque
+o JIT ainda mudou após cinco no piloto. Start secundário: três blocos de 30,
+com cinco aquecimentos e dez medidos por processo. O custo da aquisição integral
+e a retenção finita tornam 300 Starts por célula caro; reportar a menor precisão
+das 90 observações, sem promover p99 a evidência robusta. A meta de 30% permanece.
+
+## Checkpoint de integração e regressões
+
+37 testes focados do guard passaram. Core candidato idêntico ao inicial,
+SHA256 `ffec80c4405ca21a7d36abd71f0b4cc00f225b91975781acfaf3651a108ef5e2`.
+MCP candidato: `1885c568a2460993e464c24b358ceb6f4ee8b102f76f3104bfc9e16af8fc1068`.
+
+Primeira suíte: projetos principais e strict-preconditions passaram, cobertura
+94,49% linhas / 86,05% branches. Alternate-time-zone não iniciou: Docker rootless
+retornou erro de montagem overlay `device or resource busy`. Reter `gates.log`
+e `gates/` como tentativa de infraestrutura falha; repetir a suíte em diretório
+vazio sem alterar gates. O guard de worktree exige não editar o repositório
+enquanto a suíte executa.
+
+`functional-before-discover.json` registra sucesso por todo o catálogo exact
+de 23 ferramentas, MRTR, Move vazio/populado e limpeza autoritativa 600/600/0.
+O cliente do piloto tentou o handshake legado `initialize` com a revisão moderna;
+o servidor o rejeitou, embora as chamadas subsequentes com `_meta` moderno fossem
+válidas. Driver corrigido ANTES da comparação principal: `server/discover`,
+validação de `supportedVersions` e capabilities, `_meta` em todos os requests.
+Repetir matriz com esse handshake e manter as tentativas anteriores identificadas.
+
+Hermes 0.21.0 executou 14 chamadas MCP reais: listagem, três Starts/Continues,
+criação/releitura/patch/releitura/conclusão/releitura e review de exclusão.
+Cliente tentou initialize 2025-11-25, recebeu erro e recuperou via server/discover.
+MRTR continua sem continuação no adaptador: `input_required`, nenhuma chamada
+com requestState. Radicale confirmou resumo alterado e COMPLETED. Cliente direto
+concluiu exclusão com review/confirm e verificou 404. Evidências `hermes-*` e
+`hermes-direct-cleanup/`. O proxy transparente registra assembly/mapeamento,
+capabilities, tool name, resultado sanitizado, sessão e timestamps.
+
+`edges.json`: controles de leitura com OTLP on/off/indisponível, EOF limpo,
+escalas 1/50/200/600, excesso de 5000 ocorrências e 17º snapshot busy passaram.
+Capturas anteriores de tentativa do harness ficam separadas; não contam como
+aprovação. `schema-baseline.json` / `schema-candidate.json`: mesmo hash de página,
+100 observações após 20 aquecimentos: mediana 245/51 ms e 169/94 MB alocados no
+guard. Reflexão e alocação por thread, sem transporte; não são latências MCP.
+
+## Comparação principal em andamento
+
+Continue serial concluído: `continue-serial-summary.json`, 300 amostras por
+família/tamanho/revisão, sem erros. p95 200 itens: entidades 261,62 → 56,96 ms;
+ocorrências 307,93 → 75,77 ms; To-dos 121,91 → 67,29 ms.
+Amostras/blocks completos conservados nos JSONL correspondentes.
+
+O primeiro Start (`start-serial-*`) encontrou falha de admissão no 14º Start de
+ocorrências: o limite de bytes do store pode chegar antes do limite de 16 slots.
+Não usar essa tentativa como throughput útil nem misturá-la à comparação final.
+Nos pilotos de multiget, as duas últimas chamadas por revisão também falharam;
+a conclusão de ausência de benefício usa somente as oito medições bem-sucedidas
+após aquecimento, não as falhas.
+Nova comparação `start-serial-bounded`: cinco aquecimentos/cinco medidas por
+processo, seis coortes por bloco e três blocos de 30 por família/revisão.
+Nenhum teto do produto mudou; o erro de admissão foi preservado na evidência.
+
+Hermes repetido com a testemunha registrando a versão negociada por request:
+2026-07-28 após fallback de initialize para server/discover.
+`verify_hermes.py` confirmou persistência e limpou por MRTR direto; o corpus
+voltou a 600/600/0 antes de comparar.
+
+Start serial concluído, `start-serial-bounded-summary.json`: 90 medidas por
+revisão/família, zero erros. p95 entidades 1600,5 → 1489,2; ocorrências
+1679,6 → 1568,9; To-dos 1049,4 → 988,8 ms. Meta 30% NÃO atingida em Start.
+Regressão +6,4% de entidades no bloco 0 não se repetiu: blocos 1/2 -7,5%/-15,5%.
+Comparações concorrentes estão no processo `remaining-runs.py` (sessão exec 52441):
+continue-single_session-2 e -4 (3x100), continue-processes-2 e -4 (3x32),
+otlp-overhead (mesma candidata, alternância on/off, 3x30). Não executar build,
+gates ou profiling enquanto esse processo mede. Após ele: export final,
+repeat suite em diretório vazio, Slopwatch, package.sh, relatório/JSON e limpeza.
+
+## Encerramento
+
+11.232 chamadas medidas sem erros; 10.962 operações com OTLP correlacionadas a
+traces e 270 do controle com OTLP desligado. API e ZIP contêm os mesmos 124.729
+spans únicos. Auditoria de 633 arquivos não encontrou sentinelas privadas.
+Gates finais: 3.592 testes, 94,49% linhas/86,05% branches, Slopwatch zero findings,
+Release sem warnings/erros, pacote local e smoke aprovados. A primeira falha de
+montagem Docker continua preservada nos artefatos da primeira tentativa.
+
+Relatório e JSON finais: `docs/performance-schema-validation-2026-09-05.*`.
+Infraestrutura própria removida; um volume anônimo ausente; credenciais e Hermes
+isolado removidos; artefatos de evidência mantidos em `/tmp/caldav-perf-20260905`.
+Recursos de outras tarefas e caches compartilhados preservados. Meta 30% atingida
+em Continue 200, não em Start (5,8–7,0%). Nenhuma publicação, merge ou commit.

--- a/docs/performance-schema-validation-2026-09-05-results.json
+++ b/docs/performance-schema-validation-2026-09-05-results.json
@@ -1254,7 +1254,7 @@
       },
       "errors": 0,
       "timeouts": 0,
-      "mean_cpu_ms": 425.93333333333334,
+      "mean_cpu_ms": null,
       "max_rss_bytes": 378900480,
       "serial_service_ops_per_second": 3.230835086342127,
       "run": "continue-single_session-2",
@@ -1282,7 +1282,9 @@
         "b4a419245b1a708f97d5d40a61ac01cc",
         "bfa884ec90edc8490b01e3644580b4ea",
         "37148baec8136b9bdea8d5565bb7b807"
-      ]
+      ],
+      "mean_overlapping_process_cpu_delta_ms": 425.93333333333334,
+      "cpu_measurement_scope": "Not attributable per operation: historical deltas overlap within the shared process"
     },
     {
       "label": "candidate",
@@ -1303,7 +1305,7 @@
       },
       "errors": 0,
       "timeouts": 0,
-      "mean_cpu_ms": 128.20000000000002,
+      "mean_cpu_ms": null,
       "max_rss_bytes": 264343552,
       "serial_service_ops_per_second": 14.449620918385596,
       "run": "continue-single_session-2",
@@ -1331,7 +1333,9 @@
         "63041f8acaa5810ee5a6fdb1618b0bd1",
         "64c6fdaa8bcc05a42d463eae21eebfd7",
         "dc18a7c9f404b78e7d6f242c7d1f68df"
-      ]
+      ],
+      "mean_overlapping_process_cpu_delta_ms": 128.20000000000002,
+      "cpu_measurement_scope": "Not attributable per operation: historical deltas overlap within the shared process"
     },
     {
       "label": "baseline",
@@ -1352,7 +1356,7 @@
       },
       "errors": 0,
       "timeouts": 0,
-      "mean_cpu_ms": 641.2666666666667,
+      "mean_cpu_ms": null,
       "max_rss_bytes": 493948928,
       "serial_service_ops_per_second": 2.1318098751581473,
       "run": "continue-single_session-2",
@@ -1380,7 +1384,9 @@
         "55f8784a5a658a61f2d7fd40c107edf0",
         "17f85816d071e1258d8ef3f042bd99d0",
         "c17bfdae99cc2b2f5d315f25430dc52e"
-      ]
+      ],
+      "mean_overlapping_process_cpu_delta_ms": 641.2666666666667,
+      "cpu_measurement_scope": "Not attributable per operation: historical deltas overlap within the shared process"
     },
     {
       "label": "candidate",
@@ -1401,7 +1407,7 @@
       },
       "errors": 0,
       "timeouts": 0,
-      "mean_cpu_ms": 169.4,
+      "mean_cpu_ms": null,
       "max_rss_bytes": 230866944,
       "serial_service_ops_per_second": 10.208006415640023,
       "run": "continue-single_session-2",
@@ -1429,7 +1435,9 @@
         "c65ffbf0830572f4a28033002d43d687",
         "15ac955338c6cd448183f6952d966b05",
         "a8a1b699527f3bb80478e676ae6d1cff"
-      ]
+      ],
+      "mean_overlapping_process_cpu_delta_ms": 169.4,
+      "cpu_measurement_scope": "Not attributable per operation: historical deltas overlap within the shared process"
     },
     {
       "label": "baseline",
@@ -1450,7 +1458,7 @@
       },
       "errors": 0,
       "timeouts": 0,
-      "mean_cpu_ms": 202.4666666666667,
+      "mean_cpu_ms": null,
       "max_rss_bytes": 226578432,
       "serial_service_ops_per_second": 8.320564746754398,
       "run": "continue-single_session-2",
@@ -1478,7 +1486,9 @@
         "b0102b2a6f0958a6dd780e6754baad3c",
         "dc46976163233726d23a236bc29e1b60",
         "72fd814c54ba78041d13dee97a11901f"
-      ]
+      ],
+      "mean_overlapping_process_cpu_delta_ms": 202.4666666666667,
+      "cpu_measurement_scope": "Not attributable per operation: historical deltas overlap within the shared process"
     },
     {
       "label": "candidate",
@@ -1499,7 +1509,7 @@
       },
       "errors": 0,
       "timeouts": 0,
-      "mean_cpu_ms": 137.2,
+      "mean_cpu_ms": null,
       "max_rss_bytes": 172294144,
       "serial_service_ops_per_second": 16.092943025222453,
       "run": "continue-single_session-2",
@@ -1527,7 +1537,9 @@
         "77c2288b5bd6127a2f5777e993c61d9d",
         "c027df318c6019bc6d6c0eb64cd4b77c",
         "1be6d053965b09c50654433caf1450b3"
-      ]
+      ],
+      "mean_overlapping_process_cpu_delta_ms": 137.2,
+      "cpu_measurement_scope": "Not attributable per operation: historical deltas overlap within the shared process"
     },
     {
       "label": "baseline",
@@ -1548,7 +1560,7 @@
       },
       "errors": 0,
       "timeouts": 0,
-      "mean_cpu_ms": 901.0666666666667,
+      "mean_cpu_ms": null,
       "max_rss_bytes": 592134144,
       "serial_service_ops_per_second": 1.8740775347506011,
       "run": "continue-single_session-4",
@@ -1576,7 +1588,9 @@
         "203a60f8bc2820c3fab63a85f82e8571",
         "615ec53ec3c8bfa2886a9338cea26ba8",
         "1a491d2f5d74bbe8603c1a66d6f6a723"
-      ]
+      ],
+      "mean_overlapping_process_cpu_delta_ms": 901.0666666666667,
+      "cpu_measurement_scope": "Not attributable per operation: historical deltas overlap within the shared process"
     },
     {
       "label": "candidate",
@@ -1597,7 +1611,7 @@
       },
       "errors": 0,
       "timeouts": 0,
-      "mean_cpu_ms": 266.2666666666666,
+      "mean_cpu_ms": null,
       "max_rss_bytes": 328912896,
       "serial_service_ops_per_second": 9.929632373634869,
       "run": "continue-single_session-4",
@@ -1625,7 +1639,9 @@
         "450008fecd1bb350adf5dd33f5121c48",
         "4835124c9eb9ac6c8f87a697a3f49295",
         "f0b8472691194250d6e82c92e884e786"
-      ]
+      ],
+      "mean_overlapping_process_cpu_delta_ms": 266.2666666666666,
+      "cpu_measurement_scope": "Not attributable per operation: historical deltas overlap within the shared process"
     },
     {
       "label": "baseline",
@@ -1646,7 +1662,7 @@
       },
       "errors": 0,
       "timeouts": 0,
-      "mean_cpu_ms": 1366.0666666666662,
+      "mean_cpu_ms": null,
       "max_rss_bytes": 840560640,
       "serial_service_ops_per_second": 1.2363262156937107,
       "run": "continue-single_session-4",
@@ -1674,7 +1690,9 @@
         "433e2b54448b2057f3ff06bc626096bd",
         "8134992e7dd0dd9ca7b7c640a8f2a008",
         "6f4ecdc37a9d6cc62531871143c23636"
-      ]
+      ],
+      "mean_overlapping_process_cpu_delta_ms": 1366.0666666666662,
+      "cpu_measurement_scope": "Not attributable per operation: historical deltas overlap within the shared process"
     },
     {
       "label": "candidate",
@@ -1695,7 +1713,7 @@
       },
       "errors": 0,
       "timeouts": 0,
-      "mean_cpu_ms": 354.99999999999994,
+      "mean_cpu_ms": null,
       "max_rss_bytes": 345075712,
       "serial_service_ops_per_second": 6.863236818296969,
       "run": "continue-single_session-4",
@@ -1723,7 +1741,9 @@
         "f91343d169ea25f7e7656ba84f9af6a9",
         "18b99ef7adc0e2d93172ecabba340369",
         "715cb719f6a4550b8c0dd61de8b40bda"
-      ]
+      ],
+      "mean_overlapping_process_cpu_delta_ms": 354.99999999999994,
+      "cpu_measurement_scope": "Not attributable per operation: historical deltas overlap within the shared process"
     },
     {
       "label": "baseline",
@@ -1744,7 +1764,7 @@
       },
       "errors": 0,
       "timeouts": 0,
-      "mean_cpu_ms": 412.7000000000001,
+      "mean_cpu_ms": null,
       "max_rss_bytes": 293519360,
       "serial_service_ops_per_second": 4.8768281660650485,
       "run": "continue-single_session-4",
@@ -1772,7 +1792,9 @@
         "d037ea7794ce6f5e5d1a5d2ac4c8d12e",
         "4f251543b678b48fa355e77c580bd90c",
         "9aec4df9f1cf5110ca2dea29daa5cffa"
-      ]
+      ],
+      "mean_overlapping_process_cpu_delta_ms": 412.7000000000001,
+      "cpu_measurement_scope": "Not attributable per operation: historical deltas overlap within the shared process"
     },
     {
       "label": "candidate",
@@ -1793,7 +1815,7 @@
       },
       "errors": 0,
       "timeouts": 0,
-      "mean_cpu_ms": 308.7999999999999,
+      "mean_cpu_ms": null,
       "max_rss_bytes": 181047296,
       "serial_service_ops_per_second": 11.780635705075888,
       "run": "continue-single_session-4",
@@ -1821,7 +1843,9 @@
         "b3e6bbd1a0b40fd8b5ef048419f42151",
         "323c3b37ad2320d63356ab6bdd92bca3",
         "e8a53e4cab013f1f58669a34aea5542e"
-      ]
+      ],
+      "mean_overlapping_process_cpu_delta_ms": 308.7999999999999,
+      "cpu_measurement_scope": "Not attributable per operation: historical deltas overlap within the shared process"
     },
     {
       "label": "baseline",
@@ -3744,5 +3768,9 @@
     "anonymous_volumes_verified_removed": 1,
     "owned_containers_verified_absent": true,
     "temporary_credentials_removed": true
+  },
+  "measurement_limitations": {
+    "historical_shared_process_cpu": "Concurrent single_session CPU windows overlap. Original means are retained as mean_overlapping_process_cpu_delta_ms; mean_cpu_ms is null because those deltas cannot be attributed per operation.",
+    "historical_corpus_verification": "The original run checked collection counts and compared measured page hashes between builds; it did not persist the seed ETag map needed to detect every same-count corpus edit. Later harness verification does not retroactively strengthen that evidence."
   }
 }

--- a/docs/performance-schema-validation-2026-09-05-results.json
+++ b/docs/performance-schema-validation-2026-09-05-results.json
@@ -1,0 +1,3748 @@
+{
+  "baseline_sha": "37cdba56f3c957ee8f241eadf1e55b883e950458",
+  "candidate_is_working_tree": true,
+  "product_and_test_patch_sha256": "34672eca679a6dea3e2d51567c42e1a84e5df5af3ddf433d4f6442bc186e2771",
+  "percentile_estimator": "nearest rank ceil(p*n)",
+  "p99_is_descriptive_only": true,
+  "full_evidence_directory": "/tmp/caldav-perf-20260905",
+  "corpus": {
+    "seed": 20260905,
+    "resources": {
+      "events": 600,
+      "todos": 600,
+      "archive": 0
+    },
+    "authored_sha256": "9dc856499dc41593ba1acdd8bd7abdd8a28d4c247202f020e33408f57dabfac8",
+    "window": [
+      "2026-07-01T00:00:00Z",
+      "2026-12-31T00:00:00Z"
+    ],
+    "timezone": "America/Sao_Paulo"
+  },
+  "measurements": [
+    {
+      "label": "baseline",
+      "tool": "calendar_entities.query",
+      "mode": "continue",
+      "size": 1,
+      "concurrency": 1,
+      "n": 300,
+      "p50_ms": 3.398163,
+      "p95_ms": 4.446654,
+      "p99_descriptive_ms": 5.013877,
+      "min_ms": 2.529711,
+      "max_ms": 8.597691,
+      "block_p95_ms": {
+        "0": 4.391229,
+        "1": 4.006472,
+        "2": 4.807116
+      },
+      "errors": 0,
+      "mean_cpu_ms": 4.000000000000003,
+      "max_rss_bytes": 169656320,
+      "serial_service_ops_per_second": 289.2053515449002,
+      "run": "continue-serial",
+      "topology": "single_session",
+      "otlp": true,
+      "trace_matches": 300,
+      "mean_stdio_response_bytes": 3776.24,
+      "distinct_item_hashes": [
+        "93ca3a81f11b0318f77b7fae98b6afb0348d4d724bf742a02512c6c0c0696c4f"
+      ],
+      "driver_ops_per_second": 249.30138895027935,
+      "server_mcp_p50_ms": 3.0835,
+      "server_mcp_p95_ms": 4.1292,
+      "operation_p50_ms": 0.5855,
+      "operation_p95_ms": 0.8557,
+      "http_attempt_totals": {},
+      "http_status_totals": {},
+      "retries": 0,
+      "error_spans": 0,
+      "mean_phase_ms": {
+        "caldav.query.phase.snapshot_lookup": 0.09348166666666667,
+        "caldav.query.phase.page_admission": 0.16835366666666668
+      },
+      "representative_trace_ids": [
+        "75a3d521326a56ef4cc35708ca7a1c50",
+        "4b013c1465b509590806230f4da098df",
+        "06f0d328db3166103c690758b65a8991"
+      ]
+    },
+    {
+      "label": "baseline",
+      "tool": "calendar_entities.query",
+      "mode": "continue",
+      "size": 5,
+      "concurrency": 1,
+      "n": 300,
+      "p50_ms": 10.785965,
+      "p95_ms": 12.580948,
+      "p99_descriptive_ms": 12.935778,
+      "min_ms": 8.388645,
+      "max_ms": 14.712266,
+      "block_p95_ms": {
+        "0": 12.779593,
+        "1": 12.14776,
+        "2": 11.935499
+      },
+      "errors": 0,
+      "mean_cpu_ms": 15.633333333333333,
+      "max_rss_bytes": 180649984,
+      "serial_service_ops_per_second": 92.51248483274001,
+      "run": "continue-serial",
+      "topology": "single_session",
+      "otlp": true,
+      "trace_matches": 300,
+      "mean_stdio_response_bytes": 15355,
+      "distinct_item_hashes": [
+        "9f1719a87250cb9ed7ef3292392903df7de92b3f29532b3d43ebbc049c5e03d4"
+      ],
+      "driver_ops_per_second": 85.80164726000767,
+      "server_mcp_p50_ms": 10.3113,
+      "server_mcp_p95_ms": 12.1944,
+      "operation_p50_ms": 1.3314,
+      "operation_p95_ms": 1.9354,
+      "http_attempt_totals": {},
+      "http_status_totals": {},
+      "retries": 0,
+      "error_spans": 0,
+      "mean_phase_ms": {
+        "caldav.query.phase.snapshot_lookup": 0.10249933333333333,
+        "caldav.query.phase.page_admission": 0.5102923333333333
+      },
+      "representative_trace_ids": [
+        "a2f1a1a11d27c1d4cc6ed2a7165714fb",
+        "8f350cf6cfc723da12ac38a504564bac",
+        "cd25f4945df1b363c7ae00e564484f8a"
+      ]
+    },
+    {
+      "label": "baseline",
+      "tool": "calendar_entities.query",
+      "mode": "continue",
+      "size": 200,
+      "concurrency": 1,
+      "n": 300,
+      "p50_ms": 183.96058,
+      "p95_ms": 261.622574,
+      "p99_descriptive_ms": 335.795815,
+      "min_ms": 145.021568,
+      "max_ms": 462.748022,
+      "block_p95_ms": {
+        "0": 205.630676,
+        "1": 332.487262,
+        "2": 197.436529
+      },
+      "errors": 0,
+      "mean_cpu_ms": 199.73333333333332,
+      "max_rss_bytes": 271765504,
+      "serial_service_ops_per_second": 5.132300431279379,
+      "run": "continue-serial",
+      "topology": "single_session",
+      "otlp": true,
+      "trace_matches": 300,
+      "mean_stdio_response_bytes": 576125,
+      "distinct_item_hashes": [
+        "15595ffd23c0a8f21585e72c079e7bd33c76c0503d496f885ed2b27f41ba80cf"
+      ],
+      "driver_ops_per_second": 4.863858914518142,
+      "server_mcp_p50_ms": 179.088,
+      "server_mcp_p95_ms": 254.9867,
+      "operation_p50_ms": 6.1254,
+      "operation_p95_ms": 14.7833,
+      "http_attempt_totals": {},
+      "http_status_totals": {},
+      "retries": 0,
+      "error_spans": 0,
+      "mean_phase_ms": {
+        "caldav.query.phase.snapshot_lookup": 0.08425666666666666,
+        "caldav.query.phase.page_admission": 3.71351
+      },
+      "representative_trace_ids": [
+        "4afae28f686f347d8f216b53a89bd0b8",
+        "f5d502ec0632beb6481fe7f9663002cd",
+        "a9263bb7b00d2ed41fa7b0a89eadb1c2"
+      ]
+    },
+    {
+      "label": "candidate",
+      "tool": "calendar_entities.query",
+      "mode": "continue",
+      "size": 1,
+      "concurrency": 1,
+      "n": 300,
+      "p50_ms": 2.316578,
+      "p95_ms": 3.112162,
+      "p99_descriptive_ms": 3.527687,
+      "min_ms": 1.708068,
+      "max_ms": 8.228442,
+      "block_p95_ms": {
+        "0": 3.097013,
+        "1": 3.060645,
+        "2": 3.112162
+      },
+      "errors": 0,
+      "mean_cpu_ms": 3.099999999999999,
+      "max_rss_bytes": 167464960,
+      "serial_service_ops_per_second": 419.3888445159182,
+      "run": "continue-serial",
+      "topology": "single_session",
+      "otlp": true,
+      "trace_matches": 300,
+      "mean_stdio_response_bytes": 3776.24,
+      "distinct_item_hashes": [
+        "93ca3a81f11b0318f77b7fae98b6afb0348d4d724bf742a02512c6c0c0696c4f"
+      ],
+      "driver_ops_per_second": 351.5730786416698,
+      "server_mcp_p50_ms": 2.0755,
+      "server_mcp_p95_ms": 2.7821,
+      "operation_p50_ms": 0.4964,
+      "operation_p95_ms": 0.7743,
+      "http_attempt_totals": {},
+      "http_status_totals": {},
+      "retries": 0,
+      "error_spans": 0,
+      "mean_phase_ms": {
+        "caldav.query.phase.snapshot_lookup": 0.092266,
+        "caldav.query.phase.page_admission": 0.161319
+      },
+      "representative_trace_ids": [
+        "98f3fcd4d82b6f40cfcc099460e1f147",
+        "3d312c74612e00cfc7e8dced42c30f32",
+        "f965840dbabf0b5bd6267b6c58a5917f"
+      ]
+    },
+    {
+      "label": "candidate",
+      "tool": "calendar_entities.query",
+      "mode": "continue",
+      "size": 5,
+      "concurrency": 1,
+      "n": 300,
+      "p50_ms": 7.571742,
+      "p95_ms": 8.978039,
+      "p99_descriptive_ms": 9.765747,
+      "min_ms": 6.426687,
+      "max_ms": 9.993688,
+      "block_p95_ms": {
+        "0": 9.162848,
+        "1": 8.519162,
+        "2": 8.945929
+      },
+      "errors": 0,
+      "mean_cpu_ms": 11.5,
+      "max_rss_bytes": 183062528,
+      "serial_service_ops_per_second": 130.01749197695972,
+      "run": "continue-serial",
+      "topology": "single_session",
+      "otlp": true,
+      "trace_matches": 300,
+      "mean_stdio_response_bytes": 15355,
+      "distinct_item_hashes": [
+        "9f1719a87250cb9ed7ef3292392903df7de92b3f29532b3d43ebbc049c5e03d4"
+      ],
+      "driver_ops_per_second": 116.95869402668453,
+      "server_mcp_p50_ms": 7.0719,
+      "server_mcp_p95_ms": 8.4713,
+      "operation_p50_ms": 1.2507,
+      "operation_p95_ms": 1.8014,
+      "http_attempt_totals": {},
+      "http_status_totals": {},
+      "retries": 0,
+      "error_spans": 0,
+      "mean_phase_ms": {
+        "caldav.query.phase.snapshot_lookup": 0.09552766666666666,
+        "caldav.query.phase.page_admission": 0.48076766666666665
+      },
+      "representative_trace_ids": [
+        "0cad4b54d94deb4bcc9dfbafeff10d52",
+        "a9dc5b0f653551cd1796ac97c58b98b9",
+        "00a08140966a8578a111ce7721a0e17a"
+      ]
+    },
+    {
+      "label": "candidate",
+      "tool": "calendar_entities.query",
+      "mode": "continue",
+      "size": 200,
+      "concurrency": 1,
+      "n": 300,
+      "p50_ms": 51.61887,
+      "p95_ms": 56.959343,
+      "p99_descriptive_ms": 59.456322,
+      "min_ms": 47.29662,
+      "max_ms": 68.806002,
+      "block_p95_ms": {
+        "0": 57.501567,
+        "1": 54.40059,
+        "2": 58.463003
+      },
+      "errors": 0,
+      "mean_cpu_ms": 55.733333333333334,
+      "max_rss_bytes": 211931136,
+      "serial_service_ops_per_second": 19.25143130329688,
+      "run": "continue-serial",
+      "topology": "single_session",
+      "otlp": true,
+      "trace_matches": 300,
+      "mean_stdio_response_bytes": 576125,
+      "distinct_item_hashes": [
+        "15595ffd23c0a8f21585e72c079e7bd33c76c0503d496f885ed2b27f41ba80cf"
+      ],
+      "driver_ops_per_second": 16.139412086666265,
+      "server_mcp_p50_ms": 46.5251,
+      "server_mcp_p95_ms": 51.3624,
+      "operation_p50_ms": 6.4229,
+      "operation_p95_ms": 8.8128,
+      "http_attempt_totals": {},
+      "http_status_totals": {},
+      "retries": 0,
+      "error_spans": 0,
+      "mean_phase_ms": {
+        "caldav.query.phase.snapshot_lookup": 0.08695333333333333,
+        "caldav.query.phase.page_admission": 3.008124
+      },
+      "representative_trace_ids": [
+        "63307d2fca8f4c6aee386571780c2d31",
+        "f4bffd63cd6cab8547f009259a2318f1",
+        "edea03e89146ddc10686f1bf702149e5"
+      ]
+    },
+    {
+      "label": "baseline",
+      "tool": "calendar_occurrences.query",
+      "mode": "continue",
+      "size": 1,
+      "concurrency": 1,
+      "n": 300,
+      "p50_ms": 3.805743,
+      "p95_ms": 4.876897,
+      "p99_descriptive_ms": 5.424302,
+      "min_ms": 3.092735,
+      "max_ms": 6.274239,
+      "block_p95_ms": {
+        "0": 4.979902,
+        "1": 4.863012,
+        "2": 4.844668
+      },
+      "errors": 0,
+      "mean_cpu_ms": 5.199999999999997,
+      "max_rss_bytes": 187961344,
+      "serial_service_ops_per_second": 254.43489995997143,
+      "run": "continue-serial",
+      "topology": "single_session",
+      "otlp": true,
+      "trace_matches": 300,
+      "mean_stdio_response_bytes": 4741.24,
+      "distinct_item_hashes": [
+        "6fa3c99da83de898883e522f1b691b162bc4069a8abc863d4b4a56cf1a318542"
+      ],
+      "driver_ops_per_second": 222.77263895755237,
+      "server_mcp_p50_ms": 3.5114,
+      "server_mcp_p95_ms": 4.5943,
+      "operation_p50_ms": 0.5455,
+      "operation_p95_ms": 0.982,
+      "http_attempt_totals": {},
+      "http_status_totals": {},
+      "retries": 0,
+      "error_spans": 0,
+      "mean_phase_ms": {
+        "caldav.query.phase.snapshot_lookup": 0.08755133333333333,
+        "caldav.query.phase.page_admission": 0.187306
+      },
+      "representative_trace_ids": [
+        "70015540504774517bbb3d2554760447",
+        "07895f1986cb279151c686d74f82ca13",
+        "e5fc07f2b74d3e0b230b350fc5022700"
+      ]
+    },
+    {
+      "label": "baseline",
+      "tool": "calendar_occurrences.query",
+      "mode": "continue",
+      "size": 5,
+      "concurrency": 1,
+      "n": 300,
+      "p50_ms": 14.819531,
+      "p95_ms": 17.5124,
+      "p99_descriptive_ms": 20.171286,
+      "min_ms": 12.300558,
+      "max_ms": 24.43821,
+      "block_p95_ms": {
+        "0": 16.336335,
+        "1": 18.160956,
+        "2": 17.378948
+      },
+      "errors": 0,
+      "mean_cpu_ms": 17.900000000000002,
+      "max_rss_bytes": 190660608,
+      "serial_service_ops_per_second": 66.59429060056124,
+      "run": "continue-serial",
+      "topology": "single_session",
+      "otlp": true,
+      "trace_matches": 300,
+      "mean_stdio_response_bytes": 21466,
+      "distinct_item_hashes": [
+        "07569f540908f8efd3996ae2c07e64c72881fc930152028007cd1ed08de7c5b0"
+      ],
+      "driver_ops_per_second": 62.53004671658767,
+      "server_mcp_p50_ms": 14.2558,
+      "server_mcp_p95_ms": 16.9291,
+      "operation_p50_ms": 1.3013,
+      "operation_p95_ms": 2.1659,
+      "http_attempt_totals": {},
+      "http_status_totals": {},
+      "retries": 0,
+      "error_spans": 0,
+      "mean_phase_ms": {
+        "caldav.query.phase.snapshot_lookup": 0.11415033333333334,
+        "caldav.query.phase.page_admission": 0.490163
+      },
+      "representative_trace_ids": [
+        "9e979669358a36fbc3743fbad6d2464e",
+        "3081681bf75e095241ed9cb8829135ad",
+        "ffded965f1152ea7250c49fc6b3e69a8"
+      ]
+    },
+    {
+      "label": "baseline",
+      "tool": "calendar_occurrences.query",
+      "mode": "continue",
+      "size": 200,
+      "concurrency": 1,
+      "n": 300,
+      "p50_ms": 276.757547,
+      "p95_ms": 307.925834,
+      "p99_descriptive_ms": 342.264589,
+      "min_ms": 227.247109,
+      "max_ms": 368.70185,
+      "block_p95_ms": {
+        "0": 312.86174,
+        "1": 307.023563,
+        "2": 305.478076
+      },
+      "errors": 0,
+      "mean_cpu_ms": 281.53333333333336,
+      "max_rss_bytes": 339894272,
+      "serial_service_ops_per_second": 3.60386796032705,
+      "run": "continue-serial",
+      "topology": "single_session",
+      "otlp": true,
+      "trace_matches": 300,
+      "mean_stdio_response_bytes": 742404,
+      "distinct_item_hashes": [
+        "3e933bc895d8c7ea816e7be018ddf32119e347573589f9f6155499cae89b2730"
+      ],
+      "driver_ops_per_second": 3.435216298270209,
+      "server_mcp_p50_ms": 270.5338,
+      "server_mcp_p95_ms": 302.2245,
+      "operation_p50_ms": 7.2983,
+      "operation_p95_ms": 14.6118,
+      "http_attempt_totals": {},
+      "http_status_totals": {},
+      "retries": 0,
+      "error_spans": 0,
+      "mean_phase_ms": {
+        "caldav.query.phase.snapshot_lookup": 0.10061866666666666,
+        "caldav.query.phase.page_admission": 3.9256426666666666
+      },
+      "representative_trace_ids": [
+        "f517c8e2b8fa91a0d978094ff7504d6d",
+        "1c4504aebd9c0cc11e867a8a1605a20c",
+        "12b98387bd3ec290e4bcc7a7c8478cd0"
+      ]
+    },
+    {
+      "label": "candidate",
+      "tool": "calendar_occurrences.query",
+      "mode": "continue",
+      "size": 1,
+      "concurrency": 1,
+      "n": 300,
+      "p50_ms": 2.918427,
+      "p95_ms": 3.910501,
+      "p99_descriptive_ms": 4.738095,
+      "min_ms": 2.287273,
+      "max_ms": 6.43377,
+      "block_p95_ms": {
+        "0": 3.829117,
+        "1": 3.713018,
+        "2": 4.12138
+      },
+      "errors": 0,
+      "mean_cpu_ms": 3.8000000000000016,
+      "max_rss_bytes": 186662912,
+      "serial_service_ops_per_second": 332.1435298877147,
+      "run": "continue-serial",
+      "topology": "single_session",
+      "otlp": true,
+      "trace_matches": 300,
+      "mean_stdio_response_bytes": 4741.24,
+      "distinct_item_hashes": [
+        "6fa3c99da83de898883e522f1b691b162bc4069a8abc863d4b4a56cf1a318542"
+      ],
+      "driver_ops_per_second": 280.4194201111843,
+      "server_mcp_p50_ms": 2.6439,
+      "server_mcp_p95_ms": 3.601,
+      "operation_p50_ms": 0.5669,
+      "operation_p95_ms": 0.9412,
+      "http_attempt_totals": {},
+      "http_status_totals": {},
+      "retries": 0,
+      "error_spans": 0,
+      "mean_phase_ms": {
+        "caldav.query.phase.snapshot_lookup": 0.08969566666666667,
+        "caldav.query.phase.page_admission": 0.18737366666666666
+      },
+      "representative_trace_ids": [
+        "9807553b9f80895f4c532ef12615de59",
+        "6596e2d546cc4038c6ffcf308bedee45",
+        "f6454c7cd4e509bc6f27e494f409d0f8"
+      ]
+    },
+    {
+      "label": "candidate",
+      "tool": "calendar_occurrences.query",
+      "mode": "continue",
+      "size": 5,
+      "concurrency": 1,
+      "n": 300,
+      "p50_ms": 11.068089,
+      "p95_ms": 16.538479,
+      "p99_descriptive_ms": 25.984202,
+      "min_ms": 9.289047,
+      "max_ms": 34.435395,
+      "block_p95_ms": {
+        "0": 13.78814,
+        "1": 19.344703,
+        "2": 11.968442
+      },
+      "errors": 0,
+      "mean_cpu_ms": 14.533333333333333,
+      "max_rss_bytes": 189841408,
+      "serial_service_ops_per_second": 84.63570187134954,
+      "run": "continue-serial",
+      "topology": "single_session",
+      "otlp": true,
+      "trace_matches": 300,
+      "mean_stdio_response_bytes": 21466,
+      "distinct_item_hashes": [
+        "07569f540908f8efd3996ae2c07e64c72881fc930152028007cd1ed08de7c5b0"
+      ],
+      "driver_ops_per_second": 77.96276612271542,
+      "server_mcp_p50_ms": 10.5535,
+      "server_mcp_p95_ms": 15.7042,
+      "operation_p50_ms": 1.7033,
+      "operation_p95_ms": 2.3477,
+      "http_attempt_totals": {},
+      "http_status_totals": {},
+      "retries": 0,
+      "error_spans": 0,
+      "mean_phase_ms": {
+        "caldav.query.phase.snapshot_lookup": 0.10973733333333334,
+        "caldav.query.phase.page_admission": 0.613629
+      },
+      "representative_trace_ids": [
+        "c00685734b2e1a6e54bc4f57c0e62ebc",
+        "a9a18456d4a6bc56fd827d1b19fcd0d3",
+        "dd23b5dcb4e77be342e57037c9fb5728"
+      ]
+    },
+    {
+      "label": "candidate",
+      "tool": "calendar_occurrences.query",
+      "mode": "continue",
+      "size": 200,
+      "concurrency": 1,
+      "n": 300,
+      "p50_ms": 70.857676,
+      "p95_ms": 75.769806,
+      "p99_descriptive_ms": 83.710719,
+      "min_ms": 66.331078,
+      "max_ms": 91.159536,
+      "block_p95_ms": {
+        "0": 72.900554,
+        "1": 75.540368,
+        "2": 77.514735
+      },
+      "errors": 0,
+      "mean_cpu_ms": 71.76666666666667,
+      "max_rss_bytes": 210583552,
+      "serial_service_ops_per_second": 14.029777152953942,
+      "run": "continue-serial",
+      "topology": "single_session",
+      "otlp": true,
+      "trace_matches": 300,
+      "mean_stdio_response_bytes": 742404,
+      "distinct_item_hashes": [
+        "3e933bc895d8c7ea816e7be018ddf32119e347573589f9f6155499cae89b2730"
+      ],
+      "driver_ops_per_second": 11.818884883065339,
+      "server_mcp_p50_ms": 64.1589,
+      "server_mcp_p95_ms": 68.7498,
+      "operation_p50_ms": 7.4893,
+      "operation_p95_ms": 9.7371,
+      "http_attempt_totals": {},
+      "http_status_totals": {},
+      "retries": 0,
+      "error_spans": 0,
+      "mean_phase_ms": {
+        "caldav.query.phase.snapshot_lookup": 0.08337033333333334,
+        "caldav.query.phase.page_admission": 3.351170333333333
+      },
+      "representative_trace_ids": [
+        "b80510805a7f22e8fc7ab379066bfaee",
+        "f15d45f080d2e481f660d42be6f79101",
+        "156094c831e08cf59895dd67e64d8f7e"
+      ]
+    },
+    {
+      "label": "baseline",
+      "tool": "todos.query",
+      "mode": "continue",
+      "size": 1,
+      "concurrency": 1,
+      "n": 300,
+      "p50_ms": 2.083378,
+      "p95_ms": 2.93122,
+      "p99_descriptive_ms": 4.051759,
+      "min_ms": 1.387602,
+      "max_ms": 5.467473,
+      "block_p95_ms": {
+        "0": 3.140816,
+        "1": 2.93077,
+        "2": 2.5822
+      },
+      "errors": 0,
+      "mean_cpu_ms": 2.1666666666666656,
+      "max_rss_bytes": 143478784,
+      "serial_service_ops_per_second": 471.08225537582933,
+      "run": "continue-serial",
+      "topology": "single_session",
+      "otlp": true,
+      "trace_matches": 300,
+      "mean_stdio_response_bytes": 1851.24,
+      "distinct_item_hashes": [
+        "46094766d7c161d12d4e4c56f348d2c52745ebd9d0433939ea434a044b0790cf"
+      ],
+      "driver_ops_per_second": 397.75359482473146,
+      "server_mcp_p50_ms": 1.8651,
+      "server_mcp_p95_ms": 2.6653,
+      "operation_p50_ms": 0.4269,
+      "operation_p95_ms": 0.6178,
+      "http_attempt_totals": {},
+      "http_status_totals": {},
+      "retries": 0,
+      "error_spans": 0,
+      "mean_phase_ms": {
+        "caldav.query.phase.snapshot_lookup": 0.08574033333333334,
+        "caldav.query.phase.page_admission": 0.10635166666666666
+      },
+      "representative_trace_ids": [
+        "5786b9f0fd3ab9d299e8330b5a1e0c14",
+        "85fa65397fc5bd99c932cf815fdc6c17",
+        "87e8c78fb60501028933f86a1ba19336"
+      ]
+    },
+    {
+      "label": "baseline",
+      "tool": "todos.query",
+      "mode": "continue",
+      "size": 5,
+      "concurrency": 1,
+      "n": 300,
+      "p50_ms": 4.567363,
+      "p95_ms": 5.854855,
+      "p99_descriptive_ms": 6.323452,
+      "min_ms": 3.806595,
+      "max_ms": 10.102937,
+      "block_p95_ms": {
+        "0": 5.808709,
+        "1": 5.907215,
+        "2": 5.769215
+      },
+      "errors": 0,
+      "mean_cpu_ms": 6.1,
+      "max_rss_bytes": 149532672,
+      "serial_service_ops_per_second": 213.18639458244252,
+      "run": "continue-serial",
+      "topology": "single_session",
+      "otlp": true,
+      "trace_matches": 300,
+      "mean_stdio_response_bytes": 4960,
+      "distinct_item_hashes": [
+        "588a90c428ab752cedb1863852685b11a9ecf70d194080a76c4858bb2aeb920c"
+      ],
+      "driver_ops_per_second": 189.3424211619703,
+      "server_mcp_p50_ms": 4.2584,
+      "server_mcp_p95_ms": 5.5155,
+      "operation_p50_ms": 0.5403,
+      "operation_p95_ms": 0.9406,
+      "http_attempt_totals": {},
+      "http_status_totals": {},
+      "retries": 0,
+      "error_spans": 0,
+      "mean_phase_ms": {
+        "caldav.query.phase.snapshot_lookup": 0.07066566666666667,
+        "caldav.query.phase.page_admission": 0.21986133333333333
+      },
+      "representative_trace_ids": [
+        "9f9ddcc31702866a92fb79fe8868f7d1",
+        "021f1085e7b64a7dbff87d56953e1894",
+        "a78622954f36c134bee8e2bdaf942c52"
+      ]
+    },
+    {
+      "label": "baseline",
+      "tool": "todos.query",
+      "mode": "continue",
+      "size": 200,
+      "concurrency": 1,
+      "n": 300,
+      "p50_ms": 62.137661,
+      "p95_ms": 121.911267,
+      "p99_descriptive_ms": 145.905034,
+      "min_ms": 49.000266,
+      "max_ms": 154.969015,
+      "block_p95_ms": {
+        "0": 118.332433,
+        "1": 120.384179,
+        "2": 126.894711
+      },
+      "errors": 0,
+      "mean_cpu_ms": 85.86666666666666,
+      "max_rss_bytes": 197799936,
+      "serial_service_ops_per_second": 14.557411886412936,
+      "run": "continue-serial",
+      "topology": "single_session",
+      "otlp": true,
+      "trace_matches": 300,
+      "mean_stdio_response_bytes": 146739,
+      "distinct_item_hashes": [
+        "74f73d492cc638d65e6d20cf9e485fce2ff4e7e97b9f4afba767896f6be14764"
+      ],
+      "driver_ops_per_second": 14.037520674142264,
+      "server_mcp_p50_ms": 60.5807,
+      "server_mcp_p95_ms": 120.2694,
+      "operation_p50_ms": 2.8046,
+      "operation_p95_ms": 10.5471,
+      "http_attempt_totals": {},
+      "http_status_totals": {},
+      "retries": 0,
+      "error_spans": 0,
+      "mean_phase_ms": {
+        "caldav.query.phase.snapshot_lookup": 0.12693466666666667,
+        "caldav.query.phase.page_admission": 2.5452996666666667
+      },
+      "representative_trace_ids": [
+        "d974bafcaf8a43a7ff993f549b155ce3",
+        "fb2a15583d75b847e9fb716f24e9d41c",
+        "b3c6e9881c0ea7d4ae909e883e1db32e"
+      ]
+    },
+    {
+      "label": "candidate",
+      "tool": "todos.query",
+      "mode": "continue",
+      "size": 1,
+      "concurrency": 1,
+      "n": 300,
+      "p50_ms": 1.449951,
+      "p95_ms": 2.087205,
+      "p99_descriptive_ms": 3.281793,
+      "min_ms": 0.990933,
+      "max_ms": 9.105851,
+      "block_p95_ms": {
+        "0": 2.120598,
+        "1": 2.023735,
+        "2": 2.057349
+      },
+      "errors": 0,
+      "mean_cpu_ms": 1.7333333333333325,
+      "max_rss_bytes": 150380544,
+      "serial_service_ops_per_second": 630.5380392438553,
+      "run": "continue-serial",
+      "topology": "single_session",
+      "otlp": true,
+      "trace_matches": 300,
+      "mean_stdio_response_bytes": 1851.24,
+      "distinct_item_hashes": [
+        "46094766d7c161d12d4e4c56f348d2c52745ebd9d0433939ea434a044b0790cf"
+      ],
+      "driver_ops_per_second": 517.8911514435034,
+      "server_mcp_p50_ms": 1.2502,
+      "server_mcp_p95_ms": 1.8744,
+      "operation_p50_ms": 0.3142,
+      "operation_p95_ms": 0.5318,
+      "http_attempt_totals": {},
+      "http_status_totals": {},
+      "retries": 0,
+      "error_spans": 0,
+      "mean_phase_ms": {
+        "caldav.query.phase.snapshot_lookup": 0.06184066666666667,
+        "caldav.query.phase.page_admission": 0.098306
+      },
+      "representative_trace_ids": [
+        "bd94811bcc957cd020479cf409dac7f7",
+        "fe05ef2dbf5e34eef8415e6466ec5915",
+        "c041c1b16547d51ad1d14f97e1d64fdc"
+      ]
+    },
+    {
+      "label": "candidate",
+      "tool": "todos.query",
+      "mode": "continue",
+      "size": 5,
+      "concurrency": 1,
+      "n": 300,
+      "p50_ms": 2.948372,
+      "p95_ms": 4.141869,
+      "p99_descriptive_ms": 4.434972,
+      "min_ms": 2.469428,
+      "max_ms": 5.997456,
+      "block_p95_ms": {
+        "0": 3.877188,
+        "1": 4.02604,
+        "2": 4.326127
+      },
+      "errors": 0,
+      "mean_cpu_ms": 3.533333333333334,
+      "max_rss_bytes": 148004864,
+      "serial_service_ops_per_second": 323.50828220185184,
+      "run": "continue-serial",
+      "topology": "single_session",
+      "otlp": true,
+      "trace_matches": 300,
+      "mean_stdio_response_bytes": 4960,
+      "distinct_item_hashes": [
+        "588a90c428ab752cedb1863852685b11a9ecf70d194080a76c4858bb2aeb920c"
+      ],
+      "driver_ops_per_second": 274.2053026249182,
+      "server_mcp_p50_ms": 2.658,
+      "server_mcp_p95_ms": 3.8956,
+      "operation_p50_ms": 0.4653,
+      "operation_p95_ms": 0.8622,
+      "http_attempt_totals": {},
+      "http_status_totals": {},
+      "retries": 0,
+      "error_spans": 0,
+      "mean_phase_ms": {
+        "caldav.query.phase.snapshot_lookup": 0.06383233333333334,
+        "caldav.query.phase.page_admission": 0.19956966666666667
+      },
+      "representative_trace_ids": [
+        "8d3e2bc51756ccb6b04e0f8c9cca6a7d",
+        "e54bc20f50bd587895c21c5e014ee6bf",
+        "de544db6ff894af9b2d40da486462c9e"
+      ]
+    },
+    {
+      "label": "candidate",
+      "tool": "todos.query",
+      "mode": "continue",
+      "size": 200,
+      "concurrency": 1,
+      "n": 300,
+      "p50_ms": 25.977011,
+      "p95_ms": 67.286823,
+      "p99_descriptive_ms": 72.444373,
+      "min_ms": 16.114909,
+      "max_ms": 92.696621,
+      "block_p95_ms": {
+        "0": 67.029168,
+        "1": 64.890149,
+        "2": 71.192936
+      },
+      "errors": 0,
+      "mean_cpu_ms": 54.43333333333334,
+      "max_rss_bytes": 172396544,
+      "serial_service_ops_per_second": 25.91361913805825,
+      "run": "continue-serial",
+      "topology": "single_session",
+      "otlp": true,
+      "trace_matches": 300,
+      "mean_stdio_response_bytes": 146739,
+      "distinct_item_hashes": [
+        "74f73d492cc638d65e6d20cf9e485fce2ff4e7e97b9f4afba767896f6be14764"
+      ],
+      "driver_ops_per_second": 24.134346321741525,
+      "server_mcp_p50_ms": 24.1205,
+      "server_mcp_p95_ms": 65.6648,
+      "operation_p50_ms": 3.8496,
+      "operation_p95_ms": 5.975,
+      "http_attempt_totals": {},
+      "http_status_totals": {},
+      "retries": 0,
+      "error_spans": 0,
+      "mean_phase_ms": {
+        "caldav.query.phase.snapshot_lookup": 0.12334866666666666,
+        "caldav.query.phase.page_admission": 2.180035
+      },
+      "representative_trace_ids": [
+        "e838a2b0a6df14192c8649a28a2f9a8e",
+        "ee82be7f3179e7612171aa2040c939bf",
+        "b87e3b51c35a387910544044f577f7e8"
+      ]
+    },
+    {
+      "label": "baseline",
+      "tool": "calendar_entities.query",
+      "mode": "start",
+      "size": 200,
+      "concurrency": 1,
+      "n": 90,
+      "p50_ms": 1408.529961,
+      "p95_ms": 1600.494974,
+      "p99_descriptive_ms": 1642.96873,
+      "min_ms": 1357.80951,
+      "max_ms": 1642.96873,
+      "block_p95_ms": {
+        "0": 1447.22038,
+        "1": 1609.516813,
+        "2": 1631.809508
+      },
+      "errors": 0,
+      "mean_cpu_ms": 726.0,
+      "max_rss_bytes": 361508864,
+      "serial_service_ops_per_second": 0.7031840493037096,
+      "run": "start-serial-bounded",
+      "topology": "single_session",
+      "otlp": true,
+      "trace_matches": 90,
+      "mean_stdio_response_bytes": 576123.6,
+      "distinct_item_hashes": [
+        "36be43b711dc864dd85a453c241bb754db76ebe88f884e8195503f16ed9a7b2e"
+      ],
+      "server_mcp_p50_ms": 1403.072,
+      "server_mcp_p95_ms": 1595.8039,
+      "operation_p50_ms": 1218.5621,
+      "operation_p95_ms": 1403.0445,
+      "http_attempt_totals": {
+        "PROPFIND": 457,
+        "REPORT": 2430
+      },
+      "http_status_totals": {
+        "207": 2790,
+        "301": 90,
+        "unavailable": 7
+      },
+      "retries": 7,
+      "error_spans": 7,
+      "mean_phase_ms": {
+        "caldav.query.phase.discovery": 124.37723777777778,
+        "caldav.query.phase.candidate": 189.30853555555555,
+        "caldav.query.phase.fetch": 853.0458111111111,
+        "caldav.query.phase.evaluation": 14.470424444444445,
+        "caldav.query.phase.serialization": 47.33310222222222,
+        "caldav.query.phase.page_admission": 1.334631111111111,
+        "caldav.query.phase.reservation": 1.4770544444444444
+      },
+      "representative_trace_ids": [
+        "bedc1c732472911ab4bb46d284616040",
+        "e808b2acfba3014a887e610493916939",
+        "12a1d40556f384676b4d02c1338b420e"
+      ]
+    },
+    {
+      "label": "candidate",
+      "tool": "calendar_entities.query",
+      "mode": "start",
+      "size": 200,
+      "concurrency": 1,
+      "n": 90,
+      "p50_ms": 1276.8494,
+      "p95_ms": 1489.23965,
+      "p99_descriptive_ms": 1556.282423,
+      "min_ms": 1241.359734,
+      "max_ms": 1556.282423,
+      "block_p95_ms": {
+        "0": 1539.641402,
+        "1": 1489.23965,
+        "2": 1379.236307
+      },
+      "errors": 0,
+      "mean_cpu_ms": 649.3333333333333,
+      "max_rss_bytes": 303906816,
+      "serial_service_ops_per_second": 0.7696295769045244,
+      "run": "start-serial-bounded",
+      "topology": "single_session",
+      "otlp": true,
+      "trace_matches": 90,
+      "mean_stdio_response_bytes": 576123.6,
+      "distinct_item_hashes": [
+        "36be43b711dc864dd85a453c241bb754db76ebe88f884e8195503f16ed9a7b2e"
+      ],
+      "server_mcp_p50_ms": 1270.5426,
+      "server_mcp_p95_ms": 1484.5829,
+      "operation_p50_ms": 1226.755,
+      "operation_p95_ms": 1437.0253,
+      "http_attempt_totals": {
+        "PROPFIND": 458,
+        "REPORT": 2431
+      },
+      "http_status_totals": {
+        "207": 2790,
+        "301": 90,
+        "unavailable": 9
+      },
+      "retries": 9,
+      "error_spans": 9,
+      "mean_phase_ms": {
+        "caldav.query.phase.discovery": 125.27899111111111,
+        "caldav.query.phase.candidate": 185.95948444444446,
+        "caldav.query.phase.fetch": 863.2453822222222,
+        "caldav.query.phase.evaluation": 17.732577777777777,
+        "caldav.query.phase.serialization": 48.39677555555556,
+        "caldav.query.phase.page_admission": 1.262671111111111,
+        "caldav.query.phase.reservation": 1.654188888888889
+      },
+      "representative_trace_ids": [
+        "cfdc3957b71bfd31c1d776298ee411bc",
+        "b47abf02a20e32b5327a8006daa5a39a",
+        "8deab02f249ca9f917dfcbe861395dad"
+      ]
+    },
+    {
+      "label": "baseline",
+      "tool": "calendar_occurrences.query",
+      "mode": "start",
+      "size": 200,
+      "concurrency": 1,
+      "n": 90,
+      "p50_ms": 1595.630814,
+      "p95_ms": 1679.558302,
+      "p99_descriptive_ms": 1911.730458,
+      "min_ms": 1552.448613,
+      "max_ms": 1911.730458,
+      "block_p95_ms": {
+        "0": 1848.766565,
+        "1": 1641.883429,
+        "2": 1679.558302
+      },
+      "errors": 0,
+      "mean_cpu_ms": 737.2222222222222,
+      "max_rss_bytes": 473092096,
+      "serial_service_ops_per_second": 0.6217616134017052,
+      "run": "start-serial-bounded",
+      "topology": "single_session",
+      "otlp": true,
+      "trace_matches": 90,
+      "mean_stdio_response_bytes": 741658.6,
+      "distinct_item_hashes": [
+        "2f31a3867446b66faf447765f92f002baeaf03c705adbe3c0e7f8c030669ca0e"
+      ],
+      "server_mcp_p50_ms": 1588.7878,
+      "server_mcp_p95_ms": 1670.5234,
+      "operation_p50_ms": 1337.9615,
+      "operation_p95_ms": 1395.4816,
+      "http_attempt_totals": {
+        "PROPFIND": 453,
+        "REPORT": 2431
+      },
+      "http_status_totals": {
+        "207": 2790,
+        "301": 90,
+        "unavailable": 4
+      },
+      "retries": 4,
+      "error_spans": 4,
+      "mean_phase_ms": {
+        "caldav.query.phase.discovery": 117.35077111111111,
+        "caldav.query.phase.candidate": 186.95263,
+        "caldav.query.phase.fetch": 859.8023088888889,
+        "caldav.query.phase.evaluation": 21.084127777777777,
+        "caldav.query.phase.serialization": 152.8819411111111,
+        "caldav.query.phase.page_admission": 1.206288888888889,
+        "caldav.query.phase.reservation": 2.0286555555555554
+      },
+      "representative_trace_ids": [
+        "a2f6d8b22125d8dbf9b0c612eb37a931",
+        "9e9ce4d2abf5d6971c7f1fccd06268da",
+        "47820828a66f00caf591513412c01818"
+      ]
+    },
+    {
+      "label": "candidate",
+      "tool": "calendar_occurrences.query",
+      "mode": "start",
+      "size": 200,
+      "concurrency": 1,
+      "n": 90,
+      "p50_ms": 1405.207911,
+      "p95_ms": 1568.902172,
+      "p99_descriptive_ms": 1657.347789,
+      "min_ms": 1373.631446,
+      "max_ms": 1657.347789,
+      "block_p95_ms": {
+        "0": 1614.684327,
+        "1": 1440.192699,
+        "2": 1454.939697
+      },
+      "errors": 0,
+      "mean_cpu_ms": 556.7777777777777,
+      "max_rss_bytes": 363974656,
+      "serial_service_ops_per_second": 0.705685245969393,
+      "run": "start-serial-bounded",
+      "topology": "single_session",
+      "otlp": true,
+      "trace_matches": 90,
+      "mean_stdio_response_bytes": 741658.6,
+      "distinct_item_hashes": [
+        "2f31a3867446b66faf447765f92f002baeaf03c705adbe3c0e7f8c030669ca0e"
+      ],
+      "server_mcp_p50_ms": 1398.0204,
+      "server_mcp_p95_ms": 1563.8,
+      "operation_p50_ms": 1330.1164,
+      "operation_p95_ms": 1497.645,
+      "http_attempt_totals": {
+        "PROPFIND": 457,
+        "REPORT": 2431
+      },
+      "http_status_totals": {
+        "207": 2790,
+        "301": 90,
+        "unavailable": 8
+      },
+      "retries": 8,
+      "error_spans": 8,
+      "mean_phase_ms": {
+        "caldav.query.phase.discovery": 122.36523222222222,
+        "caldav.query.phase.candidate": 186.21388222222222,
+        "caldav.query.phase.fetch": 851.6715188888888,
+        "caldav.query.phase.evaluation": 21.99575,
+        "caldav.query.phase.serialization": 151.27851555555554,
+        "caldav.query.phase.page_admission": 1.1546544444444444,
+        "caldav.query.phase.reservation": 2.2059155555555554
+      },
+      "representative_trace_ids": [
+        "f6de62a5a245eadd129d4be31f74ea72",
+        "0b187dce232a1448f680932df189f9f4",
+        "886196effb5b3ac6f47f5f87a5edf593"
+      ]
+    },
+    {
+      "label": "baseline",
+      "tool": "todos.query",
+      "mode": "start",
+      "size": 200,
+      "concurrency": 1,
+      "n": 90,
+      "p50_ms": 826.568551,
+      "p95_ms": 1049.444925,
+      "p99_descriptive_ms": 1069.832273,
+      "min_ms": 753.326678,
+      "max_ms": 1069.832273,
+      "block_p95_ms": {
+        "0": 1048.968494,
+        "1": 1046.758618,
+        "2": 1068.785004
+      },
+      "errors": 0,
+      "mean_cpu_ms": 790.8888888888889,
+      "max_rss_bytes": 230551552,
+      "serial_service_ops_per_second": 1.1538368329007405,
+      "run": "start-serial-bounded",
+      "topology": "single_session",
+      "otlp": true,
+      "trace_matches": 90,
+      "mean_stdio_response_bytes": 146736.6,
+      "distinct_item_hashes": [
+        "496f3118789cc64dd1d32424ae96fa2b2fd1df4b5f9eaca09108814f7c510746"
+      ],
+      "server_mcp_p50_ms": 824.8256,
+      "server_mcp_p95_ms": 1047.9107,
+      "operation_p50_ms": 746.331,
+      "operation_p95_ms": 928.911,
+      "http_attempt_totals": {
+        "PROPFIND": 450,
+        "REPORT": 1261
+      },
+      "http_status_totals": {
+        "207": 1620,
+        "301": 90,
+        "unavailable": 1
+      },
+      "retries": 1,
+      "error_spans": 1,
+      "mean_phase_ms": {
+        "caldav.query.phase.discovery": 110.63356222222222,
+        "caldav.query.phase.candidate": 97.18511333333333,
+        "caldav.query.phase.fetch": 484.3843655555556,
+        "caldav.query.phase.evaluation": 78.85148666666667,
+        "caldav.query.phase.page_admission": 2.8977755555555555,
+        "caldav.query.phase.reservation": 0.8855877777777778
+      },
+      "representative_trace_ids": [
+        "b5403ddd12169f9a1f45428fe3ed337c",
+        "97193f00c7ba2d261bdb9f0c5fb903c4",
+        "7d24b59d81176d6428f620801e93cc3c"
+      ]
+    },
+    {
+      "label": "candidate",
+      "tool": "todos.query",
+      "mode": "start",
+      "size": 200,
+      "concurrency": 1,
+      "n": 90,
+      "p50_ms": 801.847665,
+      "p95_ms": 988.795241,
+      "p99_descriptive_ms": 1001.368334,
+      "min_ms": 705.148398,
+      "max_ms": 1001.368334,
+      "block_p95_ms": {
+        "0": 994.351025,
+        "1": 974.015479,
+        "2": 989.039998
+      },
+      "errors": 0,
+      "mean_cpu_ms": 749.6666666666666,
+      "max_rss_bytes": 215810048,
+      "serial_service_ops_per_second": 1.200270032030744,
+      "run": "start-serial-bounded",
+      "topology": "single_session",
+      "otlp": true,
+      "trace_matches": 90,
+      "mean_stdio_response_bytes": 146736.6,
+      "distinct_item_hashes": [
+        "496f3118789cc64dd1d32424ae96fa2b2fd1df4b5f9eaca09108814f7c510746"
+      ],
+      "server_mcp_p50_ms": 800.3152,
+      "server_mcp_p95_ms": 987.4515,
+      "operation_p50_ms": 739.8133,
+      "operation_p95_ms": 915.1914,
+      "http_attempt_totals": {
+        "PROPFIND": 450,
+        "REPORT": 1260
+      },
+      "http_status_totals": {
+        "207": 1620,
+        "301": 90
+      },
+      "retries": 0,
+      "error_spans": 0,
+      "mean_phase_ms": {
+        "caldav.query.phase.discovery": 110.64934333333333,
+        "caldav.query.phase.candidate": 94.45655444444445,
+        "caldav.query.phase.fetch": 481.80161444444445,
+        "caldav.query.phase.evaluation": 81.66436666666667,
+        "caldav.query.phase.page_admission": 1.3249444444444445,
+        "caldav.query.phase.reservation": 0.7452466666666667
+      },
+      "representative_trace_ids": [
+        "fcf7f27c4a10fb0d3ad7a952f5f344d4",
+        "900b1494f2d21d379740ce96428faa30",
+        "573136f0870fcf1f76d3ffa824d272a4"
+      ]
+    },
+    {
+      "label": "baseline",
+      "tool": "calendar_entities.query",
+      "mode": "continue",
+      "size": 200,
+      "concurrency": 2,
+      "n": 300,
+      "p50_ms": 309.576107,
+      "p95_ms": 339.055122,
+      "p99_descriptive_ms": 375.245936,
+      "min_ms": 238.761823,
+      "max_ms": 399.551371,
+      "block_p95_ms": {
+        "0": 341.303612,
+        "1": 327.935803,
+        "2": 339.504131
+      },
+      "errors": 0,
+      "timeouts": 0,
+      "mean_cpu_ms": 425.93333333333334,
+      "max_rss_bytes": 378900480,
+      "serial_service_ops_per_second": 3.230835086342127,
+      "run": "continue-single_session-2",
+      "topology": "single_session",
+      "otlp": true,
+      "trace_matches": 300,
+      "mean_stdio_response_bytes": 576124.44,
+      "distinct_item_hashes": [
+        "15595ffd23c0a8f21585e72c079e7bd33c76c0503d496f885ed2b27f41ba80cf"
+      ],
+      "driver_ops_per_second": 6.023302978536106,
+      "server_mcp_p50_ms": 304.3342,
+      "server_mcp_p95_ms": 331.1241,
+      "operation_p50_ms": 6.824,
+      "operation_p95_ms": 17.5511,
+      "http_attempt_totals": {},
+      "http_status_totals": {},
+      "retries": 0,
+      "error_spans": 0,
+      "mean_phase_ms": {
+        "caldav.query.phase.snapshot_lookup": 0.09159366666666667,
+        "caldav.query.phase.page_admission": 4.887203333333334
+      },
+      "representative_trace_ids": [
+        "b4a419245b1a708f97d5d40a61ac01cc",
+        "bfa884ec90edc8490b01e3644580b4ea",
+        "37148baec8136b9bdea8d5565bb7b807"
+      ]
+    },
+    {
+      "label": "candidate",
+      "tool": "calendar_entities.query",
+      "mode": "continue",
+      "size": 200,
+      "concurrency": 2,
+      "n": 300,
+      "p50_ms": 68.687624,
+      "p95_ms": 81.763071,
+      "p99_descriptive_ms": 88.562043,
+      "min_ms": 57.199387,
+      "max_ms": 95.654721,
+      "block_p95_ms": {
+        "0": 79.452212,
+        "1": 76.945784,
+        "2": 82.341904
+      },
+      "errors": 0,
+      "timeouts": 0,
+      "mean_cpu_ms": 128.20000000000002,
+      "max_rss_bytes": 264343552,
+      "serial_service_ops_per_second": 14.449620918385596,
+      "run": "continue-single_session-2",
+      "topology": "single_session",
+      "otlp": true,
+      "trace_matches": 300,
+      "mean_stdio_response_bytes": 576124.44,
+      "distinct_item_hashes": [
+        "15595ffd23c0a8f21585e72c079e7bd33c76c0503d496f885ed2b27f41ba80cf"
+      ],
+      "driver_ops_per_second": 22.037474965358655,
+      "server_mcp_p50_ms": 63.9959,
+      "server_mcp_p95_ms": 74.7422,
+      "operation_p50_ms": 7.0991,
+      "operation_p95_ms": 10.4748,
+      "http_attempt_totals": {},
+      "http_status_totals": {},
+      "retries": 0,
+      "error_spans": 0,
+      "mean_phase_ms": {
+        "caldav.query.phase.snapshot_lookup": 0.113852,
+        "caldav.query.phase.page_admission": 3.338988
+      },
+      "representative_trace_ids": [
+        "63041f8acaa5810ee5a6fdb1618b0bd1",
+        "64c6fdaa8bcc05a42d463eae21eebfd7",
+        "dc18a7c9f404b78e7d6f242c7d1f68df"
+      ]
+    },
+    {
+      "label": "baseline",
+      "tool": "calendar_occurrences.query",
+      "mode": "continue",
+      "size": 200,
+      "concurrency": 2,
+      "n": 300,
+      "p50_ms": 468.628502,
+      "p95_ms": 509.275088,
+      "p99_descriptive_ms": 545.574545,
+      "min_ms": 385.587835,
+      "max_ms": 564.608707,
+      "block_p95_ms": {
+        "0": 507.491555,
+        "1": 510.657851,
+        "2": 509.275088
+      },
+      "errors": 0,
+      "timeouts": 0,
+      "mean_cpu_ms": 641.2666666666667,
+      "max_rss_bytes": 493948928,
+      "serial_service_ops_per_second": 2.1318098751581473,
+      "run": "continue-single_session-2",
+      "topology": "single_session",
+      "otlp": true,
+      "trace_matches": 300,
+      "mean_stdio_response_bytes": 742403.44,
+      "distinct_item_hashes": [
+        "3e933bc895d8c7ea816e7be018ddf32119e347573589f9f6155499cae89b2730"
+      ],
+      "driver_ops_per_second": 4.005800558907214,
+      "server_mcp_p50_ms": 461.1935,
+      "server_mcp_p95_ms": 502.0545,
+      "operation_p50_ms": 7.8605,
+      "operation_p95_ms": 19.6864,
+      "http_attempt_totals": {},
+      "http_status_totals": {},
+      "retries": 0,
+      "error_spans": 0,
+      "mean_phase_ms": {
+        "caldav.query.phase.snapshot_lookup": 0.16331266666666666,
+        "caldav.query.phase.page_admission": 5.882611333333333
+      },
+      "representative_trace_ids": [
+        "55f8784a5a658a61f2d7fd40c107edf0",
+        "17f85816d071e1258d8ef3f042bd99d0",
+        "c17bfdae99cc2b2f5d315f25430dc52e"
+      ]
+    },
+    {
+      "label": "candidate",
+      "tool": "calendar_occurrences.query",
+      "mode": "continue",
+      "size": 200,
+      "concurrency": 2,
+      "n": 300,
+      "p50_ms": 97.159495,
+      "p95_ms": 113.56127,
+      "p99_descriptive_ms": 119.646614,
+      "min_ms": 81.280218,
+      "max_ms": 138.102993,
+      "block_p95_ms": {
+        "0": 108.661559,
+        "1": 116.898238,
+        "2": 112.530422
+      },
+      "errors": 0,
+      "timeouts": 0,
+      "mean_cpu_ms": 169.4,
+      "max_rss_bytes": 230866944,
+      "serial_service_ops_per_second": 10.208006415640023,
+      "run": "continue-single_session-2",
+      "topology": "single_session",
+      "otlp": true,
+      "trace_matches": 300,
+      "mean_stdio_response_bytes": 742403.44,
+      "distinct_item_hashes": [
+        "3e933bc895d8c7ea816e7be018ddf32119e347573589f9f6155499cae89b2730"
+      ],
+      "driver_ops_per_second": 15.745876726145829,
+      "server_mcp_p50_ms": 90.7087,
+      "server_mcp_p95_ms": 106.782,
+      "operation_p50_ms": 8.6161,
+      "operation_p95_ms": 10.5074,
+      "http_attempt_totals": {},
+      "http_status_totals": {},
+      "retries": 0,
+      "error_spans": 0,
+      "mean_phase_ms": {
+        "caldav.query.phase.snapshot_lookup": 0.102069,
+        "caldav.query.phase.page_admission": 3.886974
+      },
+      "representative_trace_ids": [
+        "c65ffbf0830572f4a28033002d43d687",
+        "15ac955338c6cd448183f6952d966b05",
+        "a8a1b699527f3bb80478e676ae6d1cff"
+      ]
+    },
+    {
+      "label": "baseline",
+      "tool": "todos.query",
+      "mode": "continue",
+      "size": 200,
+      "concurrency": 2,
+      "n": 300,
+      "p50_ms": 113.978088,
+      "p95_ms": 170.133902,
+      "p99_descriptive_ms": 179.839058,
+      "min_ms": 83.112281,
+      "max_ms": 188.68509,
+      "block_p95_ms": {
+        "0": 169.373265,
+        "1": 169.73096,
+        "2": 172.137459
+      },
+      "errors": 0,
+      "timeouts": 0,
+      "mean_cpu_ms": 202.4666666666667,
+      "max_rss_bytes": 226578432,
+      "serial_service_ops_per_second": 8.320564746754398,
+      "run": "continue-single_session-2",
+      "topology": "single_session",
+      "otlp": true,
+      "trace_matches": 300,
+      "mean_stdio_response_bytes": 146738.44,
+      "distinct_item_hashes": [
+        "74f73d492cc638d65e6d20cf9e485fce2ff4e7e97b9f4afba767896f6be14764"
+      ],
+      "driver_ops_per_second": 15.75770115436917,
+      "server_mcp_p50_ms": 112.3574,
+      "server_mcp_p95_ms": 168.9688,
+      "operation_p50_ms": 3.9025,
+      "operation_p95_ms": 13.7331,
+      "http_attempt_totals": {},
+      "http_status_totals": {},
+      "retries": 0,
+      "error_spans": 0,
+      "mean_phase_ms": {
+        "caldav.query.phase.snapshot_lookup": 0.15773966666666667,
+        "caldav.query.phase.page_admission": 3.560521666666667
+      },
+      "representative_trace_ids": [
+        "b0102b2a6f0958a6dd780e6754baad3c",
+        "dc46976163233726d23a236bc29e1b60",
+        "72fd814c54ba78041d13dee97a11901f"
+      ]
+    },
+    {
+      "label": "candidate",
+      "tool": "todos.query",
+      "mode": "continue",
+      "size": 200,
+      "concurrency": 2,
+      "n": 300,
+      "p50_ms": 67.044337,
+      "p95_ms": 81.025857,
+      "p99_descriptive_ms": 84.731923,
+      "min_ms": 21.674202,
+      "max_ms": 86.331196,
+      "block_p95_ms": {
+        "0": 79.521192,
+        "1": 78.991632,
+        "2": 82.760276
+      },
+      "errors": 0,
+      "timeouts": 0,
+      "mean_cpu_ms": 137.2,
+      "max_rss_bytes": 172294144,
+      "serial_service_ops_per_second": 16.092943025222453,
+      "run": "continue-single_session-2",
+      "topology": "single_session",
+      "otlp": true,
+      "trace_matches": 300,
+      "mean_stdio_response_bytes": 146738.44,
+      "distinct_item_hashes": [
+        "74f73d492cc638d65e6d20cf9e485fce2ff4e7e97b9f4afba767896f6be14764"
+      ],
+      "driver_ops_per_second": 29.51220601255508,
+      "server_mcp_p50_ms": 65.3782,
+      "server_mcp_p95_ms": 79.9797,
+      "operation_p50_ms": 5.7519,
+      "operation_p95_ms": 7.5845,
+      "http_attempt_totals": {},
+      "http_status_totals": {},
+      "retries": 0,
+      "error_spans": 0,
+      "mean_phase_ms": {
+        "caldav.query.phase.snapshot_lookup": 0.15020166666666668,
+        "caldav.query.phase.page_admission": 2.99554
+      },
+      "representative_trace_ids": [
+        "77c2288b5bd6127a2f5777e993c61d9d",
+        "c027df318c6019bc6d6c0eb64cd4b77c",
+        "1be6d053965b09c50654433caf1450b3"
+      ]
+    },
+    {
+      "label": "baseline",
+      "tool": "calendar_entities.query",
+      "mode": "continue",
+      "size": 200,
+      "concurrency": 4,
+      "n": 300,
+      "p50_ms": 529.090951,
+      "p95_ms": 615.826404,
+      "p99_descriptive_ms": 652.294532,
+      "min_ms": 444.236152,
+      "max_ms": 674.073147,
+      "block_p95_ms": {
+        "0": 589.296435,
+        "1": 632.9022,
+        "2": 594.413399
+      },
+      "errors": 0,
+      "timeouts": 0,
+      "mean_cpu_ms": 901.0666666666667,
+      "max_rss_bytes": 592134144,
+      "serial_service_ops_per_second": 1.8740775347506011,
+      "run": "continue-single_session-4",
+      "topology": "single_session",
+      "otlp": true,
+      "trace_matches": 300,
+      "mean_stdio_response_bytes": 576124.84,
+      "distinct_item_hashes": [
+        "15595ffd23c0a8f21585e72c079e7bd33c76c0503d496f885ed2b27f41ba80cf"
+      ],
+      "driver_ops_per_second": 6.8745162961007225,
+      "server_mcp_p50_ms": 523.8461,
+      "server_mcp_p95_ms": 608.7234,
+      "operation_p50_ms": 11.2475,
+      "operation_p95_ms": 15.6671,
+      "http_attempt_totals": {},
+      "http_status_totals": {},
+      "retries": 0,
+      "error_spans": 0,
+      "mean_phase_ms": {
+        "caldav.query.phase.snapshot_lookup": 0.06468566666666667,
+        "caldav.query.phase.page_admission": 6.385944333333334
+      },
+      "representative_trace_ids": [
+        "203a60f8bc2820c3fab63a85f82e8571",
+        "615ec53ec3c8bfa2886a9338cea26ba8",
+        "1a491d2f5d74bbe8603c1a66d6f6a723"
+      ]
+    },
+    {
+      "label": "candidate",
+      "tool": "calendar_entities.query",
+      "mode": "continue",
+      "size": 200,
+      "concurrency": 4,
+      "n": 300,
+      "p50_ms": 97.864653,
+      "p95_ms": 135.284626,
+      "p99_descriptive_ms": 151.522879,
+      "min_ms": 72.858135,
+      "max_ms": 156.391869,
+      "block_p95_ms": {
+        "0": 119.563297,
+        "1": 141.806986,
+        "2": 134.649953
+      },
+      "errors": 0,
+      "timeouts": 0,
+      "mean_cpu_ms": 266.2666666666666,
+      "max_rss_bytes": 328912896,
+      "serial_service_ops_per_second": 9.929632373634869,
+      "run": "continue-single_session-4",
+      "topology": "single_session",
+      "otlp": true,
+      "trace_matches": 300,
+      "mean_stdio_response_bytes": 576124.84,
+      "distinct_item_hashes": [
+        "15595ffd23c0a8f21585e72c079e7bd33c76c0503d496f885ed2b27f41ba80cf"
+      ],
+      "driver_ops_per_second": 27.119216769271322,
+      "server_mcp_p50_ms": 92.8163,
+      "server_mcp_p95_ms": 122.1685,
+      "operation_p50_ms": 8.6516,
+      "operation_p95_ms": 12.1813,
+      "http_attempt_totals": {},
+      "http_status_totals": {},
+      "retries": 0,
+      "error_spans": 0,
+      "mean_phase_ms": {
+        "caldav.query.phase.snapshot_lookup": 0.11049733333333334,
+        "caldav.query.phase.page_admission": 4.131959666666667
+      },
+      "representative_trace_ids": [
+        "450008fecd1bb350adf5dd33f5121c48",
+        "4835124c9eb9ac6c8f87a697a3f49295",
+        "f0b8472691194250d6e82c92e884e786"
+      ]
+    },
+    {
+      "label": "baseline",
+      "tool": "calendar_occurrences.query",
+      "mode": "continue",
+      "size": 200,
+      "concurrency": 4,
+      "n": 300,
+      "p50_ms": 806.29124,
+      "p95_ms": 889.768976,
+      "p99_descriptive_ms": 907.426173,
+      "min_ms": 667.747593,
+      "max_ms": 931.736544,
+      "block_p95_ms": {
+        "0": 895.120534,
+        "1": 868.187677,
+        "2": 892.673252
+      },
+      "errors": 0,
+      "timeouts": 0,
+      "mean_cpu_ms": 1366.0666666666662,
+      "max_rss_bytes": 840560640,
+      "serial_service_ops_per_second": 1.2363262156937107,
+      "run": "continue-single_session-4",
+      "topology": "single_session",
+      "otlp": true,
+      "trace_matches": 300,
+      "mean_stdio_response_bytes": 742403.84,
+      "distinct_item_hashes": [
+        "3e933bc895d8c7ea816e7be018ddf32119e347573589f9f6155499cae89b2730"
+      ],
+      "driver_ops_per_second": 4.584540974428446,
+      "server_mcp_p50_ms": 798.0222,
+      "server_mcp_p95_ms": 883.9634,
+      "operation_p50_ms": 12.8871,
+      "operation_p95_ms": 20.9715,
+      "http_attempt_totals": {},
+      "http_status_totals": {},
+      "retries": 0,
+      "error_spans": 0,
+      "mean_phase_ms": {
+        "caldav.query.phase.snapshot_lookup": 0.06401766666666667,
+        "caldav.query.phase.page_admission": 7.241569666666667
+      },
+      "representative_trace_ids": [
+        "433e2b54448b2057f3ff06bc626096bd",
+        "8134992e7dd0dd9ca7b7c640a8f2a008",
+        "6f4ecdc37a9d6cc62531871143c23636"
+      ]
+    },
+    {
+      "label": "candidate",
+      "tool": "calendar_occurrences.query",
+      "mode": "continue",
+      "size": 200,
+      "concurrency": 4,
+      "n": 300,
+      "p50_ms": 144.021045,
+      "p95_ms": 180.169042,
+      "p99_descriptive_ms": 201.422272,
+      "min_ms": 108.512697,
+      "max_ms": 210.064274,
+      "block_p95_ms": {
+        "0": 182.485595,
+        "1": 167.248557,
+        "2": 182.51244
+      },
+      "errors": 0,
+      "timeouts": 0,
+      "mean_cpu_ms": 354.99999999999994,
+      "max_rss_bytes": 345075712,
+      "serial_service_ops_per_second": 6.863236818296969,
+      "run": "continue-single_session-4",
+      "topology": "single_session",
+      "otlp": true,
+      "trace_matches": 300,
+      "mean_stdio_response_bytes": 742403.84,
+      "distinct_item_hashes": [
+        "3e933bc895d8c7ea816e7be018ddf32119e347573589f9f6155499cae89b2730"
+      ],
+      "driver_ops_per_second": 19.659319104823584,
+      "server_mcp_p50_ms": 137.6257,
+      "server_mcp_p95_ms": 168.7423,
+      "operation_p50_ms": 10.0561,
+      "operation_p95_ms": 12.9185,
+      "http_attempt_totals": {},
+      "http_status_totals": {},
+      "retries": 0,
+      "error_spans": 0,
+      "mean_phase_ms": {
+        "caldav.query.phase.snapshot_lookup": 0.092387,
+        "caldav.query.phase.page_admission": 4.642769
+      },
+      "representative_trace_ids": [
+        "f91343d169ea25f7e7656ba84f9af6a9",
+        "18b99ef7adc0e2d93172ecabba340369",
+        "715cb719f6a4550b8c0dd61de8b40bda"
+      ]
+    },
+    {
+      "label": "baseline",
+      "tool": "todos.query",
+      "mode": "continue",
+      "size": 200,
+      "concurrency": 4,
+      "n": 300,
+      "p50_ms": 198.597388,
+      "p95_ms": 257.111942,
+      "p99_descriptive_ms": 267.141603,
+      "min_ms": 146.683089,
+      "max_ms": 322.400696,
+      "block_p95_ms": {
+        "0": 257.802335,
+        "1": 254.332236,
+        "2": 255.1168
+      },
+      "errors": 0,
+      "timeouts": 0,
+      "mean_cpu_ms": 412.7000000000001,
+      "max_rss_bytes": 293519360,
+      "serial_service_ops_per_second": 4.8768281660650485,
+      "run": "continue-single_session-4",
+      "topology": "single_session",
+      "otlp": true,
+      "trace_matches": 300,
+      "mean_stdio_response_bytes": 146738.84,
+      "distinct_item_hashes": [
+        "74f73d492cc638d65e6d20cf9e485fce2ff4e7e97b9f4afba767896f6be14764"
+      ],
+      "driver_ops_per_second": 18.048964687233017,
+      "server_mcp_p50_ms": 197.1828,
+      "server_mcp_p95_ms": 253.7518,
+      "operation_p50_ms": 6.9175,
+      "operation_p95_ms": 17.0176,
+      "http_attempt_totals": {},
+      "http_status_totals": {},
+      "retries": 0,
+      "error_spans": 0,
+      "mean_phase_ms": {
+        "caldav.query.phase.snapshot_lookup": 0.14735633333333334,
+        "caldav.query.phase.page_admission": 5.640074333333334
+      },
+      "representative_trace_ids": [
+        "d037ea7794ce6f5e5d1a5d2ac4c8d12e",
+        "4f251543b678b48fa355e77c580bd90c",
+        "9aec4df9f1cf5110ca2dea29daa5cffa"
+      ]
+    },
+    {
+      "label": "candidate",
+      "tool": "todos.query",
+      "mode": "continue",
+      "size": 200,
+      "concurrency": 4,
+      "n": 300,
+      "p50_ms": 84.313752,
+      "p95_ms": 95.366096,
+      "p99_descriptive_ms": 99.813216,
+      "min_ms": 71.432932,
+      "max_ms": 103.133076,
+      "block_p95_ms": {
+        "0": 91.201766,
+        "1": 98.208093,
+        "2": 88.200099
+      },
+      "errors": 0,
+      "timeouts": 0,
+      "mean_cpu_ms": 308.7999999999999,
+      "max_rss_bytes": 181047296,
+      "serial_service_ops_per_second": 11.780635705075888,
+      "run": "continue-single_session-4",
+      "topology": "single_session",
+      "otlp": true,
+      "trace_matches": 300,
+      "mean_stdio_response_bytes": 146738.84,
+      "distinct_item_hashes": [
+        "74f73d492cc638d65e6d20cf9e485fce2ff4e7e97b9f4afba767896f6be14764"
+      ],
+      "driver_ops_per_second": 41.59941531278535,
+      "server_mcp_p50_ms": 82.6755,
+      "server_mcp_p95_ms": 93.5404,
+      "operation_p50_ms": 7.008,
+      "operation_p95_ms": 9.1824,
+      "http_attempt_totals": {},
+      "http_status_totals": {},
+      "retries": 0,
+      "error_spans": 0,
+      "mean_phase_ms": {
+        "caldav.query.phase.snapshot_lookup": 0.15543666666666667,
+        "caldav.query.phase.page_admission": 4.2741
+      },
+      "representative_trace_ids": [
+        "b3e6bbd1a0b40fd8b5ef048419f42151",
+        "323c3b37ad2320d63356ab6bdd92bca3",
+        "e8a53e4cab013f1f58669a34aea5542e"
+      ]
+    },
+    {
+      "label": "baseline",
+      "tool": "calendar_entities.query",
+      "mode": "continue",
+      "size": 200,
+      "concurrency": 2,
+      "n": 96,
+      "p50_ms": 221.58498,
+      "p95_ms": 279.666878,
+      "p99_descriptive_ms": 291.51607,
+      "min_ms": 174.627803,
+      "max_ms": 291.51607,
+      "block_p95_ms": {
+        "0": 226.198696,
+        "1": 239.854689,
+        "2": 286.197419
+      },
+      "errors": 0,
+      "timeouts": 0,
+      "mean_cpu_ms": 254.79166666666654,
+      "max_rss_bytes": 267644928,
+      "serial_service_ops_per_second": 4.337392687447592,
+      "run": "continue-processes-2",
+      "topology": "processes",
+      "otlp": true,
+      "trace_matches": 96,
+      "mean_stdio_response_bytes": 576124,
+      "distinct_item_hashes": [
+        "15595ffd23c0a8f21585e72c079e7bd33c76c0503d496f885ed2b27f41ba80cf"
+      ],
+      "driver_ops_per_second": 8.16861929010327,
+      "server_mcp_p50_ms": 215.5491,
+      "server_mcp_p95_ms": 273.2387,
+      "operation_p50_ms": 7.2229,
+      "operation_p95_ms": 18.5966,
+      "http_attempt_totals": {},
+      "http_status_totals": {},
+      "retries": 0,
+      "error_spans": 0,
+      "mean_phase_ms": {
+        "caldav.query.phase.snapshot_lookup": 0.13409895833333332,
+        "caldav.query.phase.page_admission": 4.441665625
+      },
+      "representative_trace_ids": [
+        "66521621e599b99d4a1fce7106ea34b1",
+        "8f8b5954f823cc116f1b687cee68cff5",
+        "0a94f081090331d9b502fdbaa4b4c7a0"
+      ]
+    },
+    {
+      "label": "candidate",
+      "tool": "calendar_entities.query",
+      "mode": "continue",
+      "size": 200,
+      "concurrency": 2,
+      "n": 96,
+      "p50_ms": 66.926349,
+      "p95_ms": 87.048372,
+      "p99_descriptive_ms": 91.050447,
+      "min_ms": 54.326089,
+      "max_ms": 91.050447,
+      "block_p95_ms": {
+        "0": 70.504227,
+        "1": 71.835563,
+        "2": 89.568125
+      },
+      "errors": 0,
+      "timeouts": 0,
+      "mean_cpu_ms": 78.22916666666666,
+      "max_rss_bytes": 184188928,
+      "serial_service_ops_per_second": 14.726420254465124,
+      "run": "continue-processes-2",
+      "topology": "processes",
+      "otlp": true,
+      "trace_matches": 96,
+      "mean_stdio_response_bytes": 576124,
+      "distinct_item_hashes": [
+        "15595ffd23c0a8f21585e72c079e7bd33c76c0503d496f885ed2b27f41ba80cf"
+      ],
+      "driver_ops_per_second": 24.95345992572902,
+      "server_mcp_p50_ms": 61.4648,
+      "server_mcp_p95_ms": 79.3343,
+      "operation_p50_ms": 7.7222,
+      "operation_p95_ms": 11.1889,
+      "http_attempt_totals": {},
+      "http_status_totals": {},
+      "retries": 0,
+      "error_spans": 0,
+      "mean_phase_ms": {
+        "caldav.query.phase.snapshot_lookup": 0.11994166666666667,
+        "caldav.query.phase.page_admission": 3.3163416666666667
+      },
+      "representative_trace_ids": [
+        "52327ed877d935bb6da6aaf0329be670",
+        "8795e28536cbe7ac0ce25483cb21d85c",
+        "66b9bc65421d1c3414842121f487ef4c"
+      ]
+    },
+    {
+      "label": "baseline",
+      "tool": "calendar_occurrences.query",
+      "mode": "continue",
+      "size": 200,
+      "concurrency": 2,
+      "n": 96,
+      "p50_ms": 334.227003,
+      "p95_ms": 423.427549,
+      "p99_descriptive_ms": 456.821492,
+      "min_ms": 279.808176,
+      "max_ms": 456.821492,
+      "block_p95_ms": {
+        "0": 347.289364,
+        "1": 356.480273,
+        "2": 443.777685
+      },
+      "errors": 0,
+      "timeouts": 0,
+      "mean_cpu_ms": 367.0833333333334,
+      "max_rss_bytes": 337260544,
+      "serial_service_ops_per_second": 2.878581973846549,
+      "run": "continue-processes-2",
+      "topology": "processes",
+      "otlp": true,
+      "trace_matches": 96,
+      "mean_stdio_response_bytes": 742403,
+      "distinct_item_hashes": [
+        "3e933bc895d8c7ea816e7be018ddf32119e347573589f9f6155499cae89b2730"
+      ],
+      "driver_ops_per_second": 5.449734020931369,
+      "server_mcp_p50_ms": 326.6605,
+      "server_mcp_p95_ms": 412.8372,
+      "operation_p50_ms": 8.9644,
+      "operation_p95_ms": 17.507,
+      "http_attempt_totals": {},
+      "http_status_totals": {},
+      "retries": 0,
+      "error_spans": 0,
+      "mean_phase_ms": {
+        "caldav.query.phase.snapshot_lookup": 0.17903229166666665,
+        "caldav.query.phase.page_admission": 4.767008333333333
+      },
+      "representative_trace_ids": [
+        "98f09a99a0fe4be34eb1dc89499006e0",
+        "7901e9fba4b692c6c042dbb50b3dfb2e",
+        "632dc61ae25fe540b182a2577f0fe0a8"
+      ]
+    },
+    {
+      "label": "candidate",
+      "tool": "calendar_occurrences.query",
+      "mode": "continue",
+      "size": 200,
+      "concurrency": 2,
+      "n": 96,
+      "p50_ms": 92.258503,
+      "p95_ms": 123.469237,
+      "p99_descriptive_ms": 127.050723,
+      "min_ms": 76.000444,
+      "max_ms": 127.050723,
+      "block_p95_ms": {
+        "0": 96.579615,
+        "1": 96.298285,
+        "2": 125.518007
+      },
+      "errors": 0,
+      "timeouts": 0,
+      "mean_cpu_ms": 102.18750000000004,
+      "max_rss_bytes": 222162944,
+      "serial_service_ops_per_second": 10.511437416874484,
+      "run": "continue-processes-2",
+      "topology": "processes",
+      "otlp": true,
+      "trace_matches": 96,
+      "mean_stdio_response_bytes": 742403,
+      "distinct_item_hashes": [
+        "3e933bc895d8c7ea816e7be018ddf32119e347573589f9f6155499cae89b2730"
+      ],
+      "driver_ops_per_second": 17.935346901375187,
+      "server_mcp_p50_ms": 85.2522,
+      "server_mcp_p95_ms": 112.4113,
+      "operation_p50_ms": 9.0972,
+      "operation_p95_ms": 12.281,
+      "http_attempt_totals": {},
+      "http_status_totals": {},
+      "retries": 0,
+      "error_spans": 0,
+      "mean_phase_ms": {
+        "caldav.query.phase.snapshot_lookup": 0.129071875,
+        "caldav.query.phase.page_admission": 3.9216104166666668
+      },
+      "representative_trace_ids": [
+        "e3d6434cb41478ba572dbde91ed67fbe",
+        "f09686d54e367c293efb9a05b8d4f9a9",
+        "171dcf9e6719e579f45a0caef65bd9da"
+      ]
+    },
+    {
+      "label": "baseline",
+      "tool": "todos.query",
+      "mode": "continue",
+      "size": 200,
+      "concurrency": 2,
+      "n": 96,
+      "p50_ms": 99.125996,
+      "p95_ms": 188.743471,
+      "p99_descriptive_ms": 903.88936,
+      "min_ms": 57.929399,
+      "max_ms": 903.88936,
+      "block_p95_ms": {
+        "0": 142.23672,
+        "1": 667.478872,
+        "2": 173.462013
+      },
+      "errors": 0,
+      "timeouts": 0,
+      "mean_cpu_ms": 168.22916666666669,
+      "max_rss_bytes": 187645952,
+      "serial_service_ops_per_second": 7.994695930310854,
+      "run": "continue-processes-2",
+      "topology": "processes",
+      "otlp": true,
+      "trace_matches": 96,
+      "mean_stdio_response_bytes": 146738,
+      "distinct_item_hashes": [
+        "74f73d492cc638d65e6d20cf9e485fce2ff4e7e97b9f4afba767896f6be14764"
+      ],
+      "driver_ops_per_second": 12.837720044076208,
+      "server_mcp_p50_ms": 97.0598,
+      "server_mcp_p95_ms": 185.515,
+      "operation_p50_ms": 4.38,
+      "operation_p95_ms": 15.6052,
+      "http_attempt_totals": {},
+      "http_status_totals": {},
+      "retries": 0,
+      "error_spans": 0,
+      "mean_phase_ms": {
+        "caldav.query.phase.snapshot_lookup": 0.2826885416666667,
+        "caldav.query.phase.page_admission": 3.4934052083333333
+      },
+      "representative_trace_ids": [
+        "1c1615a0b5568748f814dae4b3efcd59",
+        "124012991a092cd2e6379aca680bf91b",
+        "7144f4197529fdb049a9d1cc0226cd0a"
+      ]
+    },
+    {
+      "label": "candidate",
+      "tool": "todos.query",
+      "mode": "continue",
+      "size": 200,
+      "concurrency": 2,
+      "n": 96,
+      "p50_ms": 65.911654,
+      "p95_ms": 90.611645,
+      "p99_descriptive_ms": 95.873418,
+      "min_ms": 18.534275,
+      "max_ms": 95.873418,
+      "block_p95_ms": {
+        "0": 76.248007,
+        "1": 71.487389,
+        "2": 92.749271
+      },
+      "errors": 0,
+      "timeouts": 0,
+      "mean_cpu_ms": 72.81249999999997,
+      "max_rss_bytes": 163536896,
+      "serial_service_ops_per_second": 16.881044285272097,
+      "run": "continue-processes-2",
+      "topology": "processes",
+      "otlp": true,
+      "trace_matches": 96,
+      "mean_stdio_response_bytes": 146738,
+      "distinct_item_hashes": [
+        "74f73d492cc638d65e6d20cf9e485fce2ff4e7e97b9f4afba767896f6be14764"
+      ],
+      "driver_ops_per_second": 25.219327208435125,
+      "server_mcp_p50_ms": 64.4332,
+      "server_mcp_p95_ms": 88.8031,
+      "operation_p50_ms": 4.949,
+      "operation_p95_ms": 7.5158,
+      "http_attempt_totals": {},
+      "http_status_totals": {},
+      "retries": 0,
+      "error_spans": 0,
+      "mean_phase_ms": {
+        "caldav.query.phase.snapshot_lookup": 0.12749375,
+        "caldav.query.phase.page_admission": 2.6837989583333335
+      },
+      "representative_trace_ids": [
+        "87c3e5ade2afd471dadc997fd864b651",
+        "4f3d9a7a5165a17cc19888596d6e3926",
+        "3c7b81cc0dedb55b0ba68878c7abeb32"
+      ]
+    },
+    {
+      "label": "baseline",
+      "tool": "calendar_entities.query",
+      "mode": "continue",
+      "size": 200,
+      "concurrency": 4,
+      "n": 96,
+      "p50_ms": 299.877203,
+      "p95_ms": 331.256663,
+      "p99_descriptive_ms": 341.981137,
+      "min_ms": 247.292564,
+      "max_ms": 341.981137,
+      "block_p95_ms": {
+        "0": 331.256663,
+        "1": 341.147958,
+        "2": 321.484597
+      },
+      "errors": 0,
+      "timeouts": 0,
+      "mean_cpu_ms": 293.2291666666667,
+      "max_rss_bytes": 262971392,
+      "serial_service_ops_per_second": 3.3445931372319198,
+      "run": "continue-processes-4",
+      "topology": "processes",
+      "otlp": true,
+      "trace_matches": 96,
+      "mean_stdio_response_bytes": 576124,
+      "distinct_item_hashes": [
+        "15595ffd23c0a8f21585e72c079e7bd33c76c0503d496f885ed2b27f41ba80cf"
+      ],
+      "driver_ops_per_second": 12.187512151925569,
+      "server_mcp_p50_ms": 283.6983,
+      "server_mcp_p95_ms": 312.0833,
+      "operation_p50_ms": 8.8069,
+      "operation_p95_ms": 22.2515,
+      "http_attempt_totals": {},
+      "http_status_totals": {},
+      "retries": 0,
+      "error_spans": 0,
+      "mean_phase_ms": {
+        "caldav.query.phase.snapshot_lookup": 0.13079166666666667,
+        "caldav.query.phase.page_admission": 5.409930208333333
+      },
+      "representative_trace_ids": [
+        "60654565a254d9d17452a03011731c8e",
+        "c7a61bf661dbd9744bc68b60a447e33c",
+        "3a632c3ed6bdff1578eb973e71a3003e"
+      ]
+    },
+    {
+      "label": "candidate",
+      "tool": "calendar_entities.query",
+      "mode": "continue",
+      "size": 200,
+      "concurrency": 4,
+      "n": 96,
+      "p50_ms": 97.451295,
+      "p95_ms": 123.140665,
+      "p99_descriptive_ms": 143.533915,
+      "min_ms": 71.61916,
+      "max_ms": 143.533915,
+      "block_p95_ms": {
+        "0": 123.140665,
+        "1": 121.809215,
+        "2": 127.914217
+      },
+      "errors": 0,
+      "timeouts": 0,
+      "mean_cpu_ms": 80.62500000000004,
+      "max_rss_bytes": 194940928,
+      "serial_service_ops_per_second": 10.299387787149186,
+      "run": "continue-processes-4",
+      "topology": "processes",
+      "otlp": true,
+      "trace_matches": 96,
+      "mean_stdio_response_bytes": 576124,
+      "distinct_item_hashes": [
+        "15595ffd23c0a8f21585e72c079e7bd33c76c0503d496f885ed2b27f41ba80cf"
+      ],
+      "driver_ops_per_second": 31.96784345036974,
+      "server_mcp_p50_ms": 80.4228,
+      "server_mcp_p95_ms": 108.2992,
+      "operation_p50_ms": 9.3763,
+      "operation_p95_ms": 11.8125,
+      "http_attempt_totals": {},
+      "http_status_totals": {},
+      "retries": 0,
+      "error_spans": 0,
+      "mean_phase_ms": {
+        "caldav.query.phase.snapshot_lookup": 0.12847291666666666,
+        "caldav.query.phase.page_admission": 4.0706927083333335
+      },
+      "representative_trace_ids": [
+        "7a953f847ab3a4c5ffec21c4e4af9111",
+        "f0a323c7f0987d5eb328d9baf858c168",
+        "2ed273cde2be5daf36921c053764a5bf"
+      ]
+    },
+    {
+      "label": "baseline",
+      "tool": "calendar_occurrences.query",
+      "mode": "continue",
+      "size": 200,
+      "concurrency": 4,
+      "n": 96,
+      "p50_ms": 448.374098,
+      "p95_ms": 508.532904,
+      "p99_descriptive_ms": 531.871134,
+      "min_ms": 382.241181,
+      "max_ms": 531.871134,
+      "block_p95_ms": {
+        "0": 462.13824,
+        "1": 513.713879,
+        "2": 506.496927
+      },
+      "errors": 0,
+      "timeouts": 0,
+      "mean_cpu_ms": 436.04166666666674,
+      "max_rss_bytes": 335437824,
+      "serial_service_ops_per_second": 2.21860922393149,
+      "run": "continue-processes-4",
+      "topology": "processes",
+      "otlp": true,
+      "trace_matches": 96,
+      "mean_stdio_response_bytes": 742403,
+      "distinct_item_hashes": [
+        "3e933bc895d8c7ea816e7be018ddf32119e347573589f9f6155499cae89b2730"
+      ],
+      "driver_ops_per_second": 8.162863298293308,
+      "server_mcp_p50_ms": 434.695,
+      "server_mcp_p95_ms": 476.3528,
+      "operation_p50_ms": 10.5651,
+      "operation_p95_ms": 18.4565,
+      "http_attempt_totals": {},
+      "http_status_totals": {},
+      "retries": 0,
+      "error_spans": 0,
+      "mean_phase_ms": {
+        "caldav.query.phase.snapshot_lookup": 0.138309375,
+        "caldav.query.phase.page_admission": 5.106035416666667
+      },
+      "representative_trace_ids": [
+        "462381cbe2f395292301633ce8dfe5a7",
+        "d8fa4fba1ea2c1a19e1c0eabbc2dff11",
+        "4e1203fe92242caedb5cd52d447c8043"
+      ]
+    },
+    {
+      "label": "candidate",
+      "tool": "calendar_occurrences.query",
+      "mode": "continue",
+      "size": 200,
+      "concurrency": 4,
+      "n": 96,
+      "p50_ms": 137.000988,
+      "p95_ms": 176.124434,
+      "p99_descriptive_ms": 197.114018,
+      "min_ms": 102.194187,
+      "max_ms": 197.114018,
+      "block_p95_ms": {
+        "0": 174.610548,
+        "1": 180.343538,
+        "2": 173.966745
+      },
+      "errors": 0,
+      "timeouts": 0,
+      "mean_cpu_ms": 106.14583333333333,
+      "max_rss_bytes": 212140032,
+      "serial_service_ops_per_second": 7.365062056423645,
+      "run": "continue-processes-4",
+      "topology": "processes",
+      "otlp": true,
+      "trace_matches": 96,
+      "mean_stdio_response_bytes": 742403,
+      "distinct_item_hashes": [
+        "3e933bc895d8c7ea816e7be018ddf32119e347573589f9f6155499cae89b2730"
+      ],
+      "driver_ops_per_second": 23.099521527627722,
+      "server_mcp_p50_ms": 113.3305,
+      "server_mcp_p95_ms": 161.2318,
+      "operation_p50_ms": 11.4911,
+      "operation_p95_ms": 13.5545,
+      "http_attempt_totals": {},
+      "http_status_totals": {},
+      "retries": 0,
+      "error_spans": 0,
+      "mean_phase_ms": {
+        "caldav.query.phase.snapshot_lookup": 0.13938958333333334,
+        "caldav.query.phase.page_admission": 4.718777083333333
+      },
+      "representative_trace_ids": [
+        "87ab6cfac50bc8cb4e7ed4035f091d10",
+        "270da941a47054a7c5f03302ff8447b6",
+        "f826a6d4c6f350ef172ce769bc98bebc"
+      ]
+    },
+    {
+      "label": "baseline",
+      "tool": "todos.query",
+      "mode": "continue",
+      "size": 200,
+      "concurrency": 4,
+      "n": 96,
+      "p50_ms": 101.46882,
+      "p95_ms": 177.934245,
+      "p99_descriptive_ms": 191.043685,
+      "min_ms": 78.654438,
+      "max_ms": 191.043685,
+      "block_p95_ms": {
+        "0": 178.726459,
+        "1": 177.6837,
+        "2": 180.950262
+      },
+      "errors": 0,
+      "timeouts": 0,
+      "mean_cpu_ms": 137.3958333333333,
+      "max_rss_bytes": 192118784,
+      "serial_service_ops_per_second": 8.763931755856808,
+      "run": "continue-processes-4",
+      "topology": "processes",
+      "otlp": true,
+      "trace_matches": 96,
+      "mean_stdio_response_bytes": 146738,
+      "distinct_item_hashes": [
+        "74f73d492cc638d65e6d20cf9e485fce2ff4e7e97b9f4afba767896f6be14764"
+      ],
+      "driver_ops_per_second": 23.42144521686148,
+      "server_mcp_p50_ms": 98.8345,
+      "server_mcp_p95_ms": 175.8382,
+      "operation_p50_ms": 3.8619,
+      "operation_p95_ms": 16.8374,
+      "http_attempt_totals": {},
+      "http_status_totals": {},
+      "retries": 0,
+      "error_spans": 0,
+      "mean_phase_ms": {
+        "caldav.query.phase.snapshot_lookup": 0.12768854166666666,
+        "caldav.query.phase.page_admission": 4.15415
+      },
+      "representative_trace_ids": [
+        "6e8da19d2106802da8060343d7a384ba",
+        "2e83db930b54fe563507fbc295988135",
+        "2d7b3609946d6b7c5ee87f3821d529f0"
+      ]
+    },
+    {
+      "label": "candidate",
+      "tool": "todos.query",
+      "mode": "continue",
+      "size": 200,
+      "concurrency": 4,
+      "n": 96,
+      "p50_ms": 31.647089,
+      "p95_ms": 95.662214,
+      "p99_descriptive_ms": 97.336694,
+      "min_ms": 23.768787,
+      "max_ms": 97.336694,
+      "block_p95_ms": {
+        "0": 96.945451,
+        "1": 92.375044,
+        "2": 95.662214
+      },
+      "errors": 0,
+      "timeouts": 0,
+      "mean_cpu_ms": 60.31250000000001,
+      "max_rss_bytes": 165675008,
+      "serial_service_ops_per_second": 21.70545999234025,
+      "run": "continue-processes-4",
+      "topology": "processes",
+      "otlp": true,
+      "trace_matches": 96,
+      "mean_stdio_response_bytes": 146738,
+      "distinct_item_hashes": [
+        "74f73d492cc638d65e6d20cf9e485fce2ff4e7e97b9f4afba767896f6be14764"
+      ],
+      "driver_ops_per_second": 41.61370536982929,
+      "server_mcp_p50_ms": 28.8844,
+      "server_mcp_p95_ms": 93.6845,
+      "operation_p50_ms": 4.0967,
+      "operation_p95_ms": 8.5252,
+      "http_attempt_totals": {},
+      "http_status_totals": {},
+      "retries": 0,
+      "error_spans": 0,
+      "mean_phase_ms": {
+        "caldav.query.phase.snapshot_lookup": 0.14069166666666666,
+        "caldav.query.phase.page_admission": 2.826465625
+      },
+      "representative_trace_ids": [
+        "a61a109bc2856f251471059cf589a71b",
+        "0fb079bc6003d1123dafc4f1a1a4a468",
+        "038174ca24760d67f6288ff45aaae89e"
+      ]
+    },
+    {
+      "label": "baseline",
+      "tool": "calendar_entities.query",
+      "mode": "continue",
+      "size": 200,
+      "concurrency": 1,
+      "n": 90,
+      "p50_ms": 71.377022,
+      "p95_ms": 78.122899,
+      "p99_descriptive_ms": 85.117324,
+      "min_ms": 66.650429,
+      "max_ms": 85.117324,
+      "block_p95_ms": {
+        "0": 74.048041,
+        "1": 78.88841,
+        "2": 76.590855
+      },
+      "errors": 0,
+      "timeouts": 0,
+      "mean_cpu_ms": 90.4444444444445,
+      "max_rss_bytes": 193343488,
+      "serial_service_ops_per_second": 13.902080843719732,
+      "run": "otlp-overhead",
+      "topology": "single_session",
+      "otlp": true,
+      "trace_matches": 90,
+      "mean_stdio_response_bytes": 576124,
+      "distinct_item_hashes": [
+        "15595ffd23c0a8f21585e72c079e7bd33c76c0503d496f885ed2b27f41ba80cf"
+      ],
+      "driver_ops_per_second": 11.769725028512198,
+      "server_mcp_p50_ms": 65.2939,
+      "server_mcp_p95_ms": 70.4643,
+      "operation_p50_ms": 8.2125,
+      "operation_p95_ms": 11.6108,
+      "http_attempt_totals": {},
+      "http_status_totals": {},
+      "retries": 0,
+      "error_spans": 0,
+      "mean_phase_ms": {
+        "caldav.query.phase.snapshot_lookup": 0.14113555555555554,
+        "caldav.query.phase.page_admission": 3.724298888888889
+      },
+      "representative_trace_ids": [
+        "e2390e41fde301943d36fa61498dd0ad",
+        "f92f0ea6647a19cee8a6c45df9731680",
+        "592d8051da5d1d50b761f2a186bca58a"
+      ]
+    },
+    {
+      "label": "candidate",
+      "tool": "calendar_entities.query",
+      "mode": "continue",
+      "size": 200,
+      "concurrency": 1,
+      "n": 90,
+      "p50_ms": 72.18233,
+      "p95_ms": 76.029622,
+      "p99_descriptive_ms": 78.906016,
+      "min_ms": 67.137538,
+      "max_ms": 78.906016,
+      "block_p95_ms": {
+        "0": 76.76754,
+        "1": 75.713468,
+        "2": 75.804574
+      },
+      "errors": 0,
+      "timeouts": 0,
+      "mean_cpu_ms": 82.22222222222224,
+      "max_rss_bytes": 185425920,
+      "serial_service_ops_per_second": 13.849371986370212,
+      "run": "otlp-overhead",
+      "topology": "single_session",
+      "otlp": false,
+      "trace_matches": 0,
+      "mean_stdio_response_bytes": 576124,
+      "distinct_item_hashes": [
+        "15595ffd23c0a8f21585e72c079e7bd33c76c0503d496f885ed2b27f41ba80cf"
+      ],
+      "driver_ops_per_second": 11.720305751554163
+    },
+    {
+      "label": "baseline",
+      "tool": "calendar_occurrences.query",
+      "mode": "continue",
+      "size": 200,
+      "concurrency": 1,
+      "n": 90,
+      "p50_ms": 99.751093,
+      "p95_ms": 106.189137,
+      "p99_descriptive_ms": 116.954716,
+      "min_ms": 92.288094,
+      "max_ms": 116.954716,
+      "block_p95_ms": {
+        "0": 105.944028,
+        "1": 104.912406,
+        "2": 106.902769
+      },
+      "errors": 0,
+      "timeouts": 0,
+      "mean_cpu_ms": 109.44444444444447,
+      "max_rss_bytes": 206131200,
+      "serial_service_ops_per_second": 9.988185480353556,
+      "run": "otlp-overhead",
+      "topology": "single_session",
+      "otlp": true,
+      "trace_matches": 90,
+      "mean_stdio_response_bytes": 742403,
+      "distinct_item_hashes": [
+        "3e933bc895d8c7ea816e7be018ddf32119e347573589f9f6155499cae89b2730"
+      ],
+      "driver_ops_per_second": 8.511159361913785,
+      "server_mcp_p50_ms": 91.9649,
+      "server_mcp_p95_ms": 96.6694,
+      "operation_p50_ms": 10.2645,
+      "operation_p95_ms": 12.7177,
+      "http_attempt_totals": {},
+      "http_status_totals": {},
+      "retries": 0,
+      "error_spans": 0,
+      "mean_phase_ms": {
+        "caldav.query.phase.snapshot_lookup": 0.1431888888888889,
+        "caldav.query.phase.page_admission": 4.549836666666667
+      },
+      "representative_trace_ids": [
+        "3f2896c5b43f5324554721dba43fda15",
+        "94de1dc64064be45364ab5560473e03a",
+        "5237376782ccd1a2d846b75af80e59f2"
+      ]
+    },
+    {
+      "label": "candidate",
+      "tool": "calendar_occurrences.query",
+      "mode": "continue",
+      "size": 200,
+      "concurrency": 1,
+      "n": 90,
+      "p50_ms": 99.02166,
+      "p95_ms": 105.436237,
+      "p99_descriptive_ms": 138.598183,
+      "min_ms": 91.383905,
+      "max_ms": 138.598183,
+      "block_p95_ms": {
+        "0": 102.619285,
+        "1": 99.199779,
+        "2": 120.668756
+      },
+      "errors": 0,
+      "timeouts": 0,
+      "mean_cpu_ms": 103.77777777777777,
+      "max_rss_bytes": 199741440,
+      "serial_service_ops_per_second": 10.065417063516938,
+      "run": "otlp-overhead",
+      "topology": "single_session",
+      "otlp": false,
+      "trace_matches": 0,
+      "mean_stdio_response_bytes": 742403,
+      "distinct_item_hashes": [
+        "3e933bc895d8c7ea816e7be018ddf32119e347573589f9f6155499cae89b2730"
+      ],
+      "driver_ops_per_second": 8.554586146611127
+    },
+    {
+      "label": "baseline",
+      "tool": "todos.query",
+      "mode": "continue",
+      "size": 200,
+      "concurrency": 1,
+      "n": 90,
+      "p50_ms": 88.795634,
+      "p95_ms": 96.605529,
+      "p99_descriptive_ms": 99.011818,
+      "min_ms": 73.160039,
+      "max_ms": 99.011818,
+      "block_p95_ms": {
+        "0": 98.396292,
+        "1": 93.831733,
+        "2": 95.768625
+      },
+      "errors": 0,
+      "timeouts": 0,
+      "mean_cpu_ms": 119.0,
+      "max_rss_bytes": 164466688,
+      "serial_service_ops_per_second": 11.343695170178497,
+      "run": "otlp-overhead",
+      "topology": "single_session",
+      "otlp": true,
+      "trace_matches": 90,
+      "mean_stdio_response_bytes": 146738,
+      "distinct_item_hashes": [
+        "74f73d492cc638d65e6d20cf9e485fce2ff4e7e97b9f4afba767896f6be14764"
+      ],
+      "driver_ops_per_second": 10.888829795559106,
+      "server_mcp_p50_ms": 86.9334,
+      "server_mcp_p95_ms": 93.9738,
+      "operation_p50_ms": 7.2429,
+      "operation_p95_ms": 9.8531,
+      "http_attempt_totals": {},
+      "http_status_totals": {},
+      "retries": 0,
+      "error_spans": 0,
+      "mean_phase_ms": {
+        "caldav.query.phase.snapshot_lookup": 0.14132777777777777,
+        "caldav.query.phase.page_admission": 3.948672222222222
+      },
+      "representative_trace_ids": [
+        "7f7676aea0766ebbdf5c321286d47110",
+        "7cae74bf72d2d05e66c419c69657ae3e",
+        "35542432a630329bd107ab3c14859084"
+      ]
+    },
+    {
+      "label": "candidate",
+      "tool": "todos.query",
+      "mode": "continue",
+      "size": 200,
+      "concurrency": 1,
+      "n": 90,
+      "p50_ms": 80.940744,
+      "p95_ms": 95.66709,
+      "p99_descriptive_ms": 102.930256,
+      "min_ms": 26.362727,
+      "max_ms": 102.930256,
+      "block_p95_ms": {
+        "0": 90.643153,
+        "1": 93.202513,
+        "2": 100.706755
+      },
+      "errors": 0,
+      "timeouts": 0,
+      "mean_cpu_ms": 111.00000000000001,
+      "max_rss_bytes": 162721792,
+      "serial_service_ops_per_second": 12.920489160066559,
+      "run": "otlp-overhead",
+      "topology": "single_session",
+      "otlp": false,
+      "trace_matches": 0,
+      "mean_stdio_response_bytes": 146738,
+      "distinct_item_hashes": [
+        "74f73d492cc638d65e6d20cf9e485fce2ff4e7e97b9f4afba767896f6be14764"
+      ],
+      "driver_ops_per_second": 12.316885164211055
+    }
+  ],
+  "processes": [
+    {
+      "run": "continue-serial",
+      "label": "baseline",
+      "processes": 9,
+      "startup_p50_ms": 444.316957,
+      "startup_p95_ms": 488.115595,
+      "shutdown_max_ms": 56.080431,
+      "assembly_sha256": [
+        "e1244b5028bd678066f5a5457b807ba16de75fa7b8937d075c48190fb337ee81"
+      ],
+      "negotiated_versions": [
+        "2026-07-28"
+      ]
+    },
+    {
+      "run": "continue-serial",
+      "label": "candidate",
+      "processes": 9,
+      "startup_p50_ms": 447.89582,
+      "startup_p95_ms": 474.158994,
+      "shutdown_max_ms": 61.923378,
+      "assembly_sha256": [
+        "1885c568a2460993e464c24b358ceb6f4ee8b102f76f3104bfc9e16af8fc1068"
+      ],
+      "negotiated_versions": [
+        "2026-07-28"
+      ]
+    },
+    {
+      "run": "start-serial-bounded",
+      "label": "baseline",
+      "processes": 54,
+      "startup_p50_ms": 480.760078,
+      "startup_p95_ms": 495.373344,
+      "shutdown_max_ms": 94.962944,
+      "assembly_sha256": [
+        "e1244b5028bd678066f5a5457b807ba16de75fa7b8937d075c48190fb337ee81"
+      ],
+      "negotiated_versions": [
+        "2026-07-28"
+      ]
+    },
+    {
+      "run": "start-serial-bounded",
+      "label": "candidate",
+      "processes": 54,
+      "startup_p50_ms": 477.320006,
+      "startup_p95_ms": 498.870014,
+      "shutdown_max_ms": 63.121621,
+      "assembly_sha256": [
+        "1885c568a2460993e464c24b358ceb6f4ee8b102f76f3104bfc9e16af8fc1068"
+      ],
+      "negotiated_versions": [
+        "2026-07-28"
+      ]
+    },
+    {
+      "run": "continue-single_session-2",
+      "label": "baseline",
+      "processes": 9,
+      "startup_p50_ms": 482.615211,
+      "startup_p95_ms": 636.289237,
+      "shutdown_max_ms": 68.021534,
+      "assembly_sha256": [
+        "e1244b5028bd678066f5a5457b807ba16de75fa7b8937d075c48190fb337ee81"
+      ],
+      "negotiated_versions": [
+        "2026-07-28"
+      ]
+    },
+    {
+      "run": "continue-single_session-2",
+      "label": "candidate",
+      "processes": 9,
+      "startup_p50_ms": 477.353003,
+      "startup_p95_ms": 484.04317,
+      "shutdown_max_ms": 62.153732,
+      "assembly_sha256": [
+        "1885c568a2460993e464c24b358ceb6f4ee8b102f76f3104bfc9e16af8fc1068"
+      ],
+      "negotiated_versions": [
+        "2026-07-28"
+      ]
+    },
+    {
+      "run": "continue-single_session-4",
+      "label": "baseline",
+      "processes": 9,
+      "startup_p50_ms": 476.618556,
+      "startup_p95_ms": 488.511052,
+      "shutdown_max_ms": 84.888338,
+      "assembly_sha256": [
+        "e1244b5028bd678066f5a5457b807ba16de75fa7b8937d075c48190fb337ee81"
+      ],
+      "negotiated_versions": [
+        "2026-07-28"
+      ]
+    },
+    {
+      "run": "continue-single_session-4",
+      "label": "candidate",
+      "processes": 9,
+      "startup_p50_ms": 482.958404,
+      "startup_p95_ms": 488.577582,
+      "shutdown_max_ms": 74.433951,
+      "assembly_sha256": [
+        "1885c568a2460993e464c24b358ceb6f4ee8b102f76f3104bfc9e16af8fc1068"
+      ],
+      "negotiated_versions": [
+        "2026-07-28"
+      ]
+    },
+    {
+      "run": "continue-processes-2",
+      "label": "baseline",
+      "processes": 18,
+      "startup_p50_ms": 483.103237,
+      "startup_p95_ms": 1346.302986,
+      "shutdown_max_ms": 129.124088,
+      "assembly_sha256": [
+        "e1244b5028bd678066f5a5457b807ba16de75fa7b8937d075c48190fb337ee81"
+      ],
+      "negotiated_versions": [
+        "2026-07-28"
+      ]
+    },
+    {
+      "run": "continue-processes-2",
+      "label": "candidate",
+      "processes": 18,
+      "startup_p50_ms": 482.118299,
+      "startup_p95_ms": 658.486045,
+      "shutdown_max_ms": 78.035447,
+      "assembly_sha256": [
+        "1885c568a2460993e464c24b358ceb6f4ee8b102f76f3104bfc9e16af8fc1068"
+      ],
+      "negotiated_versions": [
+        "2026-07-28"
+      ]
+    },
+    {
+      "run": "continue-processes-4",
+      "label": "baseline",
+      "processes": 36,
+      "startup_p50_ms": 652.259663,
+      "startup_p95_ms": 686.459243,
+      "shutdown_max_ms": 89.199583,
+      "assembly_sha256": [
+        "e1244b5028bd678066f5a5457b807ba16de75fa7b8937d075c48190fb337ee81"
+      ],
+      "negotiated_versions": [
+        "2026-07-28"
+      ]
+    },
+    {
+      "run": "continue-processes-4",
+      "label": "candidate",
+      "processes": 36,
+      "startup_p50_ms": 649.887739,
+      "startup_p95_ms": 682.53867,
+      "shutdown_max_ms": 83.738274,
+      "assembly_sha256": [
+        "1885c568a2460993e464c24b358ceb6f4ee8b102f76f3104bfc9e16af8fc1068"
+      ],
+      "negotiated_versions": [
+        "2026-07-28"
+      ]
+    },
+    {
+      "run": "otlp-overhead",
+      "label": "baseline",
+      "processes": 9,
+      "startup_p50_ms": 631.410129,
+      "startup_p95_ms": 664.729571,
+      "shutdown_max_ms": 102.673892,
+      "assembly_sha256": [
+        "1885c568a2460993e464c24b358ceb6f4ee8b102f76f3104bfc9e16af8fc1068"
+      ],
+      "negotiated_versions": [
+        "2026-07-28"
+      ]
+    },
+    {
+      "run": "otlp-overhead",
+      "label": "candidate",
+      "processes": 9,
+      "startup_p50_ms": 537.16746,
+      "startup_p95_ms": 590.955168,
+      "shutdown_max_ms": 38.133702,
+      "assembly_sha256": [
+        "1885c568a2460993e464c24b358ceb6f4ee8b102f76f3104bfc9e16af8fc1068"
+      ],
+      "negotiated_versions": [
+        "2026-07-28"
+      ]
+    }
+  ],
+  "schema_guard": [
+    {
+      "label": "baseline",
+      "n": 100,
+      "payload_sha256": "0928dbadb37cc84a1eb8433de8b0b87cfef25b017fb91f0645341f93490817ac",
+      "median_ms": 244.99835000000002,
+      "median_allocated_bytes": 168909200.0,
+      "gc_collections": {
+        "gen0": 2204,
+        "gen1": 1208,
+        "gen2": 216
+      }
+    },
+    {
+      "label": "candidate",
+      "n": 100,
+      "payload_sha256": "0928dbadb37cc84a1eb8433de8b0b87cfef25b017fb91f0645341f93490817ac",
+      "median_ms": 50.50575,
+      "median_allocated_bytes": 94049464.0,
+      "gc_collections": {
+        "gen0": 1125,
+        "gen1": 0,
+        "gen2": 0
+      }
+    }
+  ],
+  "gates": {
+    "alternate-time-zone.trx": {
+      "total": "11",
+      "executed": "11",
+      "passed": "11",
+      "failed": "0",
+      "error": "0",
+      "timeout": "0",
+      "aborted": "0",
+      "inconclusive": "0",
+      "passedButRunAborted": "0",
+      "notRunnable": "0",
+      "notExecuted": "0",
+      "disconnected": "0",
+      "warning": "0",
+      "completed": "0",
+      "inProgress": "0",
+      "pending": "0"
+    },
+    "main-core.trx": {
+      "total": "2421",
+      "executed": "2421",
+      "passed": "2421",
+      "failed": "0",
+      "error": "0",
+      "timeout": "0",
+      "aborted": "0",
+      "inconclusive": "0",
+      "passedButRunAborted": "0",
+      "notRunnable": "0",
+      "notExecuted": "0",
+      "disconnected": "0",
+      "warning": "0",
+      "completed": "0",
+      "inProgress": "0",
+      "pending": "0"
+    },
+    "main-integration.trx": {
+      "total": "114",
+      "executed": "114",
+      "passed": "114",
+      "failed": "0",
+      "error": "0",
+      "timeout": "0",
+      "aborted": "0",
+      "inconclusive": "0",
+      "passedButRunAborted": "0",
+      "notRunnable": "0",
+      "notExecuted": "0",
+      "disconnected": "0",
+      "warning": "0",
+      "completed": "0",
+      "inProgress": "0",
+      "pending": "0"
+    },
+    "main-mcp.trx": {
+      "total": "1035",
+      "executed": "1035",
+      "passed": "1035",
+      "failed": "0",
+      "error": "0",
+      "timeout": "0",
+      "aborted": "0",
+      "inconclusive": "0",
+      "passedButRunAborted": "0",
+      "notRunnable": "0",
+      "notExecuted": "0",
+      "disconnected": "0",
+      "warning": "0",
+      "completed": "0",
+      "inProgress": "0",
+      "pending": "0"
+    },
+    "strict-preconditions.trx": {
+      "total": "11",
+      "executed": "11",
+      "passed": "11",
+      "failed": "0",
+      "error": "0",
+      "timeout": "0",
+      "aborted": "0",
+      "inconclusive": "0",
+      "passedButRunAborted": "0",
+      "notRunnable": "0",
+      "notExecuted": "0",
+      "disconnected": "0",
+      "warning": "0",
+      "completed": "0",
+      "inProgress": "0",
+      "pending": "0"
+    }
+  },
+  "coverage": {
+    "line-rate": "0.9449209327258108",
+    "branch-rate": "0.8604884337176825",
+    "lines-covered": "21153",
+    "lines-valid": "22386",
+    "branches-covered": "12015",
+    "branches-valid": "13963"
+  },
+  "environment": {
+    "sdk": "10.0.100",
+    "runtime": "10.0.0",
+    "os": "Linux 7.2.2-1-cachyos x64",
+    "cpu": "AMD Ryzen 7 7735HS",
+    "logical_cpus": 16,
+    "ram_gib": 30.59,
+    "docker": "29.7.2 rootless",
+    "container_cpu_limit": 4,
+    "container_memory_bytes": 2147483648,
+    "shared_workstation": true
+  },
+  "images": {
+    "radicale": "ghcr.io/kozea/radicale@sha256:3a0080ea51ac69dcd74e345b9587dc14a8c8af0652046069005749f9a75c5c80",
+    "dashboard": "mcr.microsoft.com/dotnet/aspire-dashboard:13.4.2@sha256:76d05882595dd43e708d6ef3e269d98ca763694c0c822bbe98edc99790eaad1b"
+  },
+  "hermes": {
+    "agent_version": "0.21.0",
+    "source_revision": "b0ab2e16",
+    "model": "openai/gpt-5.6-luna",
+    "provider": "openrouter",
+    "reasoning": "medium",
+    "call_count": 14,
+    "protocol_versions": [
+      "2025-11-25",
+      "2026-07-28"
+    ],
+    "calls": [
+      {
+        "tool": "calendars.list",
+        "cursor_call": false,
+        "continuing": false,
+        "outcome": "success"
+      },
+      {
+        "tool": "calendar_entities.query",
+        "cursor_call": false,
+        "continuing": false,
+        "outcome": "success"
+      },
+      {
+        "tool": "calendar_entities.query",
+        "cursor_call": true,
+        "continuing": false,
+        "outcome": "success"
+      },
+      {
+        "tool": "calendar_occurrences.query",
+        "cursor_call": false,
+        "continuing": false,
+        "outcome": "success"
+      },
+      {
+        "tool": "calendar_occurrences.query",
+        "cursor_call": true,
+        "continuing": false,
+        "outcome": "success"
+      },
+      {
+        "tool": "todos.query",
+        "cursor_call": false,
+        "continuing": false,
+        "outcome": "success"
+      },
+      {
+        "tool": "todos.query",
+        "cursor_call": true,
+        "continuing": false,
+        "outcome": "success"
+      },
+      {
+        "tool": "todos.create",
+        "cursor_call": false,
+        "continuing": false,
+        "outcome": "success"
+      },
+      {
+        "tool": "calendar_resources.get",
+        "cursor_call": false,
+        "continuing": false,
+        "outcome": "success"
+      },
+      {
+        "tool": "todos.patch",
+        "cursor_call": false,
+        "continuing": false,
+        "outcome": "success"
+      },
+      {
+        "tool": "calendar_resources.get",
+        "cursor_call": false,
+        "continuing": false,
+        "outcome": "success"
+      },
+      {
+        "tool": "todos.complete",
+        "cursor_call": false,
+        "continuing": false,
+        "outcome": "success"
+      },
+      {
+        "tool": "calendar_resources.get",
+        "cursor_call": false,
+        "continuing": false,
+        "outcome": "success"
+      },
+      {
+        "tool": "calendar_resources.delete",
+        "cursor_call": false,
+        "continuing": false,
+        "outcome": "input_required"
+      }
+    ],
+    "catalog": [
+      "calendars.list",
+      "calendars.create",
+      "calendars.delete",
+      "calendar_entities.query",
+      "calendar_occurrences.query",
+      "todos.query",
+      "calendar_resources.get",
+      "events.create",
+      "events.patch",
+      "todos.create",
+      "todos.patch",
+      "todos.complete",
+      "calendar_occurrences.add",
+      "calendar_occurrences.exclude",
+      "calendar_occurrences.restore_exclusion",
+      "calendar_occurrences.cancel",
+      "calendar_occurrences.restore_cancellation",
+      "calendar_resources.move",
+      "calendar_resources.delete"
+    ],
+    "command": [
+      "/home/jhow/.local/share/mise/installs/dotnet/10.0.100/dotnet",
+      "/tmp/caldav-perf-20260905/candidate/DotnetAgents.CalDav.Mcp.dll"
+    ],
+    "assembly_sha256": "1885c568a2460993e464c24b358ceb6f4ee8b102f76f3104bfc9e16af8fc1068",
+    "all_calls_mapped": true,
+    "authoritative": {
+      "http_status": 207,
+      "matching_resources": 1,
+      "checks": [
+        {
+          "completed": true,
+          "summary_patched": true
+        }
+      ]
+    },
+    "mrtr": "blocked_in_hermes; completed and cleaned via direct MCP",
+    "server_stderr_bytes": 0,
+    "exit_code": 0
+  },
+  "export_completeness": {
+    "api_total": 124729,
+    "api_returned": 124729,
+    "unique_api_spans": 124729,
+    "unique_zip_spans": 124729,
+    "exact_match": true
+  },
+  "privacy": {
+    "export_files_checked": 633,
+    "credential_and_fixture_sentinels_absent": true,
+    "exception_events_absent": true
+  },
+  "validation": {
+    "build_warnings": 0,
+    "build_errors": 0,
+    "slopwatch_issues": 0,
+    "package_smoke_tests": 1,
+    "package_version": "0.0.0-perf.20260905",
+    "first_suite_failure": "Docker overlay mount device or resource busy before alternate-time-zone fixture could start; full rerun passed"
+  },
+  "functional": {
+    "catalog_count": 23,
+    "tools": [
+      {
+        "tool": "calendar_entities.query",
+        "calls": 7,
+        "outcomes": {
+          "success": 7
+        },
+        "mutation_states": [],
+        "trace_ids": [
+          "f93e3d07a5ec82b8bd234771b0755f9b",
+          "ebddf358b41a1a61295ab4933ff9d1e8",
+          "a47d7d0b3a9b2cffb651a3b56c039507",
+          "c574c5d9cd4bdfcc1f874708cbe4ba41",
+          "24b6dd72440a38f39e64b1ba8a2bdabc",
+          "f18f3cdce053038dd5d65ba15dc35342",
+          "1ae0d38ab7678a37c90efc406e05f210"
+        ],
+        "http_totals": {
+          "PROPFIND": 20,
+          "REPORT": 108
+        }
+      },
+      {
+        "tool": "calendar_occurrences.add",
+        "calls": 1,
+        "outcomes": {
+          "success": 1
+        },
+        "mutation_states": [
+          "committed"
+        ],
+        "trace_ids": [
+          "1c095c5b1abdf461f8a10ffc3e144cce"
+        ],
+        "http_totals": {
+          "PROPFIND": 5,
+          "GET": 2,
+          "PUT": 1
+        }
+      },
+      {
+        "tool": "calendar_occurrences.cancel",
+        "calls": 1,
+        "outcomes": {
+          "success": 1
+        },
+        "mutation_states": [
+          "committed"
+        ],
+        "trace_ids": [
+          "79ad9c3892c155cb65915634edc3922f"
+        ],
+        "http_totals": {
+          "PROPFIND": 5,
+          "GET": 2,
+          "PUT": 1
+        }
+      },
+      {
+        "tool": "calendar_occurrences.exclude",
+        "calls": 1,
+        "outcomes": {
+          "success": 1
+        },
+        "mutation_states": [
+          "committed"
+        ],
+        "trace_ids": [
+          "f9289d61f913903ceed026c1047e5282"
+        ],
+        "http_totals": {
+          "PROPFIND": 6,
+          "GET": 2,
+          "PUT": 1
+        }
+      },
+      {
+        "tool": "calendar_occurrences.query",
+        "calls": 6,
+        "outcomes": {
+          "success": 6
+        },
+        "mutation_states": [],
+        "trace_ids": [
+          "070d9e3644f174408ae5f2b3486a1516",
+          "7a528dfbdf1eab1b6a4f906ff699c94f",
+          "523a6f6c6482a818f4facec21a141358",
+          "44a6060ca34d0bab00dba4cc36dc3e80",
+          "35f26395587b9db94ddb464d829b4e7b",
+          "727a613e7c352ea842d1b5fab36c2ec9"
+        ],
+        "http_totals": {
+          "PROPFIND": 15,
+          "REPORT": 81
+        }
+      },
+      {
+        "tool": "calendar_occurrences.restore_cancellation",
+        "calls": 1,
+        "outcomes": {
+          "success": 1
+        },
+        "mutation_states": [
+          "committed"
+        ],
+        "trace_ids": [
+          "35d6f6f2441be9f7c8d70c3d56612ab0"
+        ],
+        "http_totals": {
+          "PROPFIND": 5,
+          "GET": 2,
+          "PUT": 1
+        }
+      },
+      {
+        "tool": "calendar_occurrences.restore_exclusion",
+        "calls": 1,
+        "outcomes": {
+          "success": 1
+        },
+        "mutation_states": [
+          "committed"
+        ],
+        "trace_ids": [
+          "1c2df11609ea128db0ae241390ccd40a"
+        ],
+        "http_totals": {
+          "PROPFIND": 5,
+          "GET": 2,
+          "PUT": 1
+        }
+      },
+      {
+        "tool": "calendar_resources.delete",
+        "calls": 6,
+        "outcomes": {
+          "input_required": 3,
+          "success": 3
+        },
+        "mutation_states": [
+          "committed"
+        ],
+        "trace_ids": [
+          "e05f9762d49193e6ef0e3102cbc44d59",
+          "f86e4bf79df2b9d9bc9dc29c6eb96f9f",
+          "c8a9b7d172a51a029234b0b53427c013",
+          "b8e69c74d516dfd8522c5122726b0361",
+          "ad04451d211ab6aa92a87b5b8e70674b",
+          "70567a58bf4fa28fc5ad047fc4e2a0cf"
+        ],
+        "http_totals": {
+          "PROPFIND": 30,
+          "GET": 12,
+          "DELETE": 3
+        }
+      },
+      {
+        "tool": "calendar_resources.exact_create",
+        "calls": 2,
+        "outcomes": {
+          "input_required": 1,
+          "success": 1
+        },
+        "mutation_states": [
+          "committed"
+        ],
+        "trace_ids": [
+          "da334faa7f0156487f594e0e4d022c80",
+          "715862e3a1fbd472406622cf1e8df9ae"
+        ],
+        "http_totals": {
+          "PROPFIND": 10,
+          "GET": 3,
+          "PUT": 1
+        }
+      },
+      {
+        "tool": "calendar_resources.exact_get",
+        "calls": 1,
+        "outcomes": {
+          "success": 1
+        },
+        "mutation_states": [],
+        "trace_ids": [
+          "bab639a87fd2d11e70bbce87344a1cbc"
+        ],
+        "http_totals": {
+          "PROPFIND": 5,
+          "GET": 1
+        }
+      },
+      {
+        "tool": "calendar_resources.exact_move",
+        "calls": 2,
+        "outcomes": {
+          "input_required": 1,
+          "success": 1
+        },
+        "mutation_states": [
+          "committed"
+        ],
+        "trace_ids": [
+          "4a9b0df001d1066d2592ceb3c0f22e93",
+          "42b3b464112a34736330aa7e62e828cb"
+        ],
+        "http_totals": {
+          "PROPFIND": 11,
+          "GET": 6,
+          "MOVE": 1
+        }
+      },
+      {
+        "tool": "calendar_resources.exact_replace",
+        "calls": 2,
+        "outcomes": {
+          "input_required": 1,
+          "success": 1
+        },
+        "mutation_states": [
+          "committed"
+        ],
+        "trace_ids": [
+          "7a6993af0dff0592ecabee025da588a6",
+          "c51f24f281b349c8024e01f2dab65a16"
+        ],
+        "http_totals": {
+          "PROPFIND": 15,
+          "GET": 4,
+          "PUT": 1
+        }
+      },
+      {
+        "tool": "calendar_resources.get",
+        "calls": 16,
+        "outcomes": {
+          "success": 16
+        },
+        "mutation_states": [],
+        "trace_ids": [
+          "885f6f9fa2bd1bd9d2660845b35c501a",
+          "de760d0ca543584ade1321a22566239b",
+          "8909c06ca3661887af62fd81c9de4e03",
+          "f68db065f5177bf95008cdf82ce01d95",
+          "08114de6bf885a33da9a51bcafcde222",
+          "03cc107f049d3f3afc2edb312c55dc7a",
+          "842aa23bad577535072f78a629a868bf",
+          "6237dcc201f505b322c9ae5e8ff0494b",
+          "4ffcbf20e141c027be09848e5bfa64a9",
+          "b3c6e81486106f3c1cf41b025d4c6598",
+          "cedeb0a283d7d6fbf108fc635b189979",
+          "b917ef3c5807baab2b50725cbcefd3a4",
+          "1371963aed7dba134032136a36f65c6a",
+          "6aee25ee47778802086228c8f7853fb2",
+          "a37429d0af321975fe2dbc5fd6bd93a6",
+          "01aa6fb664551a7a4a512647a33fbd56"
+        ],
+        "http_totals": {
+          "PROPFIND": 80,
+          "GET": 16
+        }
+      },
+      {
+        "tool": "calendar_resources.move",
+        "calls": 2,
+        "outcomes": {
+          "success": 2
+        },
+        "mutation_states": [
+          "committed"
+        ],
+        "trace_ids": [
+          "ae70d5e62ef60301712402470570a4b4",
+          "b504e100589f3394cb62cd448ca0f6d6"
+        ],
+        "http_totals": {
+          "PROPFIND": 10,
+          "GET": 8,
+          "MOVE": 2
+        }
+      },
+      {
+        "tool": "calendars.create",
+        "calls": 1,
+        "outcomes": {
+          "success": 1
+        },
+        "mutation_states": [
+          "committed"
+        ],
+        "trace_ids": [
+          "bd35e1505e93b748d35e73450af1a71f"
+        ],
+        "http_totals": {
+          "PROPFIND": 11,
+          "MKCALENDAR": 1
+        }
+      },
+      {
+        "tool": "calendars.delete",
+        "calls": 2,
+        "outcomes": {
+          "input_required": 1,
+          "success": 1
+        },
+        "mutation_states": [
+          "committed"
+        ],
+        "trace_ids": [
+          "5be22b51f4532d3bda558991ce05c728",
+          "5ffa3608f8491eff09bee7656b784e11"
+        ],
+        "http_totals": {
+          "PROPFIND": 20,
+          "DELETE": 1
+        }
+      },
+      {
+        "tool": "calendars.list",
+        "calls": 1,
+        "outcomes": {
+          "success": 1
+        },
+        "mutation_states": [],
+        "trace_ids": [
+          "6c96dbd2329e860be6b2252628c0cecc"
+        ],
+        "http_totals": {
+          "PROPFIND": 5
+        }
+      },
+      {
+        "tool": "events.create",
+        "calls": 1,
+        "outcomes": {
+          "success": 1
+        },
+        "mutation_states": [
+          "committed"
+        ],
+        "trace_ids": [
+          "4f6336b585c671857c9f687063d7b1fe"
+        ],
+        "http_totals": {
+          "PROPFIND": 5,
+          "PUT": 1,
+          "GET": 1
+        }
+      },
+      {
+        "tool": "events.patch",
+        "calls": 1,
+        "outcomes": {
+          "success": 1
+        },
+        "mutation_states": [
+          "committed"
+        ],
+        "trace_ids": [
+          "300eb00055b3ed8d1255628d400a836b"
+        ],
+        "http_totals": {
+          "PROPFIND": 5,
+          "GET": 2,
+          "PUT": 1
+        }
+      },
+      {
+        "tool": "todos.complete",
+        "calls": 1,
+        "outcomes": {
+          "success": 1
+        },
+        "mutation_states": [
+          "committed"
+        ],
+        "trace_ids": [
+          "2b9c2a07f0ae208daa19d0836af20eb4"
+        ],
+        "http_totals": {
+          "PROPFIND": 5,
+          "GET": 2,
+          "PUT": 1
+        }
+      },
+      {
+        "tool": "todos.create",
+        "calls": 1,
+        "outcomes": {
+          "success": 1
+        },
+        "mutation_states": [
+          "committed"
+        ],
+        "trace_ids": [
+          "d5792f4e68cdcedcce49aba25ee5292f"
+        ],
+        "http_totals": {
+          "PROPFIND": 5,
+          "PUT": 1,
+          "GET": 1
+        }
+      },
+      {
+        "tool": "todos.patch",
+        "calls": 1,
+        "outcomes": {
+          "success": 1
+        },
+        "mutation_states": [
+          "committed"
+        ],
+        "trace_ids": [
+          "6a97bab52267db3bc43bfcc0194f4246"
+        ],
+        "http_totals": {
+          "PROPFIND": 5,
+          "GET": 2,
+          "PUT": 1
+        }
+      },
+      {
+        "tool": "todos.query",
+        "calls": 7,
+        "outcomes": {
+          "success": 7
+        },
+        "mutation_states": [],
+        "trace_ids": [
+          "35dcbbe26147a4eec8047cec52531005",
+          "fc4d902196af09277958127ec9172ddb",
+          "11b27ec448cc0e9b09bf4eecb8b8c23e",
+          "6b7a8d45ab7e5633dda9fb1f668617a3",
+          "4d4c6fe4a7c52d935111ac89506c3351",
+          "6d761f1e85b3d9c0d86e70131c8f3a67",
+          "29c6e5198878c2242e1e902d680f885c"
+        ],
+        "http_totals": {
+          "PROPFIND": 20,
+          "REPORT": 56
+        }
+      }
+    ],
+    "authoritative_checks": 21
+  },
+  "controls": {
+    "expected_limits": [
+      {
+        "label": "baseline",
+        "code": "limit_exhausted",
+        "store_index": null
+      },
+      {
+        "label": "candidate",
+        "code": "limit_exhausted",
+        "store_index": null
+      },
+      {
+        "label": "baseline",
+        "code": "busy",
+        "store_index": 16
+      },
+      {
+        "label": "candidate",
+        "code": "busy",
+        "store_index": 16
+      }
+    ],
+    "clean_no_request_eof": 6,
+    "collector_unavailable_successes": 150,
+    "scales": [
+      {
+        "label": "baseline",
+        "tool": "calendar_entities.query",
+        "corpus_resources": 1,
+        "elapsed_ms": 568.136404,
+        "outcome": "success"
+      },
+      {
+        "label": "baseline",
+        "tool": "calendar_occurrences.query",
+        "corpus_resources": 1,
+        "elapsed_ms": 237.145948,
+        "outcome": "success"
+      },
+      {
+        "label": "candidate",
+        "tool": "calendar_entities.query",
+        "corpus_resources": 1,
+        "elapsed_ms": 558.390107,
+        "outcome": "success"
+      },
+      {
+        "label": "candidate",
+        "tool": "calendar_occurrences.query",
+        "corpus_resources": 1,
+        "elapsed_ms": 198.070055,
+        "outcome": "success"
+      },
+      {
+        "label": "baseline",
+        "tool": "calendar_entities.query",
+        "corpus_resources": 50,
+        "elapsed_ms": 749.914725,
+        "outcome": "success"
+      },
+      {
+        "label": "baseline",
+        "tool": "calendar_occurrences.query",
+        "corpus_resources": 50,
+        "elapsed_ms": 807.236277,
+        "outcome": "success"
+      },
+      {
+        "label": "candidate",
+        "tool": "calendar_entities.query",
+        "corpus_resources": 50,
+        "elapsed_ms": 690.102319,
+        "outcome": "success"
+      },
+      {
+        "label": "candidate",
+        "tool": "calendar_occurrences.query",
+        "corpus_resources": 50,
+        "elapsed_ms": 494.340153,
+        "outcome": "success"
+      },
+      {
+        "label": "baseline",
+        "tool": "calendar_entities.query",
+        "corpus_resources": 200,
+        "elapsed_ms": 1408.015169,
+        "outcome": "success"
+      },
+      {
+        "label": "baseline",
+        "tool": "calendar_occurrences.query",
+        "corpus_resources": 200,
+        "elapsed_ms": 1309.900492,
+        "outcome": "success"
+      },
+      {
+        "label": "candidate",
+        "tool": "calendar_entities.query",
+        "corpus_resources": 200,
+        "elapsed_ms": 1057.580098,
+        "outcome": "success"
+      },
+      {
+        "label": "candidate",
+        "tool": "calendar_occurrences.query",
+        "corpus_resources": 200,
+        "elapsed_ms": 882.416157,
+        "outcome": "success"
+      },
+      {
+        "label": "candidate",
+        "tool": "calendar_entities.query",
+        "corpus_resources": 600,
+        "elapsed_ms": 1591.885134,
+        "outcome": "success"
+      }
+    ]
+  },
+  "package_sha256": {
+    "dotnet-agents-caldav.0.0.0-perf.20260905.snupkg": "3c9e1eaa5997bbb8aeddcf0b0cfd6e79006319bf2dd2218d0886649326e56c8a",
+    "dotnet-agents-caldav.0.0.0-perf.20260905.nupkg": "3d7bec648f59fddc197c37d8f094a5179a56441e8d67707e2f38c1ef01dd7d14"
+  },
+  "cleanup": {
+    "containers_removed": [
+      "caldav-perf-3f20bb0e-radicale",
+      "caldav-perf-3f20bb0e-dashboard"
+    ],
+    "complete": true,
+    "final_corpus_before_container_removal": {
+      "events": 600,
+      "todos": 600,
+      "archive": 0
+    },
+    "temporary_directories_removed": [
+      "hermes-isolated",
+      "profilers",
+      "package-checkout",
+      "package-metadata",
+      "hermes-run-private.log"
+    ],
+    "retained": "assemblies, profiles, raw measurement artifacts and sanitized evidence",
+    "anonymous_volumes_verified_removed": 1,
+    "owned_containers_verified_absent": true,
+    "temporary_credentials_removed": true
+  }
+}

--- a/docs/performance-schema-validation-2026-09-05-results.json
+++ b/docs/performance-schema-validation-2026-09-05-results.json
@@ -3771,6 +3771,8 @@
   },
   "measurement_limitations": {
     "historical_shared_process_cpu": "Concurrent single_session CPU windows overlap. Original means are retained as mean_overlapping_process_cpu_delta_ms; mean_cpu_ms is null because those deltas cannot be attributed per operation.",
-    "historical_corpus_verification": "The original run checked collection counts and compared measured page hashes between builds; it did not persist the seed ETag map needed to detect every same-count corpus edit. Later harness verification does not retroactively strengthen that evidence."
+    "historical_corpus_verification": "The original run checked collection counts and compared measured page hashes between builds; it did not persist the seed ETag map needed to detect every same-count corpus edit. Later harness verification does not retroactively strengthen that evidence.",
+    "historical_occurrence_postconditions": "The original five occurrence mutations checked HTTP 200 after schema-valid success. A later real functional run additionally verified UID, master recurrence, target RDATE/EXDATE and override identity/status; those stronger checks are not retroactively attributed to the original run.",
+    "historical_gate_source_binding": "The original gates were executed and retained in the documented checkout workflow, but they predate gate-source.json. The new aggregator requires a source/runtime-bound gate run and does not manufacture that proof for old artifact directories."
   }
 }

--- a/docs/performance-schema-validation-2026-09-05.md
+++ b/docs/performance-schema-validation-2026-09-05.md
@@ -1,0 +1,278 @@
+# Performance da validação de schemas, 2026-09-05
+
+A candidata reduziu o p95 de Continue com 200 itens em 78,2% para entidades,
+75,4% para ocorrências e 44,8% para To-dos. Preservou validação e resultados,
+aumentou throughput e reduziu CPU/RSS nos cenários medidos. A meta de 30% foi
+atingida nessas continuações, mas **não em Start**, cujo p95 melhorou 5,8–7,0%.
+Não se declara um ganho global do servidor.
+
+## Alteração e evidência causal
+
+O adaptador validava cada resposta com `OutputFormat.List`, construindo diagnósticos
+que o guard descartava: ele consumia somente `IsValid` e lançava uma mensagem fixa
+em caso de violação. A candidata usa `OutputFormat.Flag` no mesmo schema e na mesma
+chamada `Evaluate`. Schemas, catálogo, limites, mensagens, Core, stdio e política
+OTLP permanecem iguais. Cinco regressões com páginas de 200 itens comparam a
+validade com o modo anterior e verificam erro no último item e em referências
+aninhadas. A biblioteca documenta Flag como saída de validade com otimizações de
+evaluação ([JsonSchema.Net](https://docs.json-everything.net/schema/basics/)).
+
+O piloto isolou o custo pelo trace: Continue de ocorrências com 200 itens tinha
+18,2 ms em `caldav.operation`, mas 699,8 ms no span MCP e 706,6 ms no cliente.
+Nenhum HTTP ocorreu. EventPipe encontrou `CalendarOutputSchemaGuard.Validate` e
+`JsonSchema.Evaluate` no caminho remanescente. Os percentuais do perfil de tempo
+de threads incluem esperas, portanto não representam percentuais de CPU.
+
+No ensaio síncrono do guard sobre a mesma página real, 100 observações após 20
+warmups deram mediana de 245,00 → 50,51 ms; alocação por thread de 168.909.200 →
+94.049.464 bytes por validação (-44,3%). Houve 216 coleções Gen2 no baseline e zero
+na candidata nesse ensaio. Isso mede o guard por reflexão, não latência MCP ou
+GC de uma sessão completa. Payload SHA256:
+`0928dbadb37cc84a1eb8433de8b0b87cfef25b017fb91f0645341f93490817ac`.
+
+## Ambiente e identidade
+
+- SHA inicial, checkout limpo: `37cdba56f3c957ee8f241eadf1e55b883e950458`.
+- Candidata medida: alterações locais sobre esse SHA, antes do commit e da abertura
+  do PR. Os hashes abaixo identificam os assemblies usados nas medições.
+- Baseline MCP SHA256: `e1244b5028bd678066f5a5457b807ba16de75fa7b8937d075c48190fb337ee81`.
+- Candidata MCP SHA256: `1885c568a2460993e464c24b358ceb6f4ee8b102f76f3104bfc9e16af8fc1068`.
+- Core nas duas versões SHA256: `ffec80c4405ca21a7d36abd71f0b4cc00f225b91975781acfaf3651a108ef5e2`.
+- SDK 10.0.100/runtime 10.0.0; Linux x64 7.2.2-1-cachyos; Ryzen 7 7735HS,
+  8 núcleos/16 threads, 30 GiB RAM; Docker rootless 29.7.2.
+- Radicale 3.7.8: `ghcr.io/kozea/radicale@sha256:3a0080ea51ac69dcd74e345b9587dc14a8c8af0652046069005749f9a75c5c80`.
+- Dashboard 13.4.2: `mcr.microsoft.com/dotnet/aspire-dashboard:13.4.2@sha256:76d05882595dd43e708d6ef3e269d98ca763694c0c822bbe98edc99790eaad1b`.
+- Cada container: 4 CPUs/2 GiB. Portas somente em loopback, autenticação preservada.
+  Raiz CalDAV `http://127.0.0.1:32775`; OTLP HTTP/protobuf porta 32777; Dashboard
+  porta 32776. Esses endereços identificam infraestrutura descartável desta execução.
+- Aspire CLI 13.5.1; Hermes 0.21.0, revisão `b0ab2e16`, OpenRouter
+  `openai/gpt-5.6-luna`, reasoning medium. Profilers 10.0.731102.
+
+O driver executou `/home/jhow/.local/share/mise/installs/dotnet/10.0.100/dotnet`
+com a DLL absoluta em `/tmp/caldav-perf-20260905/baseline/` ou `candidate/`.
+Cada processo registra comando, hash e presença da DLL em `/proc/<pid>/maps`.
+As versões publicadas via dnx não participaram da comparação. A máquina é uma
+estação de trabalho compartilhada; cargas externas não foram interrompidas nem
+controladas. A alternância e a dispersão por bloco reduzem a confusão com deriva,
+mas estes números não são um SLA de produção.
+
+## Método
+
+Seed determinístico 20260905: 600 VEVENTs, 600 VTODOs, arquivo vazio; distribuição
+histórica de datas/recorrências/estados; janela 2026-07-01 a 2026-12-31 UTC,
+America/Sao_Paulo. PROPFIND Depth:1 com ETags confirmou 600/600/0 antes da comparação.
+O corpus completo voltou ao mesmo estado após cada passagem funcional. Build,
+seeding, mutações de preparação e restauração ficaram fora das chamadas medidas.
+
+MCP moderno negocia `2026-07-28` por `server/discover`; o driver verifica versão e
+capabilities e descobre tools/list. Os pilotos tentaram initialize legado e
+receberam rejeição; suas chamadas posteriores com metadata moderna eram válidas,
+mas suas medidas de handshake não entram na comparação. O harness foi corrigido
+antes da comparação principal e a matriz funcional foi repetida.
+
+Continue usa três blocos de 100 observações por célula, com 20 warmups por tamanho
+e processo. Baseline/candidata alternam ordem por bloco. Cada snapshot permanece
+na sessão original. Hashes dos itens e sua ordem coincidiram nas nove células
+entre versões e blocos. Percentis: nearest rank, `ceil(p*N)`. P99 nos JSONs é
+descritivo; 300 amostras não tornam sua cauda robusta.
+
+Start usa três blocos de 30 observações por célula, com cinco warmups/cinco medidas
+por processo. Essa amostragem menor limita precisão do p95 e foi escolhida pelo
+custo da aquisição integral. A tentativa inicial com dez medidas por coorte
+atingiu o limite de bytes do store no 14º Start de ocorrências. Ela permanece
+separada em `start-serial-*`, com sua falha, e não conta como throughput útil.
+A comparação final usa `start-serial-bounded-*`. Nenhum limite do produto mudou.
+
+Latência do cliente inclui envio stdio, execução, retorno e decodificação JSON;
+exclui escrita do registro de benchmark. Duração no servidor vem dos spans MCP e
+de operação. Startup/discovery MCP e shutdown constam dos registros de processos.
+Throughput serial da tabela é operações bem-sucedidas/soma das latências medidas;
+os JSONL de lotes incluem throughput do driver com suas verificações. CPU de
+`/proc` tem resolução de 10 ms; RSS/HWM são observações do processo. Bytes medidos
+são bytes JSON-RPC stdio, não bytes HTTP. A allowlist atual não exporta bytes de
+corpos CalDAV, e essa ausência não foi preenchida com estimativas.
+
+## Continue serial: resultados completos
+
+300 medidas por revisão em cada linha. Tempos em ms. Nenhuma chamada resultou em
+erro ou timeout. A última coluna é contagem HTTP por chamada.
+
+| Ferramenta | Página | Baseline p50 / p95 | Candidata p50 / p95 | Redução p95 | ops/s B / C | Erros B / C | HTTP B / C |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|
+| `calendar_entities.query` | 1 | 3.40 / 4.45 | 2.32 / 3.11 | 30.0% | 289.2 / 419.4 | 0 / 0 | 0 / 0 |
+| `calendar_entities.query` | 5 | 10.79 / 12.58 | 7.57 / 8.98 | 28.6% | 92.5 / 130.0 | 0 / 0 | 0 / 0 |
+| `calendar_entities.query` | 200 | 183.96 / 261.62 | 51.62 / 56.96 | 78.2% | 5.1 / 19.3 | 0 / 0 | 0 / 0 |
+| `calendar_occurrences.query` | 1 | 3.81 / 4.88 | 2.92 / 3.91 | 19.8% | 254.4 / 332.1 | 0 / 0 | 0 / 0 |
+| `calendar_occurrences.query` | 5 | 14.82 / 17.51 | 11.07 / 16.54 | 5.6% | 66.6 / 84.6 | 0 / 0 | 0 / 0 |
+| `calendar_occurrences.query` | 200 | 276.76 / 307.93 | 70.86 / 75.77 | 75.4% | 3.6 / 14.0 | 0 / 0 | 0 / 0 |
+| `todos.query` | 1 | 2.08 / 2.93 | 1.45 / 2.09 | 28.8% | 471.1 / 630.5 | 0 / 0 | 0 / 0 |
+| `todos.query` | 5 | 4.57 / 5.85 | 2.95 / 4.14 | 29.3% | 213.2 / 323.5 | 0 / 0 | 0 / 0 |
+| `todos.query` | 200 | 62.14 / 121.91 | 25.98 / 67.29 | 44.8% | 14.6 / 25.9 | 0 / 0 | 0 / 0 |
+
+As páginas de 200 itens superaram a meta de redução de 30% do p95 nas três
+famílias. Os ganhos menores das páginas pequenas estão expostos, sem agregação
+em um percentual global. A meta de Start não foi atingida, conforme a comparação abaixo.
+
+## Start serial: resultados completos
+
+90 medidas por revisão/família, página 200; nenhum erro ou timeout. HTTP abaixo
+é a forma normal, igual nas revisões; retries reais permanecem na exportação.
+
+| Ferramenta | Baseline p50 / p95 ms | Candidata p50 / p95 ms | Redução p95 | ops/s B / C | CPU média ms B / C | Máx. RSS MiB B / C | HTTP normal por chamada |
+|---|---:|---:|---:|---:|---:|---:|---|
+| `calendar_entities.query` | 1408.5 / 1600.5 | 1276.8 / 1489.2 | 7.0% | 0.70 / 0.77 | 726.0 / 649.3 | 344.8 / 289.8 | 5 PROPFIND + 27 REPORT |
+| `calendar_occurrences.query` | 1595.6 / 1679.6 | 1405.2 / 1568.9 | 6.6% | 0.62 / 0.71 | 737.2 / 556.8 | 451.2 / 347.1 | 5 PROPFIND + 27 REPORT |
+| `todos.query` | 826.6 / 1049.4 | 801.8 / 988.8 | 5.8% | 1.15 / 1.20 | 790.9 / 749.7 | 219.9 / 205.8 | 5 PROPFIND + 14 REPORT |
+
+**A meta de 30% não foi atingida em Start.** Os ganhos de p95 ficaram entre 5,8%
+e 7,0%; a menor amostragem limita a precisão dessa cauda. Não se declara ganho
+uniforme do servidor nem um percentual global. O custo dominante remanescente é
+a aquisição CalDAV: no trace exploratório `16c92af2e4d83a84e4f69dd52495c072`, fetch
+levou 1.288 ms, dos quais 893 ms somados nos 24 REPORTs multiget. A mudança do
+guard não elimina essas viagens nem a materialização/serialização integral de Start.
+
+Investigação do limiar de regressão: o bloco 0 de entidades teve p95 +6,4% na
+candidata; os blocos 1 e 2 tiveram -7,5% e -15,5%. A regressão não se reproduziu,
+e o agregado de 90 medidas teve -7,0%. Essa dispersão impede promover o pequeno
+ganho de Start a uma promessa de latência; a redução de Continue grande tem
+margem muito maior. Os JSONs preservam os p95 de cada bloco.
+
+## Fronteiras de tempo e recursos: Continue 200
+
+B/C = baseline/candidata. O throughput deste quadro inclui o trabalho do driver
+entre respostas, além da latência da chamada. RSS é amostrado após as chamadas;
+não substitui um perfil de heap. O Core e seus limites de retenção são idênticos.
+
+| Ferramenta | Span MCP p95 ms B/C | Operação p95 ms B/C | CPU média ms B/C | Máx. RSS MiB B/C | Driver ops/s B/C |
+|---|---:|---:|---:|---:|---:|
+| `calendar_entities.query` | 255.0 / 51.4 | 14.8 / 8.8 | 199.7 / 55.7 | 259.2 / 202.1 | 4.86 / 16.14 |
+| `calendar_occurrences.query` | 302.2 / 68.7 | 14.6 / 9.7 | 281.5 / 71.8 | 324.1 / 200.8 | 3.44 / 11.82 |
+| `todos.query` | 120.3 / 65.7 | 10.5 / 6.0 | 85.9 / 54.4 | 188.6 / 164.4 | 14.04 / 24.13 |
+
+O ganho está principalmente após `caldav.operation`, no guard do adaptador.
+Nenhuma das 5.400 chamadas de Continue serial executou HTTP. A coleta EventPipe
+retém counters de runtime; alocações/GC comparáveis do guard vêm do ensaio
+síncrono descrito acima. O Aspire não foi apresentado como origem de métricas
+de runtime que o produto não exporta.
+
+## Concorrência e overhead de OTLP
+
+Página 200. Cada célula de sessão usa 300 medidas por revisão; cada célula entre
+processos usa 96 (três blocos de 32). Um processo por chamada simultânea na
+segunda topologia; snapshots não atravessam processos. Todas as chamadas passaram.
+
+| Topologia | Concorrência | Ferramenta | p95 B/C ms | Redução | Driver ops/s B/C |
+|---|---:|---|---:|---:|---:|
+| Mesma sessão | 2 | `calendar_entities.query` | 339.1 / 81.8 | 75.9% | 6.02 / 22.04 |
+| Mesma sessão | 2 | `calendar_occurrences.query` | 509.3 / 113.6 | 77.7% | 4.01 / 15.75 |
+| Mesma sessão | 2 | `todos.query` | 170.1 / 81.0 | 52.4% | 15.76 / 29.51 |
+| Mesma sessão | 4 | `calendar_entities.query` | 615.8 / 135.3 | 78.0% | 6.87 / 27.12 |
+| Mesma sessão | 4 | `calendar_occurrences.query` | 889.8 / 180.2 | 79.8% | 4.58 / 19.66 |
+| Mesma sessão | 4 | `todos.query` | 257.1 / 95.4 | 62.9% | 18.05 / 41.60 |
+| Processos distintos | 2 | `calendar_entities.query` | 279.7 / 87.0 | 68.9% | 8.17 / 24.95 |
+| Processos distintos | 2 | `calendar_occurrences.query` | 423.4 / 123.5 | 70.8% | 5.45 / 17.94 |
+| Processos distintos | 2 | `todos.query` | 188.7 / 90.6 | 52.0% | 12.84 / 25.22 |
+| Processos distintos | 4 | `calendar_entities.query` | 331.3 / 123.1 | 62.8% | 12.19 / 31.97 |
+| Processos distintos | 4 | `calendar_occurrences.query` | 508.5 / 176.1 | 65.4% | 8.16 / 23.10 |
+| Processos distintos | 4 | `todos.query` | 177.9 / 95.7 | 46.2% | 23.42 / 41.61 |
+
+OTLP foi comparado na mesma candidata, alternando ligado/desligado em três blocos
+de 30 após 20 warmups. A etiqueta baseline desse run significa OTLP ligado,
+não o assembly antigo. p95 ligado/desligado: entidades 78,1/76,0 ms;
+ocorrências 106,2/105,4 ms; To-dos 96,6/95,7 ms. O overhead observado foi de
+aproximadamente 2,8%, 0,8% e 1,0%; o tamanho pequeno desses efeitos e a dispersão
+não justificam uma promessa de overhead fixo. Collector indisponível e OTLP
+desligado preservaram resultados e EOF limpo. O maior shutdown observado nos
+processos das comparações foi 129,2 ms.
+
+## Hipóteses e experimento descartado
+
+| Hipótese | Evidência inicial | Ganho esperado / custo / risco | Decisão |
+|---|---|---|---|
+| Diagnósticos de schema descartados | Continue grande fora da operação; perfil do guard | Alto em páginas grandes / baixo / preservar validade | Manter Flag e validar diferencialmente |
+| Rodadas multiget sequenciais | Fetch 1,3–1,6 s, 24 lotes de 50 | Reduzir espera / médio / fallback, ordem e concorrência | Experimento sem benefício; removido |
+| Parsing/projeção e recorrência | Parte de fetch e serialização nos spans | Incerto / alto / fidelidade, DST e limites | Sem alteração especulativa |
+| Discovery, snapshots e Move | Já otimizados no SHA inicial | Ganhos históricos não atribuíveis | Preservados |
+
+O experimento multiget permitiu quatro lotes por origem e não melhorou as oito
+medidas bem-sucedidas após aquecimento (~2,0 s em ambas as versões). As duas últimas
+chamadas de cada piloto falharam na admissão; não entram nessa comparação. Não se
+apresenta esse protótipo descartado como otimização entregue. Não houve alteração
+no Core final.
+
+## Integração e observabilidade
+
+Cliente direto completou as 23 ferramentas do catálogo com exact habilitado:
+criação de calendário, consultas e paginação, criação/patch/conclusão de fixtures,
+cinco mutações de recorrência, Move vazio/populado, exact get/create/replace/move,
+MRTR e exclusões com ausência autoritativa. O catálogo padrão descoberto tem 19.
+Os controles verificaram OTLP ligado/desligado/collector indisponível e EOF limpo,
+escalas 1/50/200/600, excesso de 5000 ocorrências e saturação do store. Limites
+esperados foram registrados à parte.
+
+Hermes executou listagem, as três queries com Continue na sessão persistente,
+criação/releitura/patch/releitura/conclusão/releitura de um To-do. O Radicale
+confirmou resumo alterado e COMPLETED. A negociação tentou initialize 2025-11-25,
+recebeu rejeição e recuperou via server/discover; os requests seguintes usaram
+2026-07-28 e anunciaram elicitation form/url. A prova usa tráfego MCP capturado por
+proxy transparente e resultados estruturados sanitizados, não só texto do agente.
+
+**Bloqueado no Hermes:** delete devolveu `input_required`; o adaptador não enviou
+requestState/inputResponses. O cliente direto completou MRTR e verificou ausência.
+Isso não aprova MRTR pelo Hermes. Não se alegou propagação de trace desde inferência;
+a correlação usa serviço, ferramenta, intervalo UTC e identidade do processo.
+
+Os traces confirmam zero HTTP em Continue e Move com cinco PROPFINDs, quatro GETs
+e um MOVE tanto no destino vazio como populado. Exact Move usa duas descobertas,
+seis observações dos recursos envolvidos e um MOVE, sem REPORT. O defeito histórico
+do 404 de delete não reapareceu: nesta revisão as observações de ausência têm
+`caldav.http.request_purpose=absence_probe`, `expected_absence` e status OK.
+InputRequired é separado de erro; retries reais permanecem nos spans.
+
+Exportação usa a [API/CLI suportada do Aspire](https://aspire.dev/dashboard/apis/),
+com verificação de returnedCount/totalCount e retenção configurada de 50.000 traces
+/100.000 logs. A auditoria final encontrou os mesmos 124.729 spans únicos na API e no ZIP,
+sem truncamento. O cruzamento identificou os 10.962 traces de operações medidas
+com OTLP; outras 270 chamadas medidas do controle usaram OTLP desligado.
+A auditoria de 633 arquivos exportados não encontrou sentinelas de credenciais,
+corpus, cursor ou payload iCalendar, nem eventos de exceção.
+
+## Gates, reprodução e limpeza
+
+Primeira suíte: 2.421 Core + 1.035 MCP + 114 integração e 11 strict-preconditions
+passaram. Cobertura 94,49% linhas / 86,05% branches. Alternate-time-zone falhou
+antes de executar por erro de montagem overlay do Docker; logs completos retidos.
+A repetição integral passou: 3.592 testes, zero falhas e zero skipped;
+nenhum gate, threshold ou teste foi relaxado. Build Release: zero warnings/erros;
+Slopwatch: zero findings. O pacote local `0.0.0-perf.20260905` passou conteúdo,
+metadata, instalação isolada e smoke MCP (mais um teste). Metadata de origem
+permaneceu em `0.0.0`; nada foi publicado. A limpeza final está registrada abaixo.
+
+Harness: [README](../scripts/observations/mcp-performance/README.md).
+Evidências completas locais: `/tmp/caldav-perf-20260905`. O [JSON de resultados](performance-schema-validation-2026-09-05-results.json)
+contém estatísticas, blocos, traces representativos, contagens HTTP, testes,
+catálogo e prova Hermes sanitizada. Os JSONL completos, perfis, assemblies e ZIPs
+ficam no diretório externo. A limpeza foi confirmada: corpus 600/600/0 antes da remoção, dois containers
+próprios e seu volume anônimo ausentes, processos MCP encerrados, configuração
+Hermes isolada/credenciais/profilers/clone de pacote removidos. Caches e recursos
+alheios foram preservados. `cleanup.json` registra as verificações. Assemblies,
+perfis, dados de medição e exportações permanecem como artefatos de evidência.
+
+
+## Traces representativos
+
+Os identificadores abaixo estão no ZIP exportado e no JSON de evidências;
+nenhum depende da permanência do Dashboard. As durações comparativas vêm de
+populações completas, não destes exemplos isolados.
+
+| Caso | Trace |
+|---|---|
+| calendar_entities.query / baseline / Continue 200 | `4afae28f686f347d8f216b53a89bd0b8` |
+| calendar_entities.query / candidate / Continue 200 | `63307d2fca8f4c6aee386571780c2d31` |
+| calendar_occurrences.query / baseline / Continue 200 | `f517c8e2b8fa91a0d978094ff7504d6d` |
+| calendar_occurrences.query / candidate / Continue 200 | `b80510805a7f22e8fc7ab379066bfaee` |
+| todos.query / baseline / Continue 200 | `d974bafcaf8a43a7ff993f549b155ce3` |
+| todos.query / candidate / Continue 200 | `e838a2b0a6df14192c8649a28a2f9a8e` |
+| calendar_resources.delete / cliente direto | `70567a58bf4fa28fc5ad047fc4e2a0cf` |
+| calendar_resources.exact_move / cliente direto | `42b3b464112a34736330aa7e62e828cb` |
+| calendar_resources.move / cliente direto | `b504e100589f3394cb62cd448ca0f6d6` |

--- a/docs/performance-schema-validation-2026-09-05.md
+++ b/docs/performance-schema-validation-2026-09-05.md
@@ -61,8 +61,16 @@ mas estes números não são um SLA de produção.
 Seed determinístico 20260905: 600 VEVENTs, 600 VTODOs, arquivo vazio; distribuição
 histórica de datas/recorrências/estados; janela 2026-07-01 a 2026-12-31 UTC,
 America/Sao_Paulo. PROPFIND Depth:1 com ETags confirmou 600/600/0 antes da comparação.
-O corpus completo voltou ao mesmo estado após cada passagem funcional. Build,
+As contagens voltaram a 600/600/0 após cada passagem funcional. Build,
 seeding, mutações de preparação e restauração ficaram fora das chamadas medidas.
+
+A verificação histórica do seed conferiu as contagens 600/600/0; não conservou
+um mapa de ETags para detectar edição de um recurso que mantivesse a contagem.
+As mutações funcionais usaram fixtures separadas e os hashes das páginas medidas
+coincidiram entre builds, mas isso não constitui uma verificação de integridade
+de todos os recursos do corpus. O harness corrigido passa a comparar caminhos e
+ETags fortes com os retornados na criação do seed; essa garantia não é atribuída
+retroativamente à execução histórica.
 
 MCP moderno negocia `2026-07-28` por `server/discover`; o driver verifica versão e
 capabilities e descobre tools/list. Os pilotos tentaram initialize legado e
@@ -91,6 +99,14 @@ os JSONL de lotes incluem throughput do driver com suas verificações. CPU de
 `/proc` tem resolução de 10 ms; RSS/HWM são observações do processo. Bytes medidos
 são bytes JSON-RPC stdio, não bytes HTTP. A allowlist atual não exporta bytes de
 corpos CalDAV, e essa ausência não foi preenchida com estimativas.
+
+Correção de interpretação de CPU: nas séries históricas `single_session` com
+concorrência 2/4, os deltas do processo foram coletados em intervalos sobrepostos
+e incluem trabalho das outras chamadas. Não medem CPU por operação. O JSON
+estruturado conserva esses números como `mean_overlapping_process_cpu_delta_ms`
+e marca `mean_cpu_ms` como `null` nessas células. Os ganhos de CPU apresentados
+nas tabelas seriais abaixo usam chamadas sem sobreposição e continuam aplicáveis.
+As amostras brutas permanecem preservadas fora do Git.
 
 ## Continue serial: resultados completos
 

--- a/docs/performance-schema-validation-2026-09-05.md
+++ b/docs/performance-schema-validation-2026-09-05.md
@@ -222,6 +222,11 @@ Cliente direto completou as 23 ferramentas do catálogo com exact habilitado:
 criação de calendário, consultas e paginação, criação/patch/conclusão de fixtures,
 cinco mutações de recorrência, Move vazio/populado, exact get/create/replace/move,
 MRTR e exclusões com ausência autoritativa. O catálogo padrão descoberto tem 19.
+Nas cinco mutações de recorrência, a checagem HTTP original confirmou existência
+do recurso. Durante a revisão do harness, uma nova passagem real conferiu também
+UID, regra, RDATE/EXDATE e identidade/status do override após cada verbo. Essa
+validação detecta operações sem efeito ou em outra instância; sua evidência está
+em `/tmp/caldav-perf-pr-validation/review7-occurrence-verification.json`.
 Os controles verificaram OTLP ligado/desligado/collector indisponível e EOF limpo,
 escalas 1/50/200/600, excesso de 5000 ocorrências e saturação do store. Limites
 esperados foram registrados à parte.

--- a/scripts/observations/mcp-performance/README.md
+++ b/scripts/observations/mcp-performance/README.md
@@ -39,6 +39,11 @@ dos assemblies copiados. `aggregate.py` exige esses manifestos; não infere a
 identidade pelo Git no momento da análise. Os manifestos sobrevivem à limpeza dos
 clones. Execuções históricas anteriores a esse registro mantêm suas evidências
 originais, sem reconstruir retroativamente a identidade a partir do checkout atual.
+Cada manifesto de benchmark associa os argumentos absolutos aos hashes e à fonte
+do build correspondente. Inverter baseline/candidata é erro antes da medição.
+No controle `--compare-otlp`, ambos apontam ao mesmo build e conservam essa
+identidade na agregação. Cada processo precisa corresponder ao seu argumento,
+inclusive ao hash de Core; pertencer ao conjunto dos dois builds não basta.
 
 Seed 20260905: 600 Events e 600 To-dos distribuídos em 180 dias desde
 2026-07-01; 60 recorrentes por tipo, 30 Events date-only e 12 cancelados;
@@ -76,8 +81,10 @@ Exemplo da máquina desta execução:
 python3 scripts/observations/mcp-performance/verify_hermes.py /tmp/caldav-perf-new /tmp/caldav-perf-new/candidate/DotnetAgents.CalDav.Mcp.dll
 ```
 
-O proxy preserva cada byte MCP e registra testemunhas sanitizadas. Não implementa
-MRTR pelo Hermes. O segundo comando verifica COMPLETED no Radicale e completa
+O proxy preserva cada byte MCP e registra testemunhas sanitizadas. Wrapper e proxy
+recusam um wire log existente antes de iniciar o cliente/servidor. Use um diretório
+de evidência novo para outra tentativa. O proxy não implementa MRTR pelo Hermes.
+O segundo comando verifica COMPLETED no Radicale e completa
 a limpeza via cliente direto quando o Hermes parou em input_required. Ele exige
 que a fixture ainda exista; se uma versão futura do Hermes completar o delete,
 adapte a verificação à ausência autoritativa e conserve sua evidência de wire.
@@ -89,6 +96,10 @@ como custo separado, sem alegar tracing da inferência.
 Não rode builds, testes, profiling ou outro benchmark em paralelo. Restaure
 600/600/0 antes de iniciar. Os comandos abaixo alternam baseline/candidato
 entre blocos/coortes e recusam sobrescrever amostras de um nome existente.
+Os hashes dos itens, incluindo sua ordem, são comparados entre baseline e candidata
+por ferramenta/tamanho/bloco, em ambas as topologias. Diferenças interrompem a
+execução depois de preservar a amostra divergente. Falhas e timeouts também ficam
+no JSONL antes da interrupção, sem contar como throughput útil.
 
 ```bash
 python3 scripts/observations/mcp-performance/benchmark.py /tmp/caldav-perf-new /tmp/caldav-perf-new/baseline/DotnetAgents.CalDav.Mcp.dll /tmp/caldav-perf-new/candidate/DotnetAgents.CalDav.Mcp.dll --name continue-serial
@@ -167,6 +178,22 @@ Execute `python3 scripts/observations/mcp-performance/test_harness.py` para as
 regressões do harness. Elas usam repositórios temporários e executáveis simulados
 para verificar identidade, contagens e tratamento de falhas; não substituem a
 matriz MCP real nem o gate de pacote.
+
+Depois dos ensaios de alocação (salvos como `schema-baseline.json` e
+`schema-candidate.json`), dos gates e da exportação `complete` acima, agregue as
+execuções escolhidas explicitamente. `--gates` aponta ao diretório de evidências
+da suíte dentro da raiz da observação (ou a um caminho absoluto):
+
+```bash
+python3 scripts/observations/mcp-performance/aggregate.py /tmp/caldav-perf-new /tmp/caldav-perf-new/results.json --gates gates-final --runs continue-serial start-serial --traces /tmp/caldav-perf-new/complete-traces.json
+```
+
+`--traces` aceita um ou mais arquivos `*-traces.json` produzidos por `telemetry.py`;
+não depende de um nome `final-traces.json` implícito. Exports sobrepostos são
+deduplicados por trace ID somente quando seus dados coincidem. Versões diferentes
+do mesmo trace são rejeitadas; selecione a exportação completa posterior ao
+encerramento da operação. A contagem de matches ainda precisa cobrir todas as
+chamadas medidas com OTLP.
 
 Antes de remover infraestrutura, exporte e verifique 600/600/0. `infra.py down`
 confere a label de propriedade antes de remover seus containers e volumes

--- a/scripts/observations/mcp-performance/README.md
+++ b/scripts/observations/mcp-performance/README.md
@@ -53,9 +53,10 @@ identidade na agregação. Cada processo precisa corresponder ao seu argumento,
 inclusive ao hash de Core; pertencer ao conjunto dos dois builds não basta.
 No controle OTLP, o conjunto de dependências também deve ser idêntico entre os
 argumentos; igualdade somente de MCP e Core não basta.
-Os manifestos verificam também os assets declarados em `.deps.json` e os hashes
-de todo o diretório de execução copiado, incluindo dependências, assets por RID,
-deps e runtimeconfig. O driver registra esse conjunto para cada processo. Mantenha
+Os manifestos verificam também os assets declarados em `.deps.json` e seus hashes,
+incluindo dependências, assets por RID, deps, runtimeconfig e configurações locais.
+Cópias auxiliares de publicação fora desse grafo não integram a assinatura.
+O driver registra esse conjunto para cada processo. Mantenha
 esses diretórios imutáveis; trocar uma dependência como JsonSchema.Net invalida a
 identidade mesmo quando MCP e Core não mudaram.
 
@@ -179,7 +180,9 @@ EventPipe `dotnet-sampled-thread-time` inclui esperas; seus percentuais não sã
 percentuais de CPU. Runtime counters são coleta externa, não métricas já
 exportadas pelo produto. Para a comparação síncrona de alocação, copie
 `schema-observation/` ao diretório externo, compile e passe diretório do assembly,
-uma página estruturada real de MCP salva localmente e nome da ferramenta. O
+uma página estruturada real de MCP salva localmente, nome da ferramenta e o
+manifesto `baseline-build.json` ou `candidate-build.json`, nessa ordem. O nome da
+ferramenta precisa corresponder à página capturada. O
 programa usa reflexão para chamar o guard original em cada assembly sobre o
 mesmo JSON, após 20 aquecimentos e com 100 amostras. Não mede transporte.
 A agregação exige o hash de assembly correspondente ao build de cada observação,

--- a/scripts/observations/mcp-performance/README.md
+++ b/scripts/observations/mcp-performance/README.md
@@ -116,6 +116,9 @@ arquivos `*-processes.jsonl`, separados das chamadas aquecidas.
 Contagens de blocos, amostras e coortes devem ser positivas. Start exige que
 `--samples` seja divisível por `--cohort-samples` e usa somente coortes seriais
 na topologia `single_session`; argumentos incompatíveis falham antes da execução.
+Cada coorte aceita no máximo 11 medidas, reservando cinco dos 16 snapshots para
+warmup. O limite de bytes pode exigir coortes menores; mantenha o padrão de cinco
+para o corpus documentado, como na comparação original.
 
 Para concorrência, repita Continue com `--sizes 200 --concurrency 2` e `4`, cada
 qual com `--name` próprio. `--topology single_session` envia chamadas simultâneas
@@ -173,6 +176,8 @@ completo contra HEAD, incluindo alterações staged e arquivos de build da raiz,
 mais arquivos novos não ignorados. Um checkout limpo usa diretamente seu commit.
 Gera somente o pacote de teste `0.0.0-perf.20260905`, sem publicação. A prova Hermes
 propaga o código de saída do cliente depois de emitir seu resumo diagnóstico.
+O proxy também propaga o código de saída do MCP e termina de encaminhar stderr
+antes de registrar o encerramento.
 
 Execute `python3 scripts/observations/mcp-performance/test_harness.py` para as
 regressões do harness. Elas usam repositórios temporários e executáveis simulados

--- a/scripts/observations/mcp-performance/README.md
+++ b/scripts/observations/mcp-performance/README.md
@@ -51,6 +51,11 @@ do build correspondente. Inverter baseline/candidata é erro antes da medição.
 No controle `--compare-otlp`, ambos apontam ao mesmo build e conservam essa
 identidade na agregação. Cada processo precisa corresponder ao seu argumento,
 inclusive ao hash de Core; pertencer ao conjunto dos dois builds não basta.
+Os manifestos verificam também os assets declarados em `.deps.json` e os hashes
+de todo o diretório de execução copiado, incluindo dependências, assets por RID,
+deps e runtimeconfig. O driver registra esse conjunto para cada processo. Mantenha
+esses diretórios imutáveis; trocar uma dependência como JsonSchema.Net invalida a
+identidade mesmo quando MCP e Core não mudaram.
 
 Seed 20260905: 600 Events e 600 To-dos distribuídos em 180 dias desde
 2026-07-01; 60 recorrentes por tipo, 30 Events date-only e 12 cancelados;
@@ -62,6 +67,10 @@ forte, salvo no manifesto privado. `verify` compara caminhos e ETags completos:
 editar ou substituir um recurso mantendo a contagem também falha. `corpus.json`
 registra contagens e hash das entradas determinísticas. Seeding e limpeza ficam
 fora da medida.
+`seed --count N` permite corpus personalizados. As expectativas de restauração e
+limpeza vêm de `corpus.json`. As matrizes funcional e de limites exigem ao menos
+dois To-dos semeados; o padrão de 600 mantém a matriz completa de paginação. Em
+corpus menores, a matriz funcional continua apenas páginas que tenham cursor.
 
 ## Matriz funcional e clientes
 
@@ -170,6 +179,14 @@ programa usa reflexão para chamar o guard original em cada assembly sobre o
 mesmo JSON, após 20 aquecimentos e com 100 amostras. Não mede transporte.
 A agregação exige o hash de assembly correspondente ao build de cada observação,
 além de ferramenta e payload idênticos entre baseline e candidata.
+O observador também registra os hashes dos arquivos de runtime e rejeita mudanças
+durante a coleta; esses hashes devem corresponder ao manifesto do build.
+
+`profile.py --mode start` usa cinco warmups e cinco Starts capturados por processo,
+abaixo da coorte que esgotou os bytes do store no piloto. Cada chamada é registrada
+e verificada, inclusive nos warmups; `busy`, timeout ou outro erro interrompe o
+perfil. Os collectors são encerrados em caso de falha, e o registro do processo
+fica marcado como incompleto. Use um nome novo para cada perfil.
 
 O exportador usa a API suportada do Dashboard e exige
 `returnedCount == totalCount`; não aceita truncamento silencioso. O Dashboard
@@ -204,6 +221,11 @@ Depois dos ensaios de alocação (salvos como `schema-baseline.json` e
 `schema-candidate.json`), dos gates e da exportação `complete` acima, agregue as
 execuções escolhidas explicitamente. `--gates` aponta ao diretório de evidências
 da suíte dentro da raiz da observação (ou a um caminho absoluto):
+
+A agregação executa `verify-test-artifacts.sh` na fase `complete`, incluindo o
+manifesto das variantes estrita e de fuso alternativo, e `verify-coverage.sh`
+com os limiares 90%/85%. Diretórios parciais, contadores malsucedidos e cobertura
+insuficiente são rejeitados antes da emissão do resultado.
 
 ```bash
 python3 scripts/observations/mcp-performance/aggregate.py /tmp/caldav-perf-new /tmp/caldav-perf-new/results.json --gates gates-final --runs continue-serial start-serial --traces /tmp/caldav-perf-new/complete-traces.json

--- a/scripts/observations/mcp-performance/README.md
+++ b/scripts/observations/mcp-performance/README.md
@@ -83,7 +83,8 @@ python3 scripts/observations/mcp-performance/edges.py /tmp/caldav-perf-new /tmp/
 ```
 
 `functional.py` percorre o catálogo vivo completo com exact habilitado somente
-no filho correspondente. Inclui queries limitadas e não limitadas quando
+no filho correspondente. Antes de acessar as fixtures, ele exige que o assembly
+e todas as dependências correspondam a `candidate-build.json`. Inclui queries limitadas e não limitadas quando
 permitidas, Start/Continue 1/5/200, recursos, criação/patch/conclusão, cinco
 mutações de recorrência, Move vazio/populado, exact create/replace/move e deletes
 de recurso/calendário por MRTR. Releitura HTTP verifica mutações e ausência.
@@ -107,6 +108,8 @@ python3 scripts/observations/mcp-performance/verify_hermes.py /tmp/caldav-perf-n
 ```
 
 O proxy preserva cada byte MCP e registra testemunhas sanitizadas. Wrapper e proxy
+validam a candidata preparada antes de iniciar o cliente/servidor; o proxy registra
+a fonte e os hashes de todas as dependências. A verificação direta usa a mesma checagem. Ambos
 recusam um wire log existente antes de iniciar o cliente/servidor. Use um diretório
 de evidência novo para outra tentativa. O proxy não implementa MRTR pelo Hermes.
 O segundo comando verifica COMPLETED no Radicale e completa
@@ -170,12 +173,14 @@ por delta do processo é usada somente sem chamadas sobrepostas no mesmo filho.
 ```bash
 dotnet tool install dotnet-counters --tool-path /tmp/caldav-perf-new/profilers
 dotnet tool install dotnet-trace --tool-path /tmp/caldav-perf-new/profilers
-python3 scripts/observations/mcp-performance/profile.py /tmp/caldav-perf-new /tmp/caldav-perf-new/baseline/DotnetAgents.CalDav.Mcp.dll /tmp/caldav-perf-new/profilers --name baseline-profile
+python3 scripts/observations/mcp-performance/profile.py /tmp/caldav-perf-new /tmp/caldav-perf-new/baseline/DotnetAgents.CalDav.Mcp.dll /tmp/caldav-perf-new/profilers --build baseline --name baseline-profile
 python3 scripts/observations/mcp-performance/telemetry.py /tmp/caldav-perf-new complete --zip
 ```
 
 Consulte `dotnet-trace list-profiles`, `collect --help`, `dotnet-counters collect
 --help`, `aspire export --help` e `aspire otel spans --help` na versão instalada.
+Piloto e profiling validam a candidata por padrão; `--build baseline` seleciona
+o manifesto da baseline, e essa identidade fica registrada com o processo.
 EventPipe `dotnet-sampled-thread-time` inclui esperas; seus percentuais não são
 percentuais de CPU. Runtime counters são coleta externa, não métricas já
 exportadas pelo produto. Para a comparação síncrona de alocação, copie

--- a/scripts/observations/mcp-performance/README.md
+++ b/scripts/observations/mcp-performance/README.md
@@ -1,0 +1,161 @@
+# Observação de performance por MCP stdio
+
+Harness local para comparar o SHA inicial com o checkout candidato. Usa somente
+Python stdlib para protocolo, fixtures e medidas. Hermes usa o Python da sua
+instalação, com PyYAML e python-dotenv existentes. Não há dependência nova no
+produto, AppHost, endpoint HTTP do MCP ou gate de tempo de máquina.
+
+O protocolo moderno `2026-07-28` negocia via `server/discover`; `initialize` é
+legado. O driver verifica `supportedVersions`, capabilities, catálogo e o
+assembly mapeado pelo processo Linux. `_meta` acompanha cada request. Todos os
+Continues conservam o processo original. MRTR conserva `requestState` e envia
+`inputResponses` na segunda chamada; confirmação nunca entra em `arguments`.
+
+## Preparação
+
+Execute a partir da raiz do repositório. Use diretório externo novo. O baseline
+fica em clone Git compartilhado local, sem alterar branches ou configurações
+existentes. A execução de 2026-09-05 preservou o Release original diretamente
+antes de editar; o script abaixo permite repetir com o mesmo SHA de origem.
+
+```bash
+bash scripts/observations/mcp-performance/prepare.sh /tmp/caldav-perf-new 37cdba56f3c957ee8f241eadf1e55b883e950458
+python3 scripts/observations/mcp-performance/infra.py up /tmp/caldav-perf-new
+python3 scripts/observations/mcp-performance/infra.py seed /tmp/caldav-perf-new
+python3 scripts/observations/mcp-performance/infra.py verify /tmp/caldav-perf-new
+```
+
+`infra.py` reutiliza imagem, autenticação e storage do `RadicaleFixture`, com
+portas dinâmicas em loopback. Radicale 3.7.8 e Dashboard 13.4.2 mantêm os digests
+do checkout. Ambos recebem limites de 4 CPUs/2 GiB. Dashboard conserva login por
+token e autenticação por chave na API de exportação. O manifesto privado tem
+modo 0600. Não copie esse manifesto, config do Hermes, logs privados ou chaves
+ao Git.
+
+Seed 20260905: 600 Events e 600 To-dos distribuídos em 180 dias desde
+2026-07-01; 60 recorrentes por tipo, 30 Events date-only e 12 cancelados;
+390 To-dos abertos, 180 completos e 30 cancelados. Arquivo vazio desde o início.
+Janela fixa: 2026-07-01 a 2026-12-31 UTC; contexto America/Sao_Paulo; CalDAV usa
+URL raiz, sem encurtar discovery pela URL do principal. PROPFIND Depth:1 com
+ETags verifica os recursos persistidos. `corpus.json` registra contagens e hash
+das entradas determinísticas. Seeding e limpeza ficam fora da medida.
+
+## Matriz funcional e clientes
+
+```bash
+python3 scripts/observations/mcp-performance/functional.py /tmp/caldav-perf-new /tmp/caldav-perf-new/candidate/DotnetAgents.CalDav.Mcp.dll
+python3 scripts/observations/mcp-performance/edges.py /tmp/caldav-perf-new /tmp/caldav-perf-new/baseline/DotnetAgents.CalDav.Mcp.dll /tmp/caldav-perf-new/candidate/DotnetAgents.CalDav.Mcp.dll
+```
+
+`functional.py` percorre o catálogo vivo completo com exact habilitado somente
+no filho correspondente. Inclui queries limitadas e não limitadas quando
+permitidas, Start/Continue 1/5/200, recursos, criação/patch/conclusão, cinco
+mutações de recorrência, Move vazio/populado, exact create/replace/move e deletes
+de recurso/calendário por MRTR. Releitura HTTP verifica mutações e ausência.
+`edges.py` cobre leituras de controle, OTLP ligado/desligado/indisponível, EOF,
+escalas e falhas esperadas de limites. Uma falha esperada não conta como operação
+útil. O store só retém snapshots que precisam de continuação; corpus vazio não
+serve para testar sua saturação.
+
+Use a versão e o Python da instalação Hermes que `hermes --version` identifica.
+A prova implementada aceita o perfil OpenRouter já configurado. Ela lê somente
+modelo, reasoning e a credencial desse provedor, grava configuração isolada em
+`hermes-isolated` e habilita somente o MCP `perf`. Não muda o perfil original.
+Exemplo da máquina desta execução:
+
+```bash
+/home/jhow/.hermes/hermes-agent/venv/bin/python scripts/observations/mcp-performance/hermes.py /tmp/caldav-perf-new /tmp/caldav-perf-new/candidate/DotnetAgents.CalDav.Mcp.dll
+python3 scripts/observations/mcp-performance/verify_hermes.py /tmp/caldav-perf-new /tmp/caldav-perf-new/candidate/DotnetAgents.CalDav.Mcp.dll
+```
+
+O proxy preserva cada byte MCP e registra testemunhas sanitizadas. Não implementa
+MRTR pelo Hermes. O segundo comando verifica COMPLETED no Radicale e completa
+a limpeza via cliente direto quando o Hermes parou em input_required. Ele exige
+que a fixture ainda exista; se uma versão futura do Hermes completar o delete,
+adapte a verificação à ausência autoritativa e conserve sua evidência de wire.
+Inferência não entra na latência atribuída ao MCP. Guarde `hermes-usage.json`
+como custo separado, sem alegar tracing da inferência.
+
+## Comparação
+
+Não rode builds, testes, profiling ou outro benchmark em paralelo. Restaure
+600/600/0 antes de iniciar. Os comandos abaixo alternam baseline/candidato
+entre blocos/coortes e recusam sobrescrever amostras de um nome existente.
+
+```bash
+python3 scripts/observations/mcp-performance/benchmark.py /tmp/caldav-perf-new /tmp/caldav-perf-new/baseline/DotnetAgents.CalDav.Mcp.dll /tmp/caldav-perf-new/candidate/DotnetAgents.CalDav.Mcp.dll --name continue-serial
+python3 scripts/observations/mcp-performance/benchmark.py /tmp/caldav-perf-new /tmp/caldav-perf-new/baseline/DotnetAgents.CalDav.Mcp.dll /tmp/caldav-perf-new/candidate/DotnetAgents.CalDav.Mcp.dll --name start-serial --mode start --samples 30
+```
+
+Continue: três blocos de 100 por família e tamanho, após 20 aquecimentos para
+estabilizar o JIT observado. Start: três blocos de 30, coortes de cinco
+aquecimentos/cinco medidos; reiniciar o filho entre coortes evita exceder 16
+snapshots/128 MiB/10 minutos. A redução de amostras de Start foi definida antes
+da comparação pelo custo da aquisição integral e da retenção, e reduz a precisão
+do p95. Nenhum limite foi alterado. Startup/discovery MCP e shutdown ficam nos
+arquivos `*-processes.jsonl`, separados das chamadas aquecidas.
+
+Para concorrência, repita Continue com `--sizes 200 --concurrency 2` e `4`, cada
+qual com `--name` próprio. `--topology single_session` envia chamadas simultâneas
+ao mesmo processo; `--topology processes` usa um filho por chamada concorrente,
+com snapshot próprio. Para custo limitado nos controles entre processos, use
+`--samples 32` (divisível por quatro). Nunca compare throughput de uma topologia
+como se fosse outra. Os aquecimentos concorrentes usam 20 rodadas na carga escolhida.
+
+`--compare-otlp` exige o mesmo assembly nos dois argumentos: a etiqueta baseline
+usa OTLP e a candidata o desabilita, alternando a ordem entre blocos. Use
+`--sizes 200 --samples 30 --name otlp-overhead`. `--no-otlp` desabilita ambos.
+p50/p95 usam nearest rank, `ceil(p*N)`; p99 é
+apenas descritivo. Os JSONL retêm aquecimentos, medidas, falhas, CPU do processo,
+RSS/HWM, bytes stdio e hashes de itens. CPU de `/proc` tem resolução de 10 ms
+nesta máquina. `*-batches.jsonl` fornece tempo de lote e throughput efetivo;
+o inverso da latência média só representa capacidade serial de serviço.
+
+## Profiling e exportação
+
+```bash
+dotnet tool install dotnet-counters --tool-path /tmp/caldav-perf-new/profilers
+dotnet tool install dotnet-trace --tool-path /tmp/caldav-perf-new/profilers
+python3 scripts/observations/mcp-performance/profile.py /tmp/caldav-perf-new /tmp/caldav-perf-new/baseline/DotnetAgents.CalDav.Mcp.dll /tmp/caldav-perf-new/profilers --name baseline-profile
+python3 scripts/observations/mcp-performance/telemetry.py /tmp/caldav-perf-new complete --zip
+```
+
+Consulte `dotnet-trace list-profiles`, `collect --help`, `dotnet-counters collect
+--help`, `aspire export --help` e `aspire otel spans --help` na versão instalada.
+EventPipe `dotnet-sampled-thread-time` inclui esperas; seus percentuais não são
+percentuais de CPU. Runtime counters são coleta externa, não métricas já
+exportadas pelo produto. Para a comparação síncrona de alocação, copie
+`schema-observation/` ao diretório externo, compile e passe diretório do assembly,
+uma página estruturada real de MCP salva localmente e nome da ferramenta. O
+programa usa reflexão para chamar o guard original em cada assembly sobre o
+mesmo JSON, após 20 aquecimentos e com 100 amostras. Não mede transporte.
+
+O exportador usa a API suportada do Dashboard e exige
+`returnedCount == totalCount`; não aceita truncamento silencioso. O Dashboard
+mantém 50.000 traces e 100.000 logs; exporte por bloco antes da retenção encher.
+O ZIP do Aspire conserva formato importável. As exportações completas ficam
+fora do Git. Relacione calls a spans por serviço, ferramenta e intervalo UTC;
+não invente propagação de trace pelo modelo. Contagens HTTP vêm dos spans de
+tentativas; bytes HTTP não estão na allowlist atual. Bytes registrados pelo
+driver são JSON-RPC stdio, não corpos CalDAV.
+
+## Gates e limpeza
+
+Depois de qualquer mudança de produto, execute os restores, build Release,
+`run-test-suite.sh` com diretório externo vazio e Slopwatch na ordem do AGENTS.md.
+Não edite o checkout enquanto a suíte observa seu estado. Gate de pacote usa
+metadata versionada temporária com `scripts/prepare-release-metadata.sh` e
+`scripts/verify-release-package.sh`, sem modificar `.mcp/server.json` de origem.
+`package.sh <diretório-externo>` reproduz esse gate num clone local com o patch de
+produto, gerando somente o pacote de teste `0.0.0-perf.20260905`, sem publicação.
+
+Antes de remover infraestrutura, exporte e verifique 600/600/0. `infra.py down`
+confere a label de propriedade antes de remover seus containers e volumes
+anônimos, e grava `cleanup.json`. Depois remova somente `hermes-isolated`, clone
+e ferramentas temporários criados nesta execução. Retenha amostras, hashes e
+exportações sanitizadas pelo tempo desejado. Preserve caches e containers alheios.
+
+```bash
+python3 scripts/observations/mcp-performance/infra.py verify /tmp/caldav-perf-new
+python3 scripts/observations/mcp-performance/infra.py down /tmp/caldav-perf-new
+```

--- a/scripts/observations/mcp-performance/README.md
+++ b/scripts/observations/mcp-performance/README.md
@@ -10,6 +10,9 @@ legado. O driver verifica `supportedVersions`, capabilities, catálogo e o
 assembly mapeado pelo processo Linux. `_meta` acompanha cada request. Todos os
 Continues conservam o processo original. MRTR conserva `requestState` e envia
 `inputResponses` na segunda chamada; confirmação nunca entra em `arguments`.
+Falha ou cancelamento durante a negociação fecha stdin, aguarda o filho e o mata
+se exceder o encerramento de cinco segundos. As tarefas de leitura são encerradas
+antes de propagar a falha original.
 
 ## Preparação
 

--- a/scripts/observations/mcp-performance/README.md
+++ b/scripts/observations/mcp-performance/README.md
@@ -32,6 +32,14 @@ token e autenticação por chave na API de exportação. O manifesto privado tem
 modo 0600. Não copie esse manifesto, config do Hermes, logs privados ou chaves
 ao Git.
 
+`prepare.sh` grava `baseline-build.json` e `candidate-build.json` com os SHAs
+reais, estado de alterações locais, hash do patch e dos arquivos novos, antes do
+build. Confere que as fontes não mudaram durante a compilação e associa os hashes
+dos assemblies copiados. `aggregate.py` exige esses manifestos; não infere a
+identidade pelo Git no momento da análise. Os manifestos sobrevivem à limpeza dos
+clones. Execuções históricas anteriores a esse registro mantêm suas evidências
+originais, sem reconstruir retroativamente a identidade a partir do checkout atual.
+
 Seed 20260905: 600 Events e 600 To-dos distribuídos em 180 dias desde
 2026-07-01; 60 recorrentes por tipo, 30 Events date-only e 12 cancelados;
 390 To-dos abertos, 180 completos e 30 cancelados. Arquivo vazio desde o início.
@@ -94,6 +102,9 @@ snapshots/128 MiB/10 minutos. A redução de amostras de Start foi definida ante
 da comparação pelo custo da aquisição integral e da retenção, e reduz a precisão
 do p95. Nenhum limite foi alterado. Startup/discovery MCP e shutdown ficam nos
 arquivos `*-processes.jsonl`, separados das chamadas aquecidas.
+Contagens de blocos, amostras e coortes devem ser positivas. Start exige que
+`--samples` seja divisível por `--cohort-samples` e usa somente coortes seriais
+na topologia `single_session`; argumentos incompatíveis falham antes da execução.
 
 Para concorrência, repita Continue com `--sizes 200 --concurrency 2` e `4`, cada
 qual com `--name` próprio. `--topology single_session` envia chamadas simultâneas
@@ -146,8 +157,16 @@ Depois de qualquer mudança de produto, execute os restores, build Release,
 Não edite o checkout enquanto a suíte observa seu estado. Gate de pacote usa
 metadata versionada temporária com `scripts/prepare-release-metadata.sh` e
 `scripts/verify-release-package.sh`, sem modificar `.mcp/server.json` de origem.
-`package.sh <diretório-externo>` reproduz esse gate num clone local com o patch de
-produto, gerando somente o pacote de teste `0.0.0-perf.20260905`, sem publicação.
+`package.sh <diretório-externo>` reproduz esse gate num clone local com o diff
+completo contra HEAD, incluindo alterações staged e arquivos de build da raiz,
+mais arquivos novos não ignorados. Um checkout limpo usa diretamente seu commit.
+Gera somente o pacote de teste `0.0.0-perf.20260905`, sem publicação. A prova Hermes
+propaga o código de saída do cliente depois de emitir seu resumo diagnóstico.
+
+Execute `python3 scripts/observations/mcp-performance/test_harness.py` para as
+regressões do harness. Elas usam repositórios temporários e executáveis simulados
+para verificar identidade, contagens e tratamento de falhas; não substituem a
+matriz MCP real nem o gate de pacote.
 
 Antes de remover infraestrutura, exporte e verifique 600/600/0. `infra.py down`
 confere a label de propriedade antes de remover seus containers e volumes

--- a/scripts/observations/mcp-performance/README.md
+++ b/scripts/observations/mcp-performance/README.md
@@ -51,6 +51,8 @@ do build correspondente. Inverter baseline/candidata é erro antes da medição.
 No controle `--compare-otlp`, ambos apontam ao mesmo build e conservam essa
 identidade na agregação. Cada processo precisa corresponder ao seu argumento,
 inclusive ao hash de Core; pertencer ao conjunto dos dois builds não basta.
+No controle OTLP, o conjunto de dependências também deve ser idêntico entre os
+argumentos; igualdade somente de MCP e Core não basta.
 Os manifestos verificam também os assets declarados em `.deps.json` e os hashes
 de todo o diretório de execução copiado, incluindo dependências, assets por RID,
 deps e runtimeconfig. O driver registra esse conjunto para cada processo. Mantenha
@@ -84,6 +86,9 @@ no filho correspondente. Inclui queries limitadas e não limitadas quando
 permitidas, Start/Continue 1/5/200, recursos, criação/patch/conclusão, cinco
 mutações de recorrência, Move vazio/populado, exact create/replace/move e deletes
 de recurso/calendário por MRTR. Releitura HTTP verifica mutações e ausência.
+Para a fixture UTC de recorrência, a releitura confere UID, regra e horários do
+master, RDATE/EXDATE e o RECURRENCE-ID/STATUS do override solicitado após cada
+uma das cinco mutações. Operações sem efeito ou em outra instância falham.
 `edges.py` cobre leituras de controle, OTLP ligado/desligado/indisponível, EOF,
 escalas e falhas esperadas de limites. Uma falha esperada não conta como operação
 útil. O store só retém snapshots que precisam de continuação; corpus vazio não
@@ -212,6 +217,20 @@ propaga o código de saída do cliente depois de emitir seu resumo diagnóstico.
 O proxy também propaga o código de saída do MCP e termina de encaminhar stderr
 antes de registrar o encerramento.
 
+Para associar os gates à comparação preparada, use o wrapper sem mudar o estado
+Git entre `prepare.sh` e a execução abaixo:
+
+```bash
+python3 scripts/observations/mcp-performance/gates.py /tmp/caldav-perf-new --name gates-final
+```
+
+Ele executa os cinco comandos exigidos pelo repositório, na mesma ordem, e grava
+`gate-source.json` com a identidade inicial/final da fonte e do runtime. A marca
+de conclusão só aparece após todos os comandos passarem. O arquivo é colocado
+no diretório de artefatos depois que o runner termina, preservando a exigência de
+diretório inicialmente vazio. Use outro nome para repetir uma execução falha.
+Diretórios históricos sem essa prova não recebem identidade retroativamente.
+
 Execute `python3 scripts/observations/mcp-performance/test_harness.py` para as
 regressões do harness. Elas usam repositórios temporários e executáveis simulados
 para verificar identidade, contagens e tratamento de falhas; não substituem a
@@ -226,6 +245,8 @@ A agregação executa `verify-test-artifacts.sh` na fase `complete`, incluindo o
 manifesto das variantes estrita e de fuso alternativo, e `verify-coverage.sh`
 com os limiares 90%/85%. Diretórios parciais, contadores malsucedidos e cobertura
 insuficiente são rejeitados antes da emissão do resultado.
+Ela também exige que `gate-source.json` certifique exatamente a fonte e o runtime
+da candidata preparada; gates verdes de outro checkout são recusados.
 
 ```bash
 python3 scripts/observations/mcp-performance/aggregate.py /tmp/caldav-perf-new /tmp/caldav-perf-new/results.json --gates gates-final --runs continue-serial start-serial --traces /tmp/caldav-perf-new/complete-traces.json

--- a/scripts/observations/mcp-performance/README.md
+++ b/scripts/observations/mcp-performance/README.md
@@ -186,7 +186,7 @@ ferramenta precisa corresponder à página capturada. O
 programa usa reflexão para chamar o guard original em cada assembly sobre o
 mesmo JSON, após 20 aquecimentos e com 100 amostras. Não mede transporte.
 A agregação exige o hash de assembly correspondente ao build de cada observação,
-além de ferramenta e payload idênticos entre baseline e candidata.
+além de ferramenta, payload e versão do runtime .NET idênticos entre baseline e candidata.
 O observador também registra os hashes dos arquivos de runtime e rejeita mudanças
 durante a coleta; esses hashes devem corresponder ao manifesto do build.
 
@@ -215,10 +215,15 @@ metadata versionada temporária com `scripts/prepare-release-metadata.sh` e
 `package.sh <diretório-externo>` reproduz esse gate num clone local com o diff
 completo contra HEAD, incluindo alterações staged e arquivos de build da raiz,
 mais arquivos novos não ignorados. Um checkout limpo usa diretamente seu commit.
+O gate exige `candidate-build.json` desse diretório: verifica a fonte atual antes
+do clone e a fonte copiada antes e depois da validação do pacote. Mudanças após
+`prepare.sh` exigem preparar outra candidata.
 Gera somente o pacote de teste `0.0.0-perf.20260905`, sem publicação. A prova Hermes
 propaga o código de saída do cliente depois de emitir seu resumo diagnóstico.
 O proxy também propaga o código de saída do MCP e termina de encaminhar stderr
 antes de registrar o encerramento.
+Sua configuração sanitizada retém somente provedor e nome do modelo, com permissão
+0600; credenciais, headers e opções arbitrárias do perfil ficam fora dessa evidência.
 
 Para associar os gates à comparação preparada, use o wrapper sem mudar o estado
 Git entre `prepare.sh` e a execução abaixo:

--- a/scripts/observations/mcp-performance/README.md
+++ b/scripts/observations/mcp-performance/README.md
@@ -95,6 +95,9 @@ uma das cinco mutações. Operações sem efeito ou em outra instância falham.
 escalas e falhas esperadas de limites. Uma falha esperada não conta como operação
 útil. O store só retém snapshots que precisam de continuação; corpus vazio não
 serve para testar sua saturação.
+As verificações do harness usam condicionais explícitas, preservadas com
+`python -O` e `PYTHONOPTIMIZE`. EOF exige saída zero e ambos os streams vazios;
+a agregação rejeita contagens incompletas de traces antes de produzir resultados.
 
 Use a versão e o Python da instalação Hermes que `hermes --version` identifica.
 A prova implementada aceita o perfil OpenRouter já configurado. Ela lê somente

--- a/scripts/observations/mcp-performance/README.md
+++ b/scripts/observations/mcp-performance/README.md
@@ -31,6 +31,10 @@ do checkout. Ambos recebem limites de 4 CPUs/2 GiB. Dashboard conserva login por
 token e autenticação por chave na API de exportação. O manifesto privado tem
 modo 0600. Não copie esse manifesto, config do Hermes, logs privados ou chaves
 ao Git.
+O arquivo de credenciais fica sob `radicale-private/`, criado com modo 0700.
+Somente o diretório interno é montado no container, com os arquivos legíveis pelo
+usuário não-root da imagem. O diretório privado do host bloqueia acesso de outros
+usuários locais, inclusive quando o umask é 022.
 
 `prepare.sh` grava `baseline-build.json` e `candidate-build.json` com os SHAs
 reais, estado de alterações locais, hash do patch e dos arquivos novos, antes do
@@ -50,8 +54,11 @@ Seed 20260905: 600 Events e 600 To-dos distribuídos em 180 dias desde
 390 To-dos abertos, 180 completos e 30 cancelados. Arquivo vazio desde o início.
 Janela fixa: 2026-07-01 a 2026-12-31 UTC; contexto America/Sao_Paulo; CalDAV usa
 URL raiz, sem encurtar discovery pela URL do principal. PROPFIND Depth:1 com
-ETags verifica os recursos persistidos. `corpus.json` registra contagens e hash
-das entradas determinísticas. Seeding e limpeza ficam fora da medida.
+ETags verifica os recursos persistidos. Cada PUT do seed precisa retornar um ETag
+forte, salvo no manifesto privado. `verify` compara caminhos e ETags completos:
+editar ou substituir um recurso mantendo a contagem também falha. `corpus.json`
+registra contagens e hash das entradas determinísticas. Seeding e limpeza ficam
+fora da medida.
 
 ## Matriz funcional e clientes
 
@@ -130,11 +137,15 @@ como se fosse outra. Os aquecimentos concorrentes usam 20 rodadas na carga escol
 `--compare-otlp` exige o mesmo assembly nos dois argumentos: a etiqueta baseline
 usa OTLP e a candidata o desabilita, alternando a ordem entre blocos. Use
 `--sizes 200 --samples 30 --name otlp-overhead`. `--no-otlp` desabilita ambos.
+As duas flags são mutuamente exclusivas.
 p50/p95 usam nearest rank, `ceil(p*N)`; p99 é
 apenas descritivo. Os JSONL retêm aquecimentos, medidas, falhas, CPU do processo,
 RSS/HWM, bytes stdio e hashes de itens. CPU de `/proc` tem resolução de 10 ms
 nesta máquina. `*-batches.jsonl` fornece tempo de lote e throughput efetivo;
 o inverso da latência média só representa capacidade serial de serviço.
+Em `single_session` com concorrência maior que um, CPU por chamada e sua média
+ficam `null`: os intervalos simultâneos incluem CPU das outras chamadas. A medição
+por delta do processo é usada somente sem chamadas sobrepostas no mesmo filho.
 
 ## Profiling e exportação
 
@@ -154,6 +165,8 @@ exportadas pelo produto. Para a comparação síncrona de alocação, copie
 uma página estruturada real de MCP salva localmente e nome da ferramenta. O
 programa usa reflexão para chamar o guard original em cada assembly sobre o
 mesmo JSON, após 20 aquecimentos e com 100 amostras. Não mede transporte.
+A agregação exige o hash de assembly correspondente ao build de cada observação,
+além de ferramenta e payload idênticos entre baseline e candidata.
 
 O exportador usa a API suportada do Dashboard e exige
 `returnedCount == totalCount`; não aceita truncamento silencioso. O Dashboard

--- a/scripts/observations/mcp-performance/aggregate.py
+++ b/scripts/observations/mcp-performance/aggregate.py
@@ -46,7 +46,9 @@ def join_run(root,name,traces,builds):
                     and low<=int(trace['start_ns'])<=high):
                     matches[trace['trace_id']]=trace
         expected=len(rows) if rows[0]['otlp'] else 0
-        assert len(matches)==expected,(name,summary['tool'],summary['size'],summary['label'],len(matches),expected)
+        if len(matches)!=expected:
+            raise RuntimeError(f'Incomplete trace matches for {name}/{summary["tool"]}/{summary["label"]}: '
+                               f'found {len(matches)}, expected {expected}')
         summary.update(run=name,topology=rows[0]['topology'],otlp=rows[0]['otlp'],
             trace_matches=len(matches),mean_stdio_response_bytes=statistics.mean(r['response_bytes'] for r in rows),
             distinct_item_hashes=sorted({r['item_sha256'] for r in rows}))
@@ -63,7 +65,8 @@ def join_run(root,name,traces,builds):
             http.update(trace['http']);statuses.update(trace['http_statuses'])
             for phase,value in trace['phases'].items():phases[phase].append(value)
         if summary['mode']=='continue':
-            assert not http,(name,summary['tool'],'Continue performed HTTP')
+            if http:
+                raise RuntimeError('Continue performed HTTP')
         summary.update(server_mcp_p50_ms=percentile([t['outer_ms'] for t in group],.5),
             server_mcp_p95_ms=percentile([t['outer_ms'] for t in group],.95),
             operation_p50_ms=percentile([t['operation_ms'] for t in group],.5),
@@ -73,7 +76,8 @@ def join_run(root,name,traces,builds):
             mean_phase_ms={k:statistics.mean(v) for k,v in phases.items()},
             representative_trace_ids=[t['trace_id'] for t in sorted(group,key=lambda t:t['outer_ms'])[::max(1,len(group)//3)][:3]])
     for p in processes:
-        assert p['assembly_mapped'] and p['exit_code']==0 and p['stderr_bytes']==0
+        if not p['assembly_mapped'] or p['exit_code']!=0 or p['stderr_bytes']!=0:
+            raise RuntimeError('Measured process identity or clean shutdown was not verified')
     startup=[]
     for label in ['baseline','candidate']:
         group=[p for p in processes if p['label']==label]

--- a/scripts/observations/mcp-performance/aggregate.py
+++ b/scripts/observations/mcp-performance/aggregate.py
@@ -97,19 +97,32 @@ def load_traces(paths):
     return list(traces.values())
 
 
+def schema_observations(root,builds):
+    allocation=[]
+    expected_workload=None
+    for label in ['baseline','candidate']:
+        source=json.loads((root/('schema-'+label+'.json')).read_text());samples=source['samples']
+        if source['assemblySha256']!=builds[label]['assembly_sha256']['DotnetAgents.CalDav.Mcp.dll']:
+            raise RuntimeError(f'{label} schema observation does not match its prepared build')
+        workload=(source['tool'],source['payloadSha256'])
+        if expected_workload is not None and workload!=expected_workload:
+            raise RuntimeError('Schema observations require the same tool and payload')
+        expected_workload=workload
+        allocation.append(dict(label=label,n=len(samples),payload_sha256=source['payloadSha256'],
+            tool=source['tool'],assembly_sha256=source['assemblySha256'],
+            median_ms=statistics.median(s['elapsedMilliseconds'] for s in samples),
+            median_allocated_bytes=statistics.median(s['allocatedBytes'] for s in samples),
+            gc_collections={g:sum(s[g] for s in samples) for g in ['gen0','gen1','gen2']}))
+    return allocation
+
+
 def main(a):
     builds=load_builds(a.root)
     traces=load_traces(a.traces)
     results=[];startup=[]
     for name in a.runs:
         r,s=join_run(a.root,name,traces,builds);results+=r;startup+=s
-    allocation=[]
-    for label in ['baseline','candidate']:
-        source=json.loads((a.root/('schema-'+label+'.json')).read_text());samples=source['samples']
-        allocation.append(dict(label=label,n=len(samples),payload_sha256=source['payloadSha256'],
-            median_ms=statistics.median(s['elapsedMilliseconds'] for s in samples),
-            median_allocated_bytes=statistics.median(s['allocatedBytes'] for s in samples),
-            gc_collections={g:sum(s[g] for s in samples) for g in ['gen0','gen1','gen2']}))
+    allocation=schema_observations(a.root,builds)
     gates={}
     for path in sorted((a.root/a.gates).glob('*.trx')):
         gates[path.name]=ET.parse(path).getroot().find('.//{*}Counters').attrib

--- a/scripts/observations/mcp-performance/aggregate.py
+++ b/scripts/observations/mcp-performance/aggregate.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Join measured windows to exported server traces; emit compact, sanitized evidence."""
+import argparse
+import collections
+import hashlib
+import json
+import math
+from pathlib import Path
+import statistics
+import subprocess
+import xml.etree.ElementTree as ET
+
+
+def percentile(values,p):
+    ordered=sorted(values)
+    return ordered[math.ceil(p*len(ordered))-1]
+
+
+def lines(path):
+    return [json.loads(line) for line in path.read_text().splitlines()]
+
+
+def join_run(root,name,traces):
+    summaries=json.loads((root/(name+'-summary.json')).read_text())
+    samples=[r for r in lines(root/(name+'-samples.jsonl')) if not r['warmup']]
+    batch_path=root/(name+'-batches.jsonl')
+    batches=lines(batch_path) if batch_path.exists() else []
+    for summary in summaries:
+        rows=[r for r in samples if r['label']==summary['label'] and r['tool']==summary['tool']
+              and r['size']==summary['size']]
+        cohorts=collections.defaultdict(list)
+        for row in rows:
+            cohorts[(row['block'],row['cohort'])].append(row)
+        matches={}
+        for cohort in cohorts.values():
+            if not cohort[0]['otlp']:
+                continue
+            low=min(r['timestamp_ns'] for r in cohort)
+            high=max(r['timestamp_ns']+r['elapsed_ms']*1e6 for r in cohort)
+            for trace in traces:
+                if (trace['service']==cohort[0]['service']
+                    and trace['attributes'].get('caldav.tool.name')==summary['tool']
+                    and low<=int(trace['start_ns'])<=high):
+                    matches[trace['trace_id']]=trace
+        expected=len(rows) if rows[0]['otlp'] else 0
+        assert len(matches)==expected,(name,summary['tool'],summary['size'],summary['label'],len(matches),expected)
+        summary.update(run=name,topology=rows[0]['topology'],otlp=rows[0]['otlp'],
+            trace_matches=len(matches),mean_stdio_response_bytes=statistics.mean(r['response_bytes'] for r in rows),
+            distinct_item_hashes=sorted({r['item_sha256'] for r in rows}))
+        matching_batches=[b for b in batches if b['label']==summary['label'] and b['tool']==summary['tool']
+                          and b['size']==summary['size']]
+        if matching_batches:
+            summary['driver_ops_per_second']=1000*sum(b['successful_ops'] for b in matching_batches)/sum(
+                b['elapsed_ms'] for b in matching_batches)
+        if not matches:
+            continue
+        group=list(matches.values())
+        http=collections.Counter();statuses=collections.Counter();phases=collections.defaultdict(list)
+        for trace in group:
+            http.update(trace['http']);statuses.update(trace['http_statuses'])
+            for phase,value in trace['phases'].items():phases[phase].append(value)
+        if summary['mode']=='continue':
+            assert not http,(name,summary['tool'],'Continue performed HTTP')
+        summary.update(server_mcp_p50_ms=percentile([t['outer_ms'] for t in group],.5),
+            server_mcp_p95_ms=percentile([t['outer_ms'] for t in group],.95),
+            operation_p50_ms=percentile([t['operation_ms'] for t in group],.5),
+            operation_p95_ms=percentile([t['operation_ms'] for t in group],.95),
+            http_attempt_totals=dict(http),http_status_totals=dict(statuses),
+            retries=sum(t['retries'] for t in group),error_spans=sum(t['error_spans'] for t in group),
+            mean_phase_ms={k:statistics.mean(v) for k,v in phases.items()},
+            representative_trace_ids=[t['trace_id'] for t in sorted(group,key=lambda t:t['outer_ms'])[::max(1,len(group)//3)][:3]])
+    processes=lines(root/(name+'-processes.jsonl'))
+    for p in processes:
+        assert p['assembly_mapped'] and p['exit_code']==0 and p['stderr_bytes']==0
+    startup=[]
+    for label in ['baseline','candidate']:
+        group=[p for p in processes if p['label']==label]
+        startup.append(dict(run=name,label=label,processes=len(group),
+            startup_p50_ms=percentile([p['startup_ms'] for p in group],.5),
+            startup_p95_ms=percentile([p['startup_ms'] for p in group],.95),
+            shutdown_max_ms=max(p['shutdown_ms'] for p in group),
+            assembly_sha256=sorted({p['sha256'] for p in group}),
+            negotiated_versions=sorted({v for p in group for v in p['discovery']['result']['supportedVersions']})))
+    return summaries,startup
+
+
+def main(a):
+    traces=json.loads((a.root/'final-traces.json').read_text())
+    results=[];startup=[]
+    for name in a.runs:
+        r,s=join_run(a.root,name,traces);results+=r;startup+=s
+    allocation=[]
+    for label in ['baseline','candidate']:
+        source=json.loads((a.root/('schema-'+label+'.json')).read_text());samples=source['samples']
+        allocation.append(dict(label=label,n=len(samples),payload_sha256=source['payloadSha256'],
+            median_ms=statistics.median(s['elapsedMilliseconds'] for s in samples),
+            median_allocated_bytes=statistics.median(s['allocatedBytes'] for s in samples),
+            gc_collections={g:sum(s[g] for s in samples) for g in ['gen0','gen1','gen2']}))
+    gates={}
+    for path in sorted((a.root/a.gates).glob('*.trx')):
+        gates[path.name]=ET.parse(path).getroot().find('.//{*}Counters').attrib
+    coverage=ET.parse(a.root/a.gates/'coverage-report/Cobertura.xml').getroot().attrib
+    patch=subprocess.check_output(['git','diff','--','src','tests'])
+    result=dict(baseline_sha=subprocess.check_output(['git','rev-parse','HEAD'],text=True).strip(),
+        candidate_is_working_tree=True,product_and_test_patch_sha256=hashlib.sha256(patch).hexdigest(),
+        percentile_estimator='nearest rank ceil(p*n)',p99_is_descriptive_only=True,
+        full_evidence_directory=str(a.root),corpus=json.loads((a.root/'corpus.json').read_text()),
+        measurements=results,processes=startup,schema_guard=allocation,gates=gates,
+        coverage={k:coverage[k] for k in ['line-rate','branch-rate','lines-covered','lines-valid','branches-covered','branches-valid']})
+    a.output.write_text(json.dumps(result,indent=2))
+    print(f'Joined {sum(r["trace_matches"] for r in results)} measured operations without truncation')
+
+
+if __name__=='__main__':
+    p=argparse.ArgumentParser(description=__doc__)
+    p.add_argument('root',type=Path);p.add_argument('output',type=Path)
+    p.add_argument('--gates',default='gates-final')
+    p.add_argument('--runs',nargs='+',required=True)
+    main(p.parse_args())

--- a/scripts/observations/mcp-performance/aggregate.py
+++ b/scripts/observations/mcp-performance/aggregate.py
@@ -108,12 +108,12 @@ def schema_observations(root,builds):
             raise RuntimeError(f'{label} schema observation does not match its prepared build')
         if source['runtimeFilesSha256']!=builds[label]['runtime_files_sha256']:
             raise RuntimeError(f'{label} schema observation has different runtime dependencies')
-        workload=(source['tool'],source['payloadSha256'])
+        workload=(source['tool'],source['payloadSha256'],source['runtime'])
         if expected_workload is not None and workload!=expected_workload:
-            raise RuntimeError('Schema observations require the same tool and payload')
+            raise RuntimeError('Schema observations require the same tool, payload and .NET runtime')
         expected_workload=workload
         allocation.append(dict(label=label,n=len(samples),payload_sha256=source['payloadSha256'],
-            tool=source['tool'],assembly_sha256=source['assemblySha256'],
+            tool=source['tool'],runtime=source['runtime'],assembly_sha256=source['assemblySha256'],
             median_ms=statistics.median(s['elapsedMilliseconds'] for s in samples),
             median_allocated_bytes=statistics.median(s['allocatedBytes'] for s in samples),
             gc_collections={g:sum(s[g] for s in samples) for g in ['gen0','gen1','gen2']}))

--- a/scripts/observations/mcp-performance/aggregate.py
+++ b/scripts/observations/mcp-performance/aggregate.py
@@ -6,6 +6,7 @@ import json
 import math
 from pathlib import Path
 import statistics
+import subprocess
 import xml.etree.ElementTree as ET
 from build_manifest import load_builds, verify_process_inputs
 
@@ -104,6 +105,8 @@ def schema_observations(root,builds):
         source=json.loads((root/('schema-'+label+'.json')).read_text());samples=source['samples']
         if source['assemblySha256']!=builds[label]['assembly_sha256']['DotnetAgents.CalDav.Mcp.dll']:
             raise RuntimeError(f'{label} schema observation does not match its prepared build')
+        if source['runtimeFilesSha256']!=builds[label]['runtime_files_sha256']:
+            raise RuntimeError(f'{label} schema observation has different runtime dependencies')
         workload=(source['tool'],source['payloadSha256'])
         if expected_workload is not None and workload!=expected_workload:
             raise RuntimeError('Schema observations require the same tool and payload')
@@ -116,7 +119,18 @@ def schema_observations(root,builds):
     return allocation
 
 
+def validate_gates(directory):
+    scripts=Path(__file__).resolve().parents[2]
+    for command in [
+        ['bash',str(scripts/'verify-test-artifacts.sh'),str(directory),'complete'],
+        ['bash',str(scripts/'verify-coverage.sh'),str(directory/'coverage-report'),'0.90','0.85']]:
+        result=subprocess.run(command,capture_output=True,text=True)
+        if result.returncode:
+            raise RuntimeError('Gate evidence validation failed: '+result.stderr.strip())
+
+
 def main(a):
+    validate_gates(a.root/a.gates)
     builds=load_builds(a.root)
     traces=load_traces(a.traces)
     results=[];startup=[]

--- a/scripts/observations/mcp-performance/aggregate.py
+++ b/scripts/observations/mcp-performance/aggregate.py
@@ -2,13 +2,12 @@
 """Join measured windows to exported server traces; emit compact, sanitized evidence."""
 import argparse
 import collections
-import hashlib
 import json
 import math
 from pathlib import Path
 import statistics
-import subprocess
 import xml.etree.ElementTree as ET
+from build_manifest import load_builds
 
 
 def percentile(values,p):
@@ -80,11 +79,13 @@ def join_run(root,name,traces):
             startup_p95_ms=percentile([p['startup_ms'] for p in group],.95),
             shutdown_max_ms=max(p['shutdown_ms'] for p in group),
             assembly_sha256=sorted({p['sha256'] for p in group}),
+            core_assembly_sha256=sorted({p['core_sha256'] for p in group}),
             negotiated_versions=sorted({v for p in group for v in p['discovery']['result']['supportedVersions']})))
     return summaries,startup
 
 
 def main(a):
+    builds=load_builds(a.root)
     traces=json.loads((a.root/'final-traces.json').read_text())
     results=[];startup=[]
     for name in a.runs:
@@ -100,9 +101,15 @@ def main(a):
     for path in sorted((a.root/a.gates).glob('*.trx')):
         gates[path.name]=ET.parse(path).getroot().find('.//{*}Counters').attrib
     coverage=ET.parse(a.root/a.gates/'coverage-report/Cobertura.xml').getroot().attrib
-    patch=subprocess.check_output(['git','diff','--','src','tests'])
-    result=dict(baseline_sha=subprocess.check_output(['git','rev-parse','HEAD'],text=True).strip(),
-        candidate_is_working_tree=True,product_and_test_patch_sha256=hashlib.sha256(patch).hexdigest(),
+    for process in startup:
+        for field,name in [('assembly_sha256','DotnetAgents.CalDav.Mcp.dll'),
+                           ('core_assembly_sha256','DotnetAgents.CalDav.Core.dll')]:
+            known={build['assembly_sha256'][name] for build in builds.values()}
+            if not set(process[field]).issubset(known):
+                raise RuntimeError('Measured process does not match either prepared build')
+    result=dict(baseline_sha=builds['baseline']['source']['sha'],
+        candidate_sha=builds['candidate']['source']['sha'],
+        candidate_is_working_tree=builds['candidate']['source']['dirty'],builds=builds,
         percentile_estimator='nearest rank ceil(p*n)',p99_is_descriptive_only=True,
         full_evidence_directory=str(a.root),corpus=json.loads((a.root/'corpus.json').read_text()),
         measurements=results,processes=startup,schema_guard=allocation,gates=gates,

--- a/scripts/observations/mcp-performance/aggregate.py
+++ b/scripts/observations/mcp-performance/aggregate.py
@@ -7,7 +7,7 @@ import math
 from pathlib import Path
 import statistics
 import xml.etree.ElementTree as ET
-from build_manifest import load_builds
+from build_manifest import load_builds, verify_process_inputs
 
 
 def percentile(values,p):
@@ -19,7 +19,9 @@ def lines(path):
     return [json.loads(line) for line in path.read_text().splitlines()]
 
 
-def join_run(root,name,traces):
+def join_run(root,name,traces,builds):
+    processes=lines(root/(name+'-processes.jsonl'))
+    inputs=verify_process_inputs(root,name,processes,builds)
     summaries=json.loads((root/(name+'-summary.json')).read_text())
     samples=[r for r in lines(root/(name+'-samples.jsonl')) if not r['warmup']]
     batch_path=root/(name+'-batches.jsonl')
@@ -68,13 +70,13 @@ def join_run(root,name,traces):
             retries=sum(t['retries'] for t in group),error_spans=sum(t['error_spans'] for t in group),
             mean_phase_ms={k:statistics.mean(v) for k,v in phases.items()},
             representative_trace_ids=[t['trace_id'] for t in sorted(group,key=lambda t:t['outer_ms'])[::max(1,len(group)//3)][:3]])
-    processes=lines(root/(name+'-processes.jsonl'))
     for p in processes:
         assert p['assembly_mapped'] and p['exit_code']==0 and p['stderr_bytes']==0
     startup=[]
     for label in ['baseline','candidate']:
         group=[p for p in processes if p['label']==label]
         startup.append(dict(run=name,label=label,processes=len(group),
+            source=inputs[label]['source'],
             startup_p50_ms=percentile([p['startup_ms'] for p in group],.5),
             startup_p95_ms=percentile([p['startup_ms'] for p in group],.95),
             shutdown_max_ms=max(p['shutdown_ms'] for p in group),
@@ -84,12 +86,23 @@ def join_run(root,name,traces):
     return summaries,startup
 
 
+def load_traces(paths):
+    traces = {}
+    for path in paths:
+        for trace in json.loads(path.read_text()):
+            identity = trace['trace_id']
+            if identity in traces and traces[identity] != trace:
+                raise RuntimeError(f'Conflicting exports for trace {identity}; use completed trace exports')
+            traces[identity] = trace
+    return list(traces.values())
+
+
 def main(a):
     builds=load_builds(a.root)
-    traces=json.loads((a.root/'final-traces.json').read_text())
+    traces=load_traces(a.traces)
     results=[];startup=[]
     for name in a.runs:
-        r,s=join_run(a.root,name,traces);results+=r;startup+=s
+        r,s=join_run(a.root,name,traces,builds);results+=r;startup+=s
     allocation=[]
     for label in ['baseline','candidate']:
         source=json.loads((a.root/('schema-'+label+'.json')).read_text());samples=source['samples']
@@ -101,12 +114,6 @@ def main(a):
     for path in sorted((a.root/a.gates).glob('*.trx')):
         gates[path.name]=ET.parse(path).getroot().find('.//{*}Counters').attrib
     coverage=ET.parse(a.root/a.gates/'coverage-report/Cobertura.xml').getroot().attrib
-    for process in startup:
-        for field,name in [('assembly_sha256','DotnetAgents.CalDav.Mcp.dll'),
-                           ('core_assembly_sha256','DotnetAgents.CalDav.Core.dll')]:
-            known={build['assembly_sha256'][name] for build in builds.values()}
-            if not set(process[field]).issubset(known):
-                raise RuntimeError('Measured process does not match either prepared build')
     result=dict(baseline_sha=builds['baseline']['source']['sha'],
         candidate_sha=builds['candidate']['source']['sha'],
         candidate_is_working_tree=builds['candidate']['source']['dirty'],builds=builds,
@@ -123,4 +130,5 @@ if __name__=='__main__':
     p.add_argument('root',type=Path);p.add_argument('output',type=Path)
     p.add_argument('--gates',default='gates-final')
     p.add_argument('--runs',nargs='+',required=True)
+    p.add_argument('--traces',type=Path,nargs='+',required=True,help='Completed *-traces.json exports from telemetry.py')
     main(p.parse_args())

--- a/scripts/observations/mcp-performance/aggregate.py
+++ b/scripts/observations/mcp-performance/aggregate.py
@@ -9,6 +9,7 @@ import statistics
 import subprocess
 import xml.etree.ElementTree as ET
 from build_manifest import load_builds, verify_process_inputs
+from gates import verify_gate_identity
 
 
 def percentile(values,p):
@@ -119,7 +120,8 @@ def schema_observations(root,builds):
     return allocation
 
 
-def validate_gates(directory):
+def validate_gates(directory,candidate):
+    verify_gate_identity(directory,candidate)
     scripts=Path(__file__).resolve().parents[2]
     for command in [
         ['bash',str(scripts/'verify-test-artifacts.sh'),str(directory),'complete'],
@@ -130,8 +132,8 @@ def validate_gates(directory):
 
 
 def main(a):
-    validate_gates(a.root/a.gates)
     builds=load_builds(a.root)
+    validate_gates(a.root/a.gates,builds['candidate'])
     traces=load_traces(a.traces)
     results=[];startup=[]
     for name in a.runs:

--- a/scripts/observations/mcp-performance/benchmark.py
+++ b/scripts/observations/mcp-performance/benchmark.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""Paired blocks with identical corpus/instrumentation, nearest-rank summaries."""
+import argparse
+import asyncio
+import collections
+from contextlib import AsyncExitStack
+import hashlib
+import json
+import math
+from pathlib import Path
+import time
+from driver import Client, environment, query
+from telemetry import export
+
+TOOLS = ['calendar_entities.query', 'calendar_occurrences.query', 'todos.query']
+
+
+def append(path, value):
+    with path.open('a') as stream:
+        stream.write(json.dumps(value)+'\n')
+
+
+async def cohort(args, label, tool, block, cohort_index):
+    state = json.loads((args.root/'infra-private.json').read_text())
+    service = f'caldav-perf-{args.name}-{label}-{tool.split(".")[0]}'
+    otlp = not args.no_otlp and (not args.compare_otlp or label=='baseline')
+    env = environment(state, service, otlp=otlp)
+    assembly = getattr(args,label)
+    async with Client(assembly, env) as client:
+        catalog = await client.request('tools/list', {})
+        assert set(TOOLS).issubset(t['name'] for t in catalog['result']['tools'])
+        base = dict(label=label, tool=tool, block=block, cohort=cohort_index, mode=args.mode,
+                    concurrency=args.concurrency, topology='single_session', service=service,
+                    otlp=otlp, pid=client.process.pid)
+        if args.mode == 'start':
+            for i in range(5+args.cohort_samples):
+                response, record = await client.call(tool, query(tool, args.page_size))
+                append(args.root/(args.name+'-samples.jsonl'), dict(base, **record, warmup=i<5,
+                       size=args.page_size))
+                if record['outcome'] != 'success':
+                    raise RuntimeError(f'{label} {tool}: {record["outcome"]}')
+        else:
+            response, setup = await client.call(tool, query(tool, 1))
+            assert setup['outcome']=='success', setup
+            cursor = response['result']['structuredContent']['pagination']['nextCursor']
+            for size in args.sizes:
+                call_args = dict(cursor=cursor,pageSize=size)
+                # Output validation tiers up later than five calls in the pilot.
+                for _ in range(20):
+                    for _, record in await asyncio.gather(*(client.call(tool, call_args)
+                            for _ in range(args.concurrency))):
+                        append(args.root/(args.name+'-samples.jsonl'),dict(base,**record,warmup=True,size=size))
+                reference = None
+                start = time.perf_counter_ns()
+                for offset in range(0,args.samples,args.concurrency):
+                    replies = await asyncio.gather(*(client.call(tool,call_args)
+                        for _ in range(min(args.concurrency,args.samples-offset))))
+                    for response,record in replies:
+                        value = response['result']['structuredContent']
+                        digest = hashlib.sha256(json.dumps(value,sort_keys=True).encode()).hexdigest()
+                        if reference is None:
+                            reference = digest
+                        assert reference == digest, 'Replay content/order changed'
+                        append(args.root/(args.name+'-samples.jsonl'),dict(base,**record,warmup=False,size=size,
+                               replay_sha256=digest))
+                        assert record['outcome']=='success', record
+                append(args.root/(args.name+'-batches.jsonl'),dict(base,size=size,
+                    successful_ops=args.samples, elapsed_ms=(time.perf_counter_ns()-start)/1e6))
+    append(args.root/(args.name+'-processes.jsonl'),dict(base,**client.identity))
+
+
+async def process_cohort(args,label,tool,block):
+    state=json.loads((args.root/'infra-private.json').read_text())
+    service=f'caldav-perf-{args.name}-{label}-{tool.split(".")[0]}'
+    clients=[];cursors=[]
+    base=dict(label=label,tool=tool,block=block,cohort=0,mode='continue',
+              concurrency=args.concurrency,topology='processes',service=service,otlp=not args.no_otlp)
+    async with AsyncExitStack() as stack:
+        for _ in range(args.concurrency):
+            c=await stack.enter_async_context(Client(getattr(args,label),environment(state,service,otlp=not args.no_otlp)))
+            response,record=await c.call(tool,query(tool,1))
+            assert record['outcome']=='success'
+            clients.append(c);cursors.append(response['result']['structuredContent']['pagination']['nextCursor'])
+        for size in args.sizes:
+            async def call(index):
+                response,record=await clients[index].call(tool,dict(cursor=cursors[index],pageSize=size))
+                return response,dict(record,pid=clients[index].process.pid)
+            for _ in range(20):
+                for _,record in await asyncio.gather(*(call(i) for i in range(args.concurrency))):
+                    append(args.root/(args.name+'-samples.jsonl'),dict(base,**record,warmup=True,size=size))
+            start=time.perf_counter_ns()
+            for offset in range(0,args.samples,args.concurrency):
+                for _,record in await asyncio.gather(*(call(i) for i in range(min(args.concurrency,args.samples-offset)))):
+                    append(args.root/(args.name+'-samples.jsonl'),dict(base,**record,warmup=False,size=size))
+                    assert record['outcome']=='success'
+            append(args.root/(args.name+'-batches.jsonl'),dict(base,size=size,successful_ops=args.samples,
+                   elapsed_ms=(time.perf_counter_ns()-start)/1e6))
+    for c in clients:
+        append(args.root/(args.name+'-processes.jsonl'),dict(base,**c.identity))
+
+
+async def run(args):
+    output=args.root/(args.name+'-samples.jsonl')
+    if output.exists():
+        raise RuntimeError('Use a new run name; never overwrite previous samples')
+    if args.compare_otlp:
+        assert args.baseline.read_bytes()==args.candidate.read_bytes()
+        assert args.topology=='single_session'
+    manifest={k:str(v) if isinstance(v,Path) else v for k,v in vars(args).items()}
+    manifest['harness_sha256']={p.name:hashlib.sha256(p.read_bytes()).hexdigest()
+                               for p in Path(__file__).parent.glob('*.py')}
+    (args.root/(args.name+'-manifest.json')).write_text(json.dumps(manifest,indent=2))
+    for block in range(args.blocks):
+        for tool in args.tools:
+            cohorts = args.samples//args.cohort_samples if args.mode=='start' else 1
+            for index in range(cohorts):
+                labels = ['baseline','candidate'] if (block+index)%2==0 else ['candidate','baseline']
+                for label in labels:
+                    if args.topology=='processes':
+                        await process_cohort(args,label,tool,block)
+                    else:
+                        await cohort(args,label,tool,block,index)
+                print(json.dumps(dict(run=args.name,block=block,tool=tool,cohort=index,complete=True)),flush=True)
+            if not args.no_otlp:
+                export(args.root,args.name+f'-b{block}-'+tool.split('.')[0])
+    summarize(args.root,args.name)
+
+
+def summarize(root,name):
+    groups = collections.defaultdict(list)
+    for line in (root/(name+'-samples.jsonl')).read_text().splitlines():
+        row=json.loads(line)
+        if not row['warmup']:
+            groups[(row['label'],row['tool'],row['mode'],row['size'],row['concurrency'])].append(row)
+    result=[]
+    for key,rows in groups.items():
+        times=sorted(r['elapsed_ms'] for r in rows)
+        percentile=lambda p:times[math.ceil(p*len(times))-1]
+        block_p95={str(b):sorted(r['elapsed_ms'] for r in rows if r['block']==b)[
+            math.ceil(.95*sum(r['block']==b for r in rows))-1] for b in set(r['block'] for r in rows)}
+        result.append(dict(label=key[0],tool=key[1],mode=key[2],size=key[3],concurrency=key[4],n=len(rows),
+            p50_ms=percentile(.5),p95_ms=percentile(.95),p99_descriptive_ms=percentile(.99),
+            min_ms=times[0],max_ms=times[-1],block_p95_ms=block_p95,
+            errors=sum(r['is_error'] or r['outcome']!='success' for r in rows),
+            timeouts=sum(r.get('timed_out',False) for r in rows),
+            mean_cpu_ms=sum(r['cpu_ms'] for r in rows)/len(rows),
+            max_rss_bytes=max(r['rss_bytes'] for r in rows),
+            serial_service_ops_per_second=len(rows)*1000/sum(times)))
+    (root/(name+'-summary.json')).write_text(json.dumps(result,indent=2))
+
+
+if __name__=='__main__':
+    p=argparse.ArgumentParser(description=__doc__)
+    p.add_argument('root',type=Path)
+    p.add_argument('baseline',type=Path)
+    p.add_argument('candidate',type=Path)
+    p.add_argument('--name',required=True)
+    p.add_argument('--mode',choices=['start','continue'],default='continue')
+    p.add_argument('--blocks',type=int,default=3)
+    p.add_argument('--samples',type=int,default=100)
+    p.add_argument('--cohort-samples',type=int,default=5)
+    p.add_argument('--page-size',type=int,default=200)
+    p.add_argument('--sizes',type=int,nargs='+',default=[1,5,200])
+    p.add_argument('--concurrency',type=int,choices=[1,2,4],default=1)
+    p.add_argument('--topology',choices=['single_session','processes'],default='single_session')
+    p.add_argument('--tools',nargs='+',default=TOOLS)
+    p.add_argument('--no-otlp',action='store_true')
+    p.add_argument('--compare-otlp',action='store_true',help='Same assembly: baseline OTLP on, candidate OTLP off')
+    args=p.parse_args()
+    asyncio.run(run(args))

--- a/scripts/observations/mcp-performance/benchmark.py
+++ b/scripts/observations/mcp-performance/benchmark.py
@@ -19,6 +19,8 @@ TOOLS = ['calendar_entities.query', 'calendar_occurrences.query', 'todos.query']
 def validate_args(args):
     if args.compare_otlp and args.no_otlp:
         raise ValueError('compare-otlp and no-otlp are mutually exclusive')
+    if args.compare_otlp and args.topology != 'single_session':
+        raise ValueError('compare-otlp supports only single_session topology')
     for name in ['blocks', 'samples', 'cohort_samples']:
         if getattr(args, name) <= 0:
             raise ValueError(name.replace('_', '-') + ' must be positive')
@@ -128,14 +130,12 @@ async def process_cohort(args,label,tool,block,references):
 
 
 async def run(args):
+    validate_args(args)
     args.baseline=args.baseline.resolve()
     args.candidate=args.candidate.resolve()
     output=args.root/(args.name+'-samples.jsonl')
     if output.exists():
         raise RuntimeError('Use a new run name; never overwrite previous samples')
-    if args.compare_otlp:
-        assert args.baseline.read_bytes()==args.candidate.read_bytes()
-        assert args.topology=='single_session'
     manifest={k:str(v) if isinstance(v,Path) else v for k,v in vars(args).items()}
     manifest['build_inputs']=benchmark_inputs(load_builds(args.root),args.baseline,args.candidate,args.compare_otlp)
     manifest['harness_sha256']={p.name:hashlib.sha256(p.read_bytes()).hexdigest()

--- a/scripts/observations/mcp-performance/benchmark.py
+++ b/scripts/observations/mcp-performance/benchmark.py
@@ -17,6 +17,8 @@ TOOLS = ['calendar_entities.query', 'calendar_occurrences.query', 'todos.query']
 
 
 def validate_args(args):
+    if args.compare_otlp and args.no_otlp:
+        raise ValueError('compare-otlp and no-otlp are mutually exclusive')
     for name in ['blocks', 'samples', 'cohort_samples']:
         if getattr(args, name) <= 0:
             raise ValueError(name.replace('_', '-') + ' must be positive')
@@ -35,6 +37,12 @@ def append(path, value):
 
 
 def record_sample(args, base, record, warmup, size, references):
+    record=dict(record)
+    if base['topology']=='single_session' and base['concurrency']>1:
+        record['cpu_ms']=None
+        record['cpu_measurement_scope']='unavailable: overlapping calls share the process'
+    else:
+        record['cpu_measurement_scope']='process delta for one nonoverlapping request'
     append(args.root/(args.name+'-samples.jsonl'), dict(base, **record, warmup=warmup, size=size))
     if record['outcome'] != 'success':
         raise RuntimeError(f'{base["label"]} {base["tool"]}: {record["outcome"]}')
@@ -167,7 +175,9 @@ def summarize(root,name):
             min_ms=times[0],max_ms=times[-1],block_p95_ms=block_p95,
             errors=sum(r['is_error'] or r['outcome']!='success' for r in rows),
             timeouts=sum(r.get('timed_out',False) for r in rows),
-            mean_cpu_ms=sum(r['cpu_ms'] for r in rows)/len(rows),
+            mean_cpu_ms=(sum(r['cpu_ms'] for r in rows)/len(rows)
+                         if all(r['cpu_ms'] is not None for r in rows) else None),
+            cpu_measurement_scope=rows[0]['cpu_measurement_scope'],
             max_rss_bytes=max(r['rss_bytes'] for r in rows),
             serial_service_ops_per_second=len(rows)*1000/sum(times)))
     (root/(name+'-summary.json')).write_text(json.dumps(result,indent=2))

--- a/scripts/observations/mcp-performance/benchmark.py
+++ b/scripts/observations/mcp-performance/benchmark.py
@@ -11,6 +11,7 @@ from pathlib import Path
 import time
 from driver import Client, environment, query
 from telemetry import export
+from build_manifest import load_builds, benchmark_inputs
 
 TOOLS = ['calendar_entities.query', 'calendar_occurrences.query', 'todos.query']
 
@@ -31,7 +32,19 @@ def append(path, value):
         stream.write(json.dumps(value)+'\n')
 
 
-async def cohort(args, label, tool, block, cohort_index):
+def record_sample(args, base, record, warmup, size, references):
+    append(args.root/(args.name+'-samples.jsonl'), dict(base, **record, warmup=warmup, size=size))
+    if record['outcome'] != 'success':
+        raise RuntimeError(f'{base["label"]} {base["tool"]}: {record["outcome"]}')
+    if not warmup:
+        key = (base['tool'], size, base['block'])
+        digest = (record['item_sha256'], record['items'])
+        if key in references and references[key] != digest:
+            raise RuntimeError('Result content/order differs between samples or compared builds')
+        references[key] = digest
+
+
+async def cohort(args, label, tool, block, cohort_index, references):
     state = json.loads((args.root/'infra-private.json').read_text())
     service = f'caldav-perf-{args.name}-{label}-{tool.split(".")[0]}'
     otlp = not args.no_otlp and (not args.compare_otlp or label=='baseline')
@@ -46,10 +59,7 @@ async def cohort(args, label, tool, block, cohort_index):
         if args.mode == 'start':
             for i in range(5+args.cohort_samples):
                 response, record = await client.call(tool, query(tool, args.page_size))
-                append(args.root/(args.name+'-samples.jsonl'), dict(base, **record, warmup=i<5,
-                       size=args.page_size))
-                if record['outcome'] != 'success':
-                    raise RuntimeError(f'{label} {tool}: {record["outcome"]}')
+                record_sample(args,base,record,i<5,args.page_size,references)
         else:
             response, setup = await client.call(tool, query(tool, 1))
             assert setup['outcome']=='success', setup
@@ -60,27 +70,25 @@ async def cohort(args, label, tool, block, cohort_index):
                 for _ in range(20):
                     for _, record in await asyncio.gather(*(client.call(tool, call_args)
                             for _ in range(args.concurrency))):
-                        append(args.root/(args.name+'-samples.jsonl'),dict(base,**record,warmup=True,size=size))
+                        record_sample(args,base,record,True,size,references)
                 reference = None
                 start = time.perf_counter_ns()
                 for offset in range(0,args.samples,args.concurrency):
                     replies = await asyncio.gather(*(client.call(tool,call_args)
                         for _ in range(min(args.concurrency,args.samples-offset))))
                     for response,record in replies:
+                        record_sample(args,base,record,False,size,references)
                         value = response['result']['structuredContent']
                         digest = hashlib.sha256(json.dumps(value,sort_keys=True).encode()).hexdigest()
                         if reference is None:
                             reference = digest
                         assert reference == digest, 'Replay content/order changed'
-                        append(args.root/(args.name+'-samples.jsonl'),dict(base,**record,warmup=False,size=size,
-                               replay_sha256=digest))
-                        assert record['outcome']=='success', record
                 append(args.root/(args.name+'-batches.jsonl'),dict(base,size=size,
                     successful_ops=args.samples, elapsed_ms=(time.perf_counter_ns()-start)/1e6))
     append(args.root/(args.name+'-processes.jsonl'),dict(base,**client.identity))
 
 
-async def process_cohort(args,label,tool,block):
+async def process_cohort(args,label,tool,block,references):
     state=json.loads((args.root/'infra-private.json').read_text())
     service=f'caldav-perf-{args.name}-{label}-{tool.split(".")[0]}'
     clients=[];cursors=[]
@@ -98,12 +106,11 @@ async def process_cohort(args,label,tool,block):
                 return response,dict(record,pid=clients[index].process.pid)
             for _ in range(20):
                 for _,record in await asyncio.gather(*(call(i) for i in range(args.concurrency))):
-                    append(args.root/(args.name+'-samples.jsonl'),dict(base,**record,warmup=True,size=size))
+                    record_sample(args,base,record,True,size,references)
             start=time.perf_counter_ns()
             for offset in range(0,args.samples,args.concurrency):
                 for _,record in await asyncio.gather(*(call(i) for i in range(min(args.concurrency,args.samples-offset)))):
-                    append(args.root/(args.name+'-samples.jsonl'),dict(base,**record,warmup=False,size=size))
-                    assert record['outcome']=='success'
+                    record_sample(args,base,record,False,size,references)
             append(args.root/(args.name+'-batches.jsonl'),dict(base,size=size,successful_ops=args.samples,
                    elapsed_ms=(time.perf_counter_ns()-start)/1e6))
     for c in clients:
@@ -111,6 +118,8 @@ async def process_cohort(args,label,tool,block):
 
 
 async def run(args):
+    args.baseline=args.baseline.resolve()
+    args.candidate=args.candidate.resolve()
     output=args.root/(args.name+'-samples.jsonl')
     if output.exists():
         raise RuntimeError('Use a new run name; never overwrite previous samples')
@@ -118,9 +127,11 @@ async def run(args):
         assert args.baseline.read_bytes()==args.candidate.read_bytes()
         assert args.topology=='single_session'
     manifest={k:str(v) if isinstance(v,Path) else v for k,v in vars(args).items()}
+    manifest['build_inputs']=benchmark_inputs(load_builds(args.root),args.baseline,args.candidate,args.compare_otlp)
     manifest['harness_sha256']={p.name:hashlib.sha256(p.read_bytes()).hexdigest()
                                for p in Path(__file__).parent.glob('*.py')}
     (args.root/(args.name+'-manifest.json')).write_text(json.dumps(manifest,indent=2))
+    references={}
     for block in range(args.blocks):
         for tool in args.tools:
             cohorts = args.samples//args.cohort_samples if args.mode=='start' else 1
@@ -128,9 +139,9 @@ async def run(args):
                 labels = ['baseline','candidate'] if (block+index)%2==0 else ['candidate','baseline']
                 for label in labels:
                     if args.topology=='processes':
-                        await process_cohort(args,label,tool,block)
+                        await process_cohort(args,label,tool,block,references)
                     else:
-                        await cohort(args,label,tool,block,index)
+                        await cohort(args,label,tool,block,index,references)
                 print(json.dumps(dict(run=args.name,block=block,tool=tool,cohort=index,complete=True)),flush=True)
             if not args.no_otlp:
                 export(args.root,args.name+f'-b{block}-'+tool.split('.')[0])

--- a/scripts/observations/mcp-performance/benchmark.py
+++ b/scripts/observations/mcp-performance/benchmark.py
@@ -64,7 +64,8 @@ async def cohort(args, label, tool, block, cohort_index, references):
     assembly = getattr(args,label)
     async with Client(assembly, env) as client:
         catalog = await client.request('tools/list', {})
-        assert set(TOOLS).issubset(t['name'] for t in catalog['result']['tools'])
+        if not (set(TOOLS).issubset(t['name'] for t in catalog['result']['tools'])):
+            raise RuntimeError('Required tool missing from live catalog')
         base = dict(label=label, tool=tool, block=block, cohort=cohort_index, mode=args.mode,
                     concurrency=args.concurrency, topology='single_session', service=service,
                     otlp=otlp, pid=client.process.pid)
@@ -74,7 +75,8 @@ async def cohort(args, label, tool, block, cohort_index, references):
                 record_sample(args,base,record,i<5,args.page_size,references)
         else:
             response, setup = await client.call(tool, query(tool, 1))
-            assert setup['outcome']=='success', setup
+            if not (setup['outcome']=='success'):
+                raise RuntimeError('Continue setup failed')
             cursor = response['result']['structuredContent']['pagination']['nextCursor']
             for size in args.sizes:
                 call_args = dict(cursor=cursor,pageSize=size)
@@ -94,7 +96,8 @@ async def cohort(args, label, tool, block, cohort_index, references):
                         digest = hashlib.sha256(json.dumps(value,sort_keys=True).encode()).hexdigest()
                         if reference is None:
                             reference = digest
-                        assert reference == digest, 'Replay content/order changed'
+                        if not (reference == digest):
+                            raise RuntimeError('Replay content/order changed')
                 append(args.root/(args.name+'-batches.jsonl'),dict(base,size=size,
                     successful_ops=args.samples, elapsed_ms=(time.perf_counter_ns()-start)/1e6))
     append(args.root/(args.name+'-processes.jsonl'),dict(base,**client.identity))
@@ -110,7 +113,8 @@ async def process_cohort(args,label,tool,block,references):
         for _ in range(args.concurrency):
             c=await stack.enter_async_context(Client(getattr(args,label),environment(state,service,otlp=not args.no_otlp)))
             response,record=await c.call(tool,query(tool,1))
-            assert record['outcome']=='success'
+            if not (record['outcome']=='success'):
+                raise RuntimeError('Continue setup failed')
             clients.append(c);cursors.append(response['result']['structuredContent']['pagination']['nextCursor'])
         for size in args.sizes:
             async def call(index):

--- a/scripts/observations/mcp-performance/benchmark.py
+++ b/scripts/observations/mcp-performance/benchmark.py
@@ -15,6 +15,17 @@ from telemetry import export
 TOOLS = ['calendar_entities.query', 'calendar_occurrences.query', 'todos.query']
 
 
+def validate_args(args):
+    for name in ['blocks', 'samples', 'cohort_samples']:
+        if getattr(args, name) <= 0:
+            raise ValueError(name.replace('_', '-') + ' must be positive')
+    if args.mode == 'start':
+        if args.samples % args.cohort_samples:
+            raise ValueError('Start samples must be divisible by cohort-samples')
+        if args.topology != 'single_session' or args.concurrency != 1:
+            raise ValueError('Start supports only serial single_session cohorts')
+
+
 def append(path, value):
     with path.open('a') as stream:
         stream.write(json.dumps(value)+'\n')
@@ -167,4 +178,8 @@ if __name__=='__main__':
     p.add_argument('--no-otlp',action='store_true')
     p.add_argument('--compare-otlp',action='store_true',help='Same assembly: baseline OTLP on, candidate OTLP off')
     args=p.parse_args()
+    try:
+        validate_args(args)
+    except ValueError as error:
+        p.error(str(error))
     asyncio.run(run(args))

--- a/scripts/observations/mcp-performance/benchmark.py
+++ b/scripts/observations/mcp-performance/benchmark.py
@@ -21,6 +21,8 @@ def validate_args(args):
         if getattr(args, name) <= 0:
             raise ValueError(name.replace('_', '-') + ' must be positive')
     if args.mode == 'start':
+        if args.cohort_samples > 11:
+            raise ValueError('Start allows at most 11 cohort-samples plus five warmups within 16 snapshots')
         if args.samples % args.cohort_samples:
             raise ValueError('Start samples must be divisible by cohort-samples')
         if args.topology != 'single_session' or args.concurrency != 1:

--- a/scripts/observations/mcp-performance/build_manifest.py
+++ b/scripts/observations/mcp-performance/build_manifest.py
@@ -48,6 +48,44 @@ def load_builds(root):
     return builds
 
 
+def benchmark_inputs(builds, baseline, candidate, compare_otlp=False):
+    inputs = {}
+    for label, assembly in [('baseline', baseline), ('candidate', candidate)]:
+        assembly = Path(assembly).resolve()
+        hashes = {'DotnetAgents.CalDav.Mcp.dll': hashlib.sha256(assembly.read_bytes()).hexdigest(),
+                  'DotnetAgents.CalDav.Core.dll': hashlib.sha256(
+                      assembly.with_name('DotnetAgents.CalDav.Core.dll').read_bytes()).hexdigest()}
+        if compare_otlp:
+            matching = [key for key, build in builds.items() if build['assembly_sha256'] == hashes]
+            if not matching:
+                raise RuntimeError('OTLP input does not match a prepared build')
+            prepared_label = 'candidate' if 'candidate' in matching else matching[0]
+        else:
+            prepared_label = label
+            if hashes != builds[label]['assembly_sha256']:
+                raise RuntimeError(f'{label} input does not match its prepared build')
+        inputs[label] = dict(assembly=str(assembly), assembly_sha256=hashes,
+                             source=builds[prepared_label]['source'])
+    if compare_otlp and inputs['baseline']['assembly_sha256'] != inputs['candidate']['assembly_sha256']:
+        raise RuntimeError('OTLP comparison requires the same build for both labels')
+    return inputs
+
+
+def verify_process_inputs(root, name, processes, builds):
+    manifest = json.loads((root / (name + '-manifest.json')).read_text())
+    inputs = benchmark_inputs(builds, manifest['baseline'], manifest['candidate'], manifest['compare_otlp'])
+    if inputs != manifest['build_inputs']:
+        raise RuntimeError('Benchmark input changed since its run manifest was captured')
+    for process in processes:
+        expected = inputs[process['label']]
+        hashes = expected['assembly_sha256']
+        if (process['assembly'] != expected['assembly']
+                or process['sha256'] != hashes['DotnetAgents.CalDav.Mcp.dll']
+                or process['core_sha256'] != hashes['DotnetAgents.CalDav.Core.dll']):
+            raise RuntimeError('Measured process does not match its declared benchmark input')
+    return inputs
+
+
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument('action', choices=['capture', 'finalize'])

--- a/scripts/observations/mcp-performance/build_manifest.py
+++ b/scripts/observations/mcp-performance/build_manifest.py
@@ -99,7 +99,8 @@ def benchmark_inputs(builds, baseline, candidate, compare_otlp=False):
         inputs[label] = dict(assembly=str(assembly), assembly_sha256=hashes,
                              runtime_files_sha256=closure,
                              source=builds[prepared_label]['source'])
-    if compare_otlp and inputs['baseline']['assembly_sha256'] != inputs['candidate']['assembly_sha256']:
+    if compare_otlp and (inputs['baseline']['assembly_sha256'] != inputs['candidate']['assembly_sha256']
+                         or inputs['baseline']['runtime_files_sha256'] != inputs['candidate']['runtime_files_sha256']):
         raise RuntimeError('OTLP comparison requires the same build for both labels')
     return inputs
 

--- a/scripts/observations/mcp-performance/build_manifest.py
+++ b/scripts/observations/mcp-performance/build_manifest.py
@@ -28,6 +28,33 @@ def capture(repository, manifest):
         json.dump(dict(source=source_identity(repository)), stream, indent=2)
 
 
+def runtime_files(assembly):
+    assembly=Path(assembly).resolve()
+    directory=assembly.parent
+    deps_path=assembly.with_suffix('.deps.json')
+    deps=json.loads(deps_path.read_text())
+    assembly.with_suffix('.runtimeconfig.json').read_bytes()
+    target=deps['targets'][deps['runtimeTarget']['name']]
+    for library in target.values():
+        for group in ['runtime','native','resources','runtimeTargets']:
+            for asset,metadata in library.get(group,{}).items():
+                relative=Path(asset)
+                if relative.name=='_._':
+                    continue
+                if group=='runtimeTargets':
+                    candidates=[directory/relative]
+                elif group=='resources':
+                    candidates=[directory/metadata['locale']/relative.name]
+                else:
+                    candidates=[directory/relative,directory/relative.name]
+                if not any(path.is_file() for path in candidates):
+                    raise RuntimeError(f'Missing app-local runtime dependency: {asset}')
+    # Hash the entire immutable copied output, including deps/runtimeconfig and
+    # RID assets, so changed or added files cannot alter resolution unnoticed.
+    return {path.relative_to(directory).as_posix():hashlib.sha256(path.read_bytes()).hexdigest()
+            for path in sorted(directory.rglob('*')) if path.is_file()}
+
+
 def finalize(repository, manifest, assemblies):
     record = json.loads(manifest.read_text())
     if record['source'] != source_identity(repository):
@@ -35,6 +62,7 @@ def finalize(repository, manifest, assemblies):
     record['assembly_sha256'] = {
         name: hashlib.sha256((assemblies / name).read_bytes()).hexdigest()
         for name in ['DotnetAgents.CalDav.Mcp.dll', 'DotnetAgents.CalDav.Core.dll']}
+    record['runtime_files_sha256']=runtime_files(assemblies/'DotnetAgents.CalDav.Mcp.dll')
     manifest.write_text(json.dumps(record, indent=2))
 
 
@@ -42,6 +70,8 @@ def load_builds(root):
     builds = {label: json.loads((root / (label + '-build.json')).read_text())
               for label in ['baseline', 'candidate']}
     for label, build in builds.items():
+        if runtime_files(root/label/'DotnetAgents.CalDav.Mcp.dll')!=build['runtime_files_sha256']:
+            raise RuntimeError(f'{label} runtime dependency set differs from its prepared build manifest')
         for name, digest in build['assembly_sha256'].items():
             if hashlib.sha256((root / label / name).read_bytes()).hexdigest() != digest:
                 raise RuntimeError(f'{label} assembly differs from its prepared build manifest')
@@ -55,16 +85,19 @@ def benchmark_inputs(builds, baseline, candidate, compare_otlp=False):
         hashes = {'DotnetAgents.CalDav.Mcp.dll': hashlib.sha256(assembly.read_bytes()).hexdigest(),
                   'DotnetAgents.CalDav.Core.dll': hashlib.sha256(
                       assembly.with_name('DotnetAgents.CalDav.Core.dll').read_bytes()).hexdigest()}
+        closure=runtime_files(assembly)
         if compare_otlp:
-            matching = [key for key, build in builds.items() if build['assembly_sha256'] == hashes]
+            matching = [key for key, build in builds.items() if build['assembly_sha256'] == hashes
+                        and build['runtime_files_sha256']==closure]
             if not matching:
                 raise RuntimeError('OTLP input does not match a prepared build')
             prepared_label = 'candidate' if 'candidate' in matching else matching[0]
         else:
             prepared_label = label
-            if hashes != builds[label]['assembly_sha256']:
+            if hashes != builds[label]['assembly_sha256'] or closure!=builds[label]['runtime_files_sha256']:
                 raise RuntimeError(f'{label} input does not match its prepared build')
         inputs[label] = dict(assembly=str(assembly), assembly_sha256=hashes,
+                             runtime_files_sha256=closure,
                              source=builds[prepared_label]['source'])
     if compare_otlp and inputs['baseline']['assembly_sha256'] != inputs['candidate']['assembly_sha256']:
         raise RuntimeError('OTLP comparison requires the same build for both labels')
@@ -81,7 +114,8 @@ def verify_process_inputs(root, name, processes, builds):
         hashes = expected['assembly_sha256']
         if (process['assembly'] != expected['assembly']
                 or process['sha256'] != hashes['DotnetAgents.CalDav.Mcp.dll']
-                or process['core_sha256'] != hashes['DotnetAgents.CalDav.Core.dll']):
+                or process['core_sha256'] != hashes['DotnetAgents.CalDav.Core.dll']
+                or process['runtime_files_sha256']!=expected['runtime_files_sha256']):
             raise RuntimeError('Measured process does not match its declared benchmark input')
     return inputs
 

--- a/scripts/observations/mcp-performance/build_manifest.py
+++ b/scripts/observations/mcp-performance/build_manifest.py
@@ -90,6 +90,19 @@ def load_builds(root):
     return builds
 
 
+def prepared_input(root, assembly, label='candidate'):
+    if label not in ['baseline','candidate']:
+        raise ValueError('Select the baseline or candidate prepared build')
+    build=json.loads((root/(label+'-build.json')).read_text())
+    assembly=Path(assembly).resolve()
+    closure=runtime_files(assembly)
+    hashes={name:closure[name] for name in build['assembly_sha256']}
+    if hashes!=build['assembly_sha256'] or closure!=build['runtime_files_sha256']:
+        raise RuntimeError(f'{label} input does not match its prepared build')
+    return dict(label=label,assembly=str(assembly),assembly_sha256=hashes,
+                runtime_files_sha256=closure,source=build['source'])
+
+
 def benchmark_inputs(builds, baseline, candidate, compare_otlp=False):
     inputs = {}
     for label, assembly in [('baseline', baseline), ('candidate', candidate)]:

--- a/scripts/observations/mcp-performance/build_manifest.py
+++ b/scripts/observations/mcp-performance/build_manifest.py
@@ -33,7 +33,9 @@ def runtime_files(assembly):
     directory=assembly.parent
     deps_path=assembly.with_suffix('.deps.json')
     deps=json.loads(deps_path.read_text())
-    assembly.with_suffix('.runtimeconfig.json').read_bytes()
+    config_path=assembly.with_suffix('.runtimeconfig.json')
+    config_path.read_bytes()
+    files={assembly,deps_path,config_path}
     target=deps['targets'][deps['runtimeTarget']['name']]
     for library in target.values():
         for group in ['runtime','native','resources','runtimeTargets']:
@@ -47,12 +49,17 @@ def runtime_files(assembly):
                     candidates=[directory/metadata['locale']/relative.name]
                 else:
                     candidates=[directory/relative,directory/relative.name]
-                if not any(path.is_file() for path in candidates):
+                resolved=[path for path in candidates if path.is_file()]
+                if not resolved:
                     raise RuntimeError(f'Missing app-local runtime dependency: {asset}')
-    # Hash the entire immutable copied output, including deps/runtimeconfig and
-    # RID assets, so changed or added files cannot alter resolution unnoticed.
+                files.update(resolved)
+    optional=[assembly.with_suffix('.runtimeconfig.dev.json'),directory/'.mcp/server.json']
+    files.update(path for path in optional if path.is_file())
+    files.update(directory.glob('appsettings*.json'))
+    # Ignore unrelated build/publish copies; the declared dependency graph and
+    # runtime configuration define the executable input set.
     return {path.relative_to(directory).as_posix():hashlib.sha256(path.read_bytes()).hexdigest()
-            for path in sorted(directory.rglob('*')) if path.is_file()}
+            for path in sorted(files)}
 
 
 def finalize(repository, manifest, assemblies):

--- a/scripts/observations/mcp-performance/build_manifest.py
+++ b/scripts/observations/mcp-performance/build_manifest.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Capture source identity before a build and bind it to the copied assemblies."""
+import argparse
+import hashlib
+import json
+from pathlib import Path
+import subprocess
+
+
+def git(repository, *args):
+    return subprocess.check_output(['git', '-C', str(repository), *args])
+
+
+def source_identity(repository):
+    untracked = {}
+    for name in git(repository, 'ls-files', '--others', '--exclude-standard', '-z').split(b'\0'):
+        if name:
+            path = Path(name.decode())
+            untracked[str(path)] = hashlib.sha256((repository / path).read_bytes()).hexdigest()
+    return dict(sha=git(repository, 'rev-parse', 'HEAD').decode().strip(),
+                dirty=bool(git(repository, 'status', '--porcelain=v1', '--untracked-files=all')),
+                working_tree_patch_sha256=hashlib.sha256(git(repository, 'diff', 'HEAD', '--binary')).hexdigest(),
+                untracked_file_sha256=untracked)
+
+
+def capture(repository, manifest):
+    with manifest.open('x') as stream:
+        json.dump(dict(source=source_identity(repository)), stream, indent=2)
+
+
+def finalize(repository, manifest, assemblies):
+    record = json.loads(manifest.read_text())
+    if record['source'] != source_identity(repository):
+        raise RuntimeError('Source changed during the build; prepare a new comparison')
+    record['assembly_sha256'] = {
+        name: hashlib.sha256((assemblies / name).read_bytes()).hexdigest()
+        for name in ['DotnetAgents.CalDav.Mcp.dll', 'DotnetAgents.CalDav.Core.dll']}
+    manifest.write_text(json.dumps(record, indent=2))
+
+
+def load_builds(root):
+    builds = {label: json.loads((root / (label + '-build.json')).read_text())
+              for label in ['baseline', 'candidate']}
+    for label, build in builds.items():
+        for name, digest in build['assembly_sha256'].items():
+            if hashlib.sha256((root / label / name).read_bytes()).hexdigest() != digest:
+                raise RuntimeError(f'{label} assembly differs from its prepared build manifest')
+    return builds
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('action', choices=['capture', 'finalize'])
+    parser.add_argument('repository', type=Path)
+    parser.add_argument('manifest', type=Path)
+    parser.add_argument('assemblies', type=Path, nargs='?')
+    args = parser.parse_args()
+    if args.action == 'capture':
+        capture(args.repository, args.manifest)
+    else:
+        if args.assemblies is None:
+            parser.error('finalize requires the copied assembly directory')
+        finalize(args.repository, args.manifest, args.assemblies)

--- a/scripts/observations/mcp-performance/build_manifest.py
+++ b/scripts/observations/mcp-performance/build_manifest.py
@@ -28,6 +28,11 @@ def capture(repository, manifest):
         json.dump(dict(source=source_identity(repository)), stream, indent=2)
 
 
+def verify_source(repository, manifest):
+    if source_identity(repository) != json.loads(manifest.read_text())['source']:
+        raise RuntimeError('Source does not match the prepared candidate')
+
+
 def runtime_files(assembly):
     assembly=Path(assembly).resolve()
     directory=assembly.parent
@@ -130,13 +135,15 @@ def verify_process_inputs(root, name, processes, builds):
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument('action', choices=['capture', 'finalize'])
+    parser.add_argument('action', choices=['capture', 'finalize', 'verify-source'])
     parser.add_argument('repository', type=Path)
     parser.add_argument('manifest', type=Path)
     parser.add_argument('assemblies', type=Path, nargs='?')
     args = parser.parse_args()
     if args.action == 'capture':
         capture(args.repository, args.manifest)
+    elif args.action == 'verify-source':
+        verify_source(args.repository, args.manifest)
     else:
         if args.assemblies is None:
             parser.error('finalize requires the copied assembly directory')

--- a/scripts/observations/mcp-performance/cleanup.py
+++ b/scripts/observations/mcp-performance/cleanup.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""Remove this run's infrastructure/configuration, retaining measurement artifacts."""
+import argparse
+import json
+from pathlib import Path
+import shutil
+from infra import down,verify
+
+
+def cleanup(root):
+    state=json.loads((root/'infra-private.json').read_text())
+    counts=verify(state)
+    if counts!=dict(events=600,todos=600,archive=0):
+        raise RuntimeError(f'Unexpected final corpus: {counts}; inspect owned fixtures before cleanup')
+    down(root)
+    removed=[]
+    for name in ['hermes-isolated','profilers','baseline-checkout','package-checkout','package-metadata']:
+        path=root/name
+        if path.exists():
+            shutil.rmtree(path);removed.append(name)
+    private_log=root/'hermes-run-private.log'
+    if private_log.exists():
+        private_log.unlink();removed.append(private_log.name)
+    path=root/'cleanup.json';result=json.loads(path.read_text())
+    result.update(final_corpus_before_container_removal=counts,temporary_directories_removed=removed,
+                  retained='assemblies, profiles, raw measurement artifacts and sanitized evidence')
+    path.write_text(json.dumps(result,indent=2))
+    print(json.dumps(result))
+
+
+if __name__=='__main__':
+    p=argparse.ArgumentParser(description=__doc__);p.add_argument('root',type=Path)
+    cleanup(p.parse_args().root)

--- a/scripts/observations/mcp-performance/cleanup.py
+++ b/scripts/observations/mcp-performance/cleanup.py
@@ -4,13 +4,13 @@ import argparse
 import json
 from pathlib import Path
 import shutil
-from infra import down,verify
+from infra import down,verify,expected_counts
 
 
 def cleanup(root):
     state=json.loads((root/'infra-private.json').read_text())
     counts=verify(state)
-    if counts!=dict(events=600,todos=600,archive=0):
+    if counts!=expected_counts(root):
         raise RuntimeError(f'Unexpected final corpus: {counts}; inspect owned fixtures before cleanup')
     down(root)
     removed=[]

--- a/scripts/observations/mcp-performance/driver.py
+++ b/scripts/observations/mcp-performance/driver.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """Persistent JSON-RPC stdio driver. Measurements exclude fixture setup and inference."""
 import asyncio
+from contextlib import suppress
 import hashlib
 import json
 import os
@@ -9,6 +10,8 @@ import shutil
 import time
 
 PROTOCOL = '2026-07-28'
+REQUEST_TIMEOUT_SECONDS = 45
+SHUTDOWN_TIMEOUT_SECONDS = 5
 CAPABILITIES = {'elicitation': {'form': {}}}
 WINDOW = {'from': {'kind': 'utcDateTime', 'value': '2026-07-01T00:00:00Z'},
           'to': {'kind': 'utcDateTime', 'value': '2026-12-31T00:00:00Z'}}
@@ -56,6 +59,27 @@ class Client:
             stderr=asyncio.subprocess.PIPE, env=self.env, limit=16*1024*1024)
         self.reader = asyncio.create_task(self.read())
         self.stderr = asyncio.create_task(self.process.stderr.read())
+        try:
+            return await self.initialize(start)
+        except BaseException:
+            await asyncio.shield(self.abort_startup())
+            raise
+
+    async def abort_startup(self):
+        self.process.stdin.close()
+        try:
+            await asyncio.wait_for(self.process.wait(), SHUTDOWN_TIMEOUT_SECONDS)
+        except TimeoutError:
+            with suppress(ProcessLookupError):
+                self.process.kill()
+            await self.process.wait()
+        finally:
+            for task in [self.reader, self.stderr]:
+                if not task.done():
+                    task.cancel()
+            await asyncio.gather(self.reader, self.stderr, return_exceptions=True)
+
+    async def initialize(self, start):
         self.initialized = await self.request('server/discover', {})
         assert PROTOCOL in self.initialized['result']['supportedVersions'], self.initialized
         assert 'tools' in self.initialized['result']['capabilities']
@@ -107,7 +131,7 @@ class Client:
         self.process.stdin.write((json.dumps(dict(jsonrpc='2.0', id=sequence, method=method, params=params))+'\n').encode())
         await self.process.stdin.drain()
         try:
-            return await asyncio.wait_for(future, 45)
+            return await asyncio.wait_for(future, REQUEST_TIMEOUT_SECONDS)
         finally:
             del self.pending[sequence]
 
@@ -149,7 +173,7 @@ class Client:
         start = time.perf_counter_ns()
         self.process.stdin.close()
         try:
-            await asyncio.wait_for(self.process.wait(), 5)
+            await asyncio.wait_for(self.process.wait(), SHUTDOWN_TIMEOUT_SECONDS)
         except TimeoutError:
             self.process.kill()
             await self.process.wait()

--- a/scripts/observations/mcp-performance/driver.py
+++ b/scripts/observations/mcp-performance/driver.py
@@ -8,7 +8,7 @@ import os
 from pathlib import Path
 import shutil
 import time
-from build_manifest import runtime_files
+from build_manifest import runtime_files, prepared_input
 
 PROTOCOL = '2026-07-28'
 REQUEST_TIMEOUT_SECONDS = 45
@@ -199,7 +199,9 @@ def query(tool, size=5, bounded=True):
     return args
 
 
-async def pilot(root, assembly):
+async def pilot(root, assembly, build='candidate'):
+    build_input=prepared_input(root,assembly,build)
+    assembly=Path(build_input['assembly'])
     state = json.loads((root/'infra-private.json').read_text())
     records = []
     for tool in ['calendar_entities.query','calendar_occurrences.query','todos.query']:
@@ -218,7 +220,7 @@ async def pilot(root, assembly):
                     _, record = await client.call(tool, dict(cursor=cursor,pageSize=size))
                     records.append(dict(record, size=size, phase='continue'))
                     print(json.dumps(records[-1]), flush=True)
-            (root/('pilot-process-'+tool+'.json')).write_text(json.dumps(client.identity,indent=2))
+            (root/('pilot-process-'+tool+'.json')).write_text(json.dumps(dict(client.identity,build_input=build_input),indent=2))
     (root/'pilot.json').write_text(json.dumps(records,indent=2))
 
 
@@ -227,5 +229,6 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument('root', type=Path)
     parser.add_argument('assembly', type=Path)
+    parser.add_argument('--build',choices=['baseline','candidate'],default='candidate')
     args = parser.parse_args()
-    asyncio.run(pilot(args.root,args.assembly))
+    asyncio.run(pilot(args.root,args.assembly,args.build))

--- a/scripts/observations/mcp-performance/driver.py
+++ b/scripts/observations/mcp-performance/driver.py
@@ -82,8 +82,10 @@ class Client:
 
     async def initialize(self, start):
         self.initialized = await self.request('server/discover', {})
-        assert PROTOCOL in self.initialized['result']['supportedVersions'], self.initialized
-        assert 'tools' in self.initialized['result']['capabilities']
+        if not (PROTOCOL in self.initialized['result']['supportedVersions']):
+            raise RuntimeError('Unsupported MCP protocol')
+        if not ('tools' in self.initialized['result']['capabilities']):
+            raise RuntimeError('MCP tools capability unavailable')
         self.startup_ms = (time.perf_counter_ns()-start)/1e6
         self.identity = dict(pid=self.process.pid, assembly=str(self.assembly),
             sha256=hashlib.sha256(self.assembly.read_bytes()).hexdigest(),
@@ -93,7 +95,8 @@ class Client:
             startup_ms=self.startup_ms, discovery=self.initialized)
         # Linux maps verifies the runtime actually loaded this assembly.
         self.identity['assembly_mapped'] = str(self.assembly) in Path(f'/proc/{self.process.pid}/maps').read_text()
-        assert self.identity['assembly_mapped']
+        if not (self.identity['assembly_mapped']):
+            raise RuntimeError('Assembly was not mapped')
         return self
 
     async def read(self):
@@ -184,7 +187,8 @@ class Client:
         stderr = await self.stderr
         self.identity.update(shutdown_ms=(time.perf_counter_ns()-start)/1e6,
                              exit_code=self.process.returncode, stderr_bytes=len(stderr))
-        assert self.process.returncode == 0 and not stderr, self.identity
+        if not (self.process.returncode == 0 and not stderr):
+            raise RuntimeError('MCP shutdown was not clean')
 
 
 def query(tool, size=5, bounded=True):

--- a/scripts/observations/mcp-performance/driver.py
+++ b/scripts/observations/mcp-performance/driver.py
@@ -8,6 +8,7 @@ import os
 from pathlib import Path
 import shutil
 import time
+from build_manifest import runtime_files
 
 PROTOCOL = '2026-07-28'
 REQUEST_TIMEOUT_SECONDS = 45
@@ -87,6 +88,7 @@ class Client:
         self.identity = dict(pid=self.process.pid, assembly=str(self.assembly),
             sha256=hashlib.sha256(self.assembly.read_bytes()).hexdigest(),
             core_sha256=hashlib.sha256(self.assembly.with_name('DotnetAgents.CalDav.Core.dll').read_bytes()).hexdigest(),
+            runtime_files_sha256=runtime_files(self.assembly),
             command=Path(f'/proc/{self.process.pid}/cmdline').read_bytes().decode().split('\0')[:-1],
             startup_ms=self.startup_ms, discovery=self.initialized)
         # Linux maps verifies the runtime actually loaded this assembly.

--- a/scripts/observations/mcp-performance/driver.py
+++ b/scripts/observations/mcp-performance/driver.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""Persistent JSON-RPC stdio driver. Measurements exclude fixture setup and inference."""
+import asyncio
+import hashlib
+import json
+import os
+from pathlib import Path
+import shutil
+import time
+
+PROTOCOL = '2026-07-28'
+CAPABILITIES = {'elicitation': {'form': {}}}
+WINDOW = {'from': {'kind': 'utcDateTime', 'value': '2026-07-01T00:00:00Z'},
+          'to': {'kind': 'utcDateTime', 'value': '2026-12-31T00:00:00Z'}}
+
+
+class Response(dict):
+    """JSON response plus local wire accounting, outside the protocol object."""
+    wire_bytes = 0
+
+
+def environment(state, service, otlp=True, exact=False):
+    env = {k:v for k,v in os.environ.items() if not k.startswith(('CALDAV_', 'OTEL_'))}
+    env.update(CALDAV_URL=state['url'], CALDAV_USERNAME=state['username'], CALDAV_PASSWORD=state['password'],
+               CALDAV_DEFAULT_EVENT_CALENDAR_NAME='Performance events',
+               CALDAV_DEFAULT_TODO_CALENDAR_NAME='Performance todos',
+               CALDAV_EVALUATION_TIME_ZONE='America/Sao_Paulo', CALDAV_INTEROPERABILITY_PROFILE='radicale-3.7.8',
+               OTEL_SERVICE_NAME=service)
+    if otlp:
+        env.update(OTEL_EXPORTER_OTLP_ENDPOINT=state['otlp'], OTEL_EXPORTER_OTLP_PROTOCOL='http/protobuf')
+    if exact:
+        env['CALDAV_EXPOSE_EXACT_TOOLS'] = 'true'
+    return env
+
+
+def process_stats(pid):
+    stat = Path(f'/proc/{pid}/stat').read_text().split()
+    status = Path(f'/proc/{pid}/status').read_text().splitlines()
+    mem = {k: int(line.split()[1]) * 1024 for line in status
+           for k in ['VmRSS','VmHWM'] if line.startswith(k + ':')}
+    return dict(cpu_seconds=(int(stat[13])+int(stat[14]))/os.sysconf('SC_CLK_TCK'), **mem)
+
+
+class Client:
+    def __init__(self, assembly, env):
+        self.assembly = Path(assembly).resolve()
+        self.env = env
+        self.pending = {}
+        self.sequence = 0
+        self.notifications = 0
+
+    async def __aenter__(self):
+        start = time.perf_counter_ns()
+        self.process = await asyncio.create_subprocess_exec(str(Path(shutil.which('dotnet')).resolve()),
+            str(self.assembly), stdin=asyncio.subprocess.PIPE, stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE, env=self.env, limit=16*1024*1024)
+        self.reader = asyncio.create_task(self.read())
+        self.stderr = asyncio.create_task(self.process.stderr.read())
+        self.initialized = await self.request('server/discover', {})
+        assert PROTOCOL in self.initialized['result']['supportedVersions'], self.initialized
+        assert 'tools' in self.initialized['result']['capabilities']
+        self.startup_ms = (time.perf_counter_ns()-start)/1e6
+        self.identity = dict(pid=self.process.pid, assembly=str(self.assembly),
+            sha256=hashlib.sha256(self.assembly.read_bytes()).hexdigest(),
+            core_sha256=hashlib.sha256(self.assembly.with_name('DotnetAgents.CalDav.Core.dll').read_bytes()).hexdigest(),
+            command=Path(f'/proc/{self.process.pid}/cmdline').read_bytes().decode().split('\0')[:-1],
+            startup_ms=self.startup_ms, discovery=self.initialized)
+        # Linux maps verifies the runtime actually loaded this assembly.
+        self.identity['assembly_mapped'] = str(self.assembly) in Path(f'/proc/{self.process.pid}/maps').read_text()
+        assert self.identity['assembly_mapped']
+        return self
+
+    async def read(self):
+        try:
+            while line := await self.process.stdout.readline():
+                message = Response(json.loads(line))
+                message.wire_bytes = len(line)
+                if 'id' in message and ('result' in message or 'error' in message):
+                    future = self.pending.get(message['id'])
+                    if future is not None and not future.done():
+                        future.set_result(message)
+                else:
+                    self.notifications += 1
+        except Exception as error:
+            for future in self.pending.values():
+                if not future.done():
+                    future.set_exception(error)
+        finally:
+            for future in self.pending.values():
+                if not future.done():
+                    future.set_exception(EOFError('MCP stdout closed before its response'))
+
+    async def notify(self, method, params):
+        self.process.stdin.write((json.dumps(dict(jsonrpc='2.0',method=method,params=params))+'\n').encode())
+        await self.process.stdin.drain()
+
+    async def request(self, method, params):
+        params = dict(params)
+        params.setdefault('_meta', {
+            'io.modelcontextprotocol/protocolVersion': PROTOCOL,
+            'io.modelcontextprotocol/clientCapabilities': CAPABILITIES,
+            'io.modelcontextprotocol/clientInfo': dict(name='caldav-performance',version='1.0')})
+        self.sequence += 1
+        sequence = self.sequence
+        future = asyncio.get_running_loop().create_future()
+        self.pending[sequence] = future
+        self.process.stdin.write((json.dumps(dict(jsonrpc='2.0', id=sequence, method=method, params=params))+'\n').encode())
+        await self.process.stdin.drain()
+        try:
+            return await asyncio.wait_for(future, 45)
+        finally:
+            del self.pending[sequence]
+
+    async def call(self, tool, arguments, **continuation):
+        params = dict(name=tool, arguments=arguments, _meta={
+            'io.modelcontextprotocol/protocolVersion': PROTOCOL,
+            'io.modelcontextprotocol/clientCapabilities': CAPABILITIES}, **continuation)
+        before = process_stats(self.process.pid)
+        timestamp = time.time_ns()
+        start = time.perf_counter_ns()
+        response = Response()
+        client_failure = None
+        try:
+            response = await self.request('tools/call', params)
+        except TimeoutError:
+            client_failure = 'client_timeout'
+        except (EOFError, ConnectionError):
+            client_failure = 'client_transport_error'
+        except json.JSONDecodeError:
+            client_failure = 'client_protocol_error'
+        elapsed = (time.perf_counter_ns()-start)/1e6
+        try:
+            after = process_stats(self.process.pid)
+        except OSError:
+            after = before
+        result = response.get('result', {})
+        structured = result.get('structuredContent', {})
+        record = dict(tool=tool, timestamp_ns=timestamp, elapsed_ms=elapsed,
+            cpu_ms=(after['cpu_seconds']-before['cpu_seconds'])*1000,
+            rss_bytes=after['VmRSS'], peak_rss_bytes=after['VmHWM'],
+            outcome=client_failure or structured.get('outcome', structured.get('code', result.get('resultType', 'rpc_error'))),
+            is_error=bool(client_failure or result.get('isError') or 'error' in response),
+            timed_out=client_failure=='client_timeout',
+            item_sha256=hashlib.sha256(json.dumps(structured.get('items',[]),sort_keys=True).encode()).hexdigest(),
+            items=len(structured.get('items', [])), response_bytes=response.wire_bytes)
+        return response, record
+
+    async def __aexit__(self, *exc):
+        start = time.perf_counter_ns()
+        self.process.stdin.close()
+        try:
+            await asyncio.wait_for(self.process.wait(), 5)
+        except TimeoutError:
+            self.process.kill()
+            await self.process.wait()
+            raise RuntimeError('MCP shutdown exceeded 5 seconds')
+        await self.reader
+        stderr = await self.stderr
+        self.identity.update(shutdown_ms=(time.perf_counter_ns()-start)/1e6,
+                             exit_code=self.process.returncode, stderr_bytes=len(stderr))
+        assert self.process.returncode == 0 and not stderr, self.identity
+
+
+def query(tool, size=5, bounded=True):
+    args = dict(scope={'mode':'all'}, pageSize=size)
+    if tool == 'calendar_entities.query':
+        args['entityKinds'] = ['event','todo']
+    if tool == 'todos.query':
+        args.update(completionStates=['open','completed','cancelled','indeterminate'],
+                    projection=['summary','status','due','priority','categories','recurrence'])
+    if bounded:
+        args.update(WINDOW)
+    return args
+
+
+async def pilot(root, assembly):
+    state = json.loads((root/'infra-private.json').read_text())
+    records = []
+    for tool in ['calendar_entities.query','calendar_occurrences.query','todos.query']:
+        async with Client(assembly, environment(state, 'caldav-perf-pilot-'+tool.split('.')[0])) as client:
+            catalog = await client.request('tools/list', {})
+            (root/'catalog-live.json').write_text(json.dumps(catalog, indent=2))
+            for size in [1,5,200]:
+                response, record = await client.call(tool, query(tool, size))
+                records.append(dict(record, size=size, phase='start'))
+                print(json.dumps(records[-1]), flush=True)
+                structured = response.get('result',{}).get('structuredContent',{})
+                if structured.get('outcome') != 'success':
+                    print(json.dumps(response)[:1500], flush=True)
+                cursor = structured.get('pagination',{}).get('nextCursor')
+                if cursor:
+                    _, record = await client.call(tool, dict(cursor=cursor,pageSize=size))
+                    records.append(dict(record, size=size, phase='continue'))
+                    print(json.dumps(records[-1]), flush=True)
+            (root/('pilot-process-'+tool+'.json')).write_text(json.dumps(client.identity,indent=2))
+    (root/'pilot.json').write_text(json.dumps(records,indent=2))
+
+
+if __name__ == '__main__':
+    import argparse
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('root', type=Path)
+    parser.add_argument('assembly', type=Path)
+    args = parser.parse_args()
+    asyncio.run(pilot(args.root,args.assembly))

--- a/scripts/observations/mcp-performance/edges.py
+++ b/scripts/observations/mcp-performance/edges.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Read controls, corpus scales, expected limits and telemetry lifecycle probes."""
+import argparse
+import asyncio
+import json
+from pathlib import Path
+import shutil
+from driver import Client, environment, query
+from infra import request, resource, verify
+
+
+async def run(root,baseline,candidate):
+    state=json.loads((root/'infra-private.json').read_text());records=[]
+    def remember(value):
+        records.append(value)
+        with (root/'edges.jsonl').open('a') as stream:
+            stream.write(json.dumps(value)+'\n')
+    for label,assembly in [('baseline',baseline),('candidate',candidate)]:
+        for otlp in [True,False,'unavailable']:
+            env=environment(state,f'caldav-perf-controls-{label}-{otlp}',otlp=bool(otlp),exact=True)
+            if otlp=='unavailable':
+                env['OTEL_EXPORTER_OTLP_ENDPOINT']='http://127.0.0.1:1'
+            async with Client(assembly,env) as c:
+                for tool in ['calendars.list','calendar_resources.get','calendar_resources.exact_get']:
+                    args={} if tool=='calendars.list' else dict(href=state['url']+'/perftest/todos/0001.ics')
+                    for i in range(25):
+                        _,record=await c.call(tool,args)
+                        assert record['outcome']=='success'
+                        remember(dict(record,label=label,otlp=otlp,warmup=i<5))
+            remember(dict(label=label,otlp=otlp,process=c.identity))
+            # No-request EOF must leave both streams empty, including collector failure.
+            p=await asyncio.create_subprocess_exec(shutil.which('dotnet'),str(assembly),env=env,
+                    stdin=asyncio.subprocess.PIPE,stdout=asyncio.subprocess.PIPE,stderr=asyncio.subprocess.PIPE)
+            out,err=await asyncio.wait_for(p.communicate(b''),5)
+            assert not out and not err and p.returncode==0
+            remember(dict(label=label,otlp=otlp,no_request_eof_clean=True))
+    path='/perftest/scale/';href=state['url']+path
+    body='''<D:mkcol xmlns:D="DAV:" xmlns:C="urn:ietf:params:xml:ns:caldav"><D:set><D:prop>
+<D:resourcetype><D:collection/><C:calendar/></D:resourcetype><D:displayname>Scale fixture</D:displayname>
+<C:supported-calendar-component-set><C:comp name="VEVENT"/></C:supported-calendar-component-set>
+</D:prop></D:set></D:mkcol>'''
+    assert request(state,'MKCOL',path,body)[0]==201
+    try:
+        previous=0
+        for count in [1,50,200]:
+            for index in range(previous,count):
+                assert request(state,'PUT',path+f'{index:04d}.ics',resource('VEVENT',index),
+                               {'Content-Type':'text/calendar','If-None-Match':'*'})[0]==201
+            previous=count
+            for label,assembly in [('baseline',baseline),('candidate',candidate)]:
+                async with Client(assembly,environment(state,'caldav-perf-scale-'+label)) as c:
+                    for tool in ['calendar_entities.query','calendar_occurrences.query']:
+                        args=query(tool,200);args['scope']=dict(mode='selected',calendar=dict(by='href',href=href))
+                        if tool=='calendar_entities.query':args['entityKinds']=['event']
+                        _,record=await c.call(tool,args)
+                        assert record['outcome']=='success'
+                        remember(dict(record,label=label,corpus_resources=count,scale=True))
+        # Existing 600-event collection supplies the next scale without reseeding it.
+        async with Client(candidate,environment(state,'caldav-perf-limits')) as c:
+            args=query('calendar_entities.query',200)
+            args.update(scope=dict(mode='selected',calendar=dict(by='href',href=state['url']+'/perftest/events/')),
+                        entityKinds=['event'])
+            _,record=await c.call('calendar_entities.query',args)
+            remember(dict(record,corpus_resources=600,scale=True,label='candidate'))
+        over=resource('VEVENT',10000).replace('RRULE:FREQ=WEEKLY;COUNT=20','RRULE:FREQ=MINUTELY;COUNT=6000')
+        assert request(state,'PUT',path+'over-limit.ics',over,{'Content-Type':'text/calendar'})[0]==201
+        for label,assembly in [('baseline',baseline),('candidate',candidate)]:
+            async with Client(assembly,environment(state,'caldav-perf-limits-'+label)) as c:
+                args=query('calendar_occurrences.query',5)
+                args['scope']=dict(mode='selected',calendar=dict(by='href',href=href))
+                response,record=await c.call('calendar_occurrences.query',args)
+                code=response['result']['structuredContent'].get('code')
+                assert code=='limit_exhausted',response
+                remember(dict(record,label=label,expected_limit=True,code=code))
+    finally:
+        assert request(state,'DELETE',path)[0] in (200,204)
+    # Demonstrate the actual finite store boundary separately from useful throughput.
+    for label,assembly in [('baseline',baseline),('candidate',candidate)]:
+        async with Client(assembly,environment(state,'caldav-perf-store-'+label)) as c:
+            args=query('todos.query',1,bounded=False)
+            args['scope']=dict(mode='selected',calendar=dict(by='href',href=state['url']+'/perftest/todos/'))
+            for index in range(17):
+                response,record=await c.call('todos.query',args)
+                code=response['result']['structuredContent'].get('code')
+                assert record['outcome']=='success' if index<16 else code=='busy'
+                remember(dict(record,label=label,store_index=index,expected_limit=index==16,code=code))
+    assert verify(state)==dict(events=600,todos=600,archive=0)
+    (root/'edges.json').write_text(json.dumps(records,indent=2))
+    print('Read controls, scales, limits, EOF and collector failure passed',flush=True)
+
+
+if __name__=='__main__':
+    p=argparse.ArgumentParser(description=__doc__)
+    p.add_argument('root',type=Path);p.add_argument('baseline',type=Path);p.add_argument('candidate',type=Path)
+    a=p.parse_args();asyncio.run(run(a.root,a.baseline,a.candidate))

--- a/scripts/observations/mcp-performance/edges.py
+++ b/scripts/observations/mcp-performance/edges.py
@@ -2,12 +2,30 @@
 """Read controls, corpus scales, expected limits and telemetry lifecycle probes."""
 import argparse
 import asyncio
+from contextlib import suppress
 import json
 from pathlib import Path
 import shutil
 from driver import Client, environment, query
 from infra import request, resource, verify, expected_counts
 from build_manifest import load_builds, benchmark_inputs
+
+EOF_TIMEOUT_SECONDS=5
+
+
+async def eof_control(assembly,env):
+    process=await asyncio.create_subprocess_exec(shutil.which('dotnet'),str(assembly),env=env,
+        stdin=asyncio.subprocess.PIPE,stdout=asyncio.subprocess.PIPE,stderr=asyncio.subprocess.PIPE)
+    try:
+        out,err=await asyncio.wait_for(process.communicate(b''),EOF_TIMEOUT_SECONDS)
+    except BaseException:
+        if process.returncode is None:
+            with suppress(ProcessLookupError):
+                process.kill()
+        await process.wait()
+        raise
+    if out or err or process.returncode!=0:
+        raise RuntimeError('No-request EOF must exit successfully with both streams empty')
 
 
 def record_scale(remember,record,**metadata):
@@ -40,27 +58,27 @@ async def run(root,baseline,candidate):
                     args={} if tool=='calendars.list' else dict(href=state['url']+'/perftest/todos/0001.ics')
                     for i in range(25):
                         _,record=await c.call(tool,args)
-                        assert record['outcome']=='success'
+                        if not (record['outcome']=='success'):
+                            raise RuntimeError('Read control failed')
                         remember(dict(record,label=label,otlp=otlp,warmup=i<5))
             remember(dict(label=label,otlp=otlp,process=c.identity))
             # No-request EOF must leave both streams empty, including collector failure.
-            p=await asyncio.create_subprocess_exec(shutil.which('dotnet'),str(assembly),env=env,
-                    stdin=asyncio.subprocess.PIPE,stdout=asyncio.subprocess.PIPE,stderr=asyncio.subprocess.PIPE)
-            out,err=await asyncio.wait_for(p.communicate(b''),5)
-            assert not out and not err and p.returncode==0
+            await eof_control(assembly,env)
             remember(dict(label=label,otlp=otlp,no_request_eof_clean=True))
     path='/perftest/scale/';href=state['url']+path
     body='''<D:mkcol xmlns:D="DAV:" xmlns:C="urn:ietf:params:xml:ns:caldav"><D:set><D:prop>
 <D:resourcetype><D:collection/><C:calendar/></D:resourcetype><D:displayname>Scale fixture</D:displayname>
 <C:supported-calendar-component-set><C:comp name="VEVENT"/></C:supported-calendar-component-set>
 </D:prop></D:set></D:mkcol>'''
-    assert request(state,'MKCOL',path,body)[0]==201
+    if not (request(state,'MKCOL',path,body)[0]==201):
+        raise RuntimeError('Scale collection creation failed')
     try:
         previous=0
         for count in [1,50,200]:
             for index in range(previous,count):
-                assert request(state,'PUT',path+f'{index:04d}.ics',resource('VEVENT',index),
-                               {'Content-Type':'text/calendar','If-None-Match':'*'})[0]==201
+                if not (request(state,'PUT',path+f'{index:04d}.ics',resource('VEVENT',index),
+                               {'Content-Type':'text/calendar','If-None-Match':'*'})[0]==201):
+                    raise RuntimeError('Scale resource creation failed')
             previous=count
             for label,assembly in [('baseline',baseline),('candidate',candidate)]:
                 async with Client(assembly,environment(state,'caldav-perf-scale-'+label)) as c:
@@ -77,17 +95,20 @@ async def run(root,baseline,candidate):
             _,record=await c.call('calendar_entities.query',args)
             record_scale(remember,record,corpus_resources=expected['events'],label='candidate')
         over=resource('VEVENT',10000).replace('RRULE:FREQ=WEEKLY;COUNT=20','RRULE:FREQ=MINUTELY;COUNT=6000')
-        assert request(state,'PUT',path+'over-limit.ics',over,{'Content-Type':'text/calendar'})[0]==201
+        if not (request(state,'PUT',path+'over-limit.ics',over,{'Content-Type':'text/calendar'})[0]==201):
+            raise RuntimeError('Limit fixture creation failed')
         for label,assembly in [('baseline',baseline),('candidate',candidate)]:
             async with Client(assembly,environment(state,'caldav-perf-limits-'+label)) as c:
                 args=query('calendar_occurrences.query',5)
                 args['scope']=dict(mode='selected',calendar=dict(by='href',href=href))
                 response,record=await c.call('calendar_occurrences.query',args)
                 code=response['result']['structuredContent'].get('code')
-                assert code=='limit_exhausted',response
+                if not (code=='limit_exhausted'):
+                    raise RuntimeError('Expected occurrence limit was not enforced')
                 remember(dict(record,label=label,expected_limit=True,code=code))
     finally:
-        assert request(state,'DELETE',path)[0] in (200,204)
+        if not (request(state,'DELETE',path)[0] in (200,204)):
+            raise RuntimeError('Scale collection cleanup failed')
     # Demonstrate the actual finite store boundary separately from useful throughput.
     for label,assembly in [('baseline',baseline),('candidate',candidate)]:
         async with Client(assembly,environment(state,'caldav-perf-store-'+label)) as c:
@@ -96,9 +117,11 @@ async def run(root,baseline,candidate):
             for index in range(17):
                 response,record=await c.call('todos.query',args)
                 code=response['result']['structuredContent'].get('code')
-                assert record['outcome']=='success' if index<16 else code=='busy'
+                if not (record['outcome']=='success' if index<16 else code=='busy'):
+                    raise RuntimeError('Snapshot store boundary was not enforced')
                 remember(dict(record,label=label,store_index=index,expected_limit=index==16,code=code))
-    assert verify(state)==expected
+    if not (verify(state)==expected):
+        raise RuntimeError('Corpus restoration failed')
     (root/'edges.json').write_text(json.dumps(records,indent=2))
     print('Read controls, scales, limits, EOF and collector failure passed',flush=True)
 

--- a/scripts/observations/mcp-performance/edges.py
+++ b/scripts/observations/mcp-performance/edges.py
@@ -6,10 +6,13 @@ import json
 from pathlib import Path
 import shutil
 from driver import Client, environment, query
-from infra import request, resource, verify
+from infra import request, resource, verify, expected_counts
 
 
 async def run(root,baseline,candidate):
+    expected=expected_counts(root)
+    if expected['todos']<2:
+        raise RuntimeError('The limit matrix requires at least two seeded todos; cleanup supports any seed count')
     state=json.loads((root/'infra-private.json').read_text());records=[]
     def remember(value):
         records.append(value)
@@ -55,13 +58,13 @@ async def run(root,baseline,candidate):
                         _,record=await c.call(tool,args)
                         assert record['outcome']=='success'
                         remember(dict(record,label=label,corpus_resources=count,scale=True))
-        # Existing 600-event collection supplies the next scale without reseeding it.
+        # Include the requested seeded collection size without reseeding it.
         async with Client(candidate,environment(state,'caldav-perf-limits')) as c:
             args=query('calendar_entities.query',200)
             args.update(scope=dict(mode='selected',calendar=dict(by='href',href=state['url']+'/perftest/events/')),
                         entityKinds=['event'])
             _,record=await c.call('calendar_entities.query',args)
-            remember(dict(record,corpus_resources=600,scale=True,label='candidate'))
+            remember(dict(record,corpus_resources=expected['events'],scale=True,label='candidate'))
         over=resource('VEVENT',10000).replace('RRULE:FREQ=WEEKLY;COUNT=20','RRULE:FREQ=MINUTELY;COUNT=6000')
         assert request(state,'PUT',path+'over-limit.ics',over,{'Content-Type':'text/calendar'})[0]==201
         for label,assembly in [('baseline',baseline),('candidate',candidate)]:
@@ -84,7 +87,7 @@ async def run(root,baseline,candidate):
                 code=response['result']['structuredContent'].get('code')
                 assert record['outcome']=='success' if index<16 else code=='busy'
                 remember(dict(record,label=label,store_index=index,expected_limit=index==16,code=code))
-    assert verify(state)==dict(events=600,todos=600,archive=0)
+    assert verify(state)==expected
     (root/'edges.json').write_text(json.dumps(records,indent=2))
     print('Read controls, scales, limits, EOF and collector failure passed',flush=True)
 

--- a/scripts/observations/mcp-performance/edges.py
+++ b/scripts/observations/mcp-performance/edges.py
@@ -9,6 +9,12 @@ from driver import Client, environment, query
 from infra import request, resource, verify, expected_counts
 
 
+def record_scale(remember,record,**metadata):
+    remember(dict(record,**metadata,scale=True))
+    if record['outcome']!='success' or record.get('is_error'):
+        raise RuntimeError('Scale query failed: '+record['outcome'])
+
+
 async def run(root,baseline,candidate):
     expected=expected_counts(root)
     if expected['todos']<2:
@@ -56,15 +62,14 @@ async def run(root,baseline,candidate):
                         args=query(tool,200);args['scope']=dict(mode='selected',calendar=dict(by='href',href=href))
                         if tool=='calendar_entities.query':args['entityKinds']=['event']
                         _,record=await c.call(tool,args)
-                        assert record['outcome']=='success'
-                        remember(dict(record,label=label,corpus_resources=count,scale=True))
+                        record_scale(remember,record,label=label,corpus_resources=count)
         # Include the requested seeded collection size without reseeding it.
         async with Client(candidate,environment(state,'caldav-perf-limits')) as c:
             args=query('calendar_entities.query',200)
             args.update(scope=dict(mode='selected',calendar=dict(by='href',href=state['url']+'/perftest/events/')),
                         entityKinds=['event'])
             _,record=await c.call('calendar_entities.query',args)
-            remember(dict(record,corpus_resources=expected['events'],scale=True,label='candidate'))
+            record_scale(remember,record,corpus_resources=expected['events'],label='candidate')
         over=resource('VEVENT',10000).replace('RRULE:FREQ=WEEKLY;COUNT=20','RRULE:FREQ=MINUTELY;COUNT=6000')
         assert request(state,'PUT',path+'over-limit.ics',over,{'Content-Type':'text/calendar'})[0]==201
         for label,assembly in [('baseline',baseline),('candidate',candidate)]:

--- a/scripts/observations/mcp-performance/edges.py
+++ b/scripts/observations/mcp-performance/edges.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import shutil
 from driver import Client, environment, query
 from infra import request, resource, verify, expected_counts
+from build_manifest import load_builds, benchmark_inputs
 
 
 def record_scale(remember,record,**metadata):
@@ -16,10 +17,15 @@ def record_scale(remember,record,**metadata):
 
 
 async def run(root,baseline,candidate):
+    inputs=benchmark_inputs(load_builds(root),baseline,candidate)
+    baseline=Path(inputs['baseline']['assembly']);candidate=Path(inputs['candidate']['assembly'])
+    if (root/'edges.jsonl').exists() or (root/'edges-manifest.json').exists():
+        raise RuntimeError('Use fresh edge evidence; preserve previous attempts')
     expected=expected_counts(root)
     if expected['todos']<2:
         raise RuntimeError('The limit matrix requires at least two seeded todos; cleanup supports any seed count')
     state=json.loads((root/'infra-private.json').read_text());records=[]
+    (root/'edges-manifest.json').write_text(json.dumps(dict(build_inputs=inputs),indent=2))
     def remember(value):
         records.append(value)
         with (root/'edges.jsonl').open('a') as stream:

--- a/scripts/observations/mcp-performance/functional.py
+++ b/scripts/observations/mcp-performance/functional.py
@@ -193,8 +193,10 @@ class Functional:
         await self.call('calendars.delete',dict(href=collection))
         self.authoritative(collection,absent=True);self.owned.discard(collection)
         called={r['tool'] for r in self.records if 'tool' in r}
-        assert called=={t['name'] for t in catalog},called
-        assert verify(self.state)==expected_counts(self.root)
+        if not (called=={t['name'] for t in catalog}):
+            raise RuntimeError('Functional matrix did not cover the live catalog')
+        if not (verify(self.state)==expected_counts(self.root)):
+            raise RuntimeError('Corpus restoration failed')
 
 
 async def run(root,assembly):
@@ -210,7 +212,8 @@ async def run(root,assembly):
         finally:
             for href in f.owned:
                 status,_,_=request(state,'DELETE',urllib.parse.urlparse(href).path)
-                assert status in (200,204,404)
+                if not (status in (200,204,404)):
+                    raise RuntimeError('Owned fixture cleanup failed')
     (root/'functional-process.json').write_text(json.dumps(dict(client.identity,build_input=build_input),indent=2))
 
 

--- a/scripts/observations/mcp-performance/functional.py
+++ b/scripts/observations/mcp-performance/functional.py
@@ -3,6 +3,7 @@
 import argparse
 import asyncio
 import json
+import re
 from pathlib import Path
 import secrets
 import urllib.parse
@@ -22,6 +23,51 @@ def sanitize(value, key=''):
     if isinstance(value,str) and key not in SAFE_STRINGS:
         return '[redacted]'
     return value
+
+
+def verify_occurrence_fixture(data,verb,uid):
+    """Check the authored UTC fixture, including the targeted RDATE/override."""
+    def require(condition,detail):
+        if not condition:
+            raise RuntimeError('Persisted occurrence postcondition failed: '+detail)
+    events=[];stack=[];event=None
+    for line in re.sub(rb'\r?\n[ \t]',b'',data).decode().splitlines():
+        if ':' not in line:
+            continue
+        token,value=line.split(':',1)
+        name=token.split(';',1)[0].upper()
+        if name=='BEGIN':
+            stack.append(value.upper())
+            if value.upper()=='VEVENT': event={}
+        elif name=='END':
+            require(bool(stack) and stack[-1]==value.upper(),'component nesting')
+            if value.upper()=='VEVENT': events.append(event);event=None
+            stack.pop()
+        elif stack and stack[-1]=='VEVENT':
+            require(name!='RECURRENCE-ID' or ';RANGE=' not in token.upper(),'unexpected range override')
+            event.setdefault(name,[]).append(value)
+    require(not stack,'unclosed component')
+    require(all(event.get('UID')==[uid] for event in events),'event UID')
+    masters=[event for event in events if 'RECURRENCE-ID' not in event]
+    overrides=[event for event in events if 'RECURRENCE-ID' in event]
+    require(len(masters)==1,'master count')
+    master=masters[0];target='20260909T120000Z'
+    require(master.get('DTSTART')==['20260905T120000Z'],'master start')
+    require(master.get('DTEND')==['20260905T130000Z'],'master end')
+    rules=master.get('RRULE',[])
+    require(len(rules)==1 and dict(part.split('=',1) for part in rules[0].split(';'))==
+            {'FREQ':'DAILY','COUNT':'3'},'master recurrence rule')
+    values=lambda name:{value for line in master.get(name,[]) for value in line.split(',')}
+    require(values('RDATE')=={target},'added occurrence membership')
+    require(values('EXDATE')==({target} if verb=='exclude' else set()),'excluded occurrence membership')
+    require('CANCELLED' not in master.get('STATUS',[]),'master was cancelled')
+    require(len(overrides)<=1 and all(event['RECURRENCE-ID']==[target] for event in overrides),'override identity')
+    if verb=='cancel':
+        require(len(overrides)==1 and overrides[0].get('STATUS')==['CANCELLED'],'target cancellation')
+    elif verb=='restore_cancellation':
+        require(all('CANCELLED' not in event.get('STATUS',[]) for event in overrides),'target restoration')
+    else:
+        require(not overrides,'unexpected override')
 
 
 class Functional:
@@ -54,11 +100,23 @@ class Functional:
 
     def authoritative(self,href,contains=None,absent=False):
         status,data,_=request(self.state,'GET',urllib.parse.urlparse(href).path)
-        assert status==(404 if absent else 200), status
-        if contains:
-            assert contains.encode() in data
-        self.records.append(dict(authoritative=True,status=status,postcondition=True))
+        passed=status==(404 if absent else 200) and (not contains or contains.encode() in data)
+        self.records.append(dict(authoritative=True,status=status,postcondition=passed))
         self.save()
+        if not passed:
+            raise RuntimeError('Authoritative resource postcondition failed')
+
+    def authoritative_occurrence(self,href,verb,uid):
+        status,data,_=request(self.state,'GET',urllib.parse.urlparse(href).path)
+        passed=False
+        try:
+            if status!=200:
+                raise RuntimeError('Authoritative occurrence read failed')
+            verify_occurrence_fixture(data,verb,uid)
+            passed=True
+        finally:
+            self.records.append(dict(authoritative=True,status=status,occurrence_action=verb,postcondition=passed))
+            self.save()
 
     async def run(self):
         catalog=(await self.client.request('tools/list',{}))['result']['tools']
@@ -80,8 +138,9 @@ class Functional:
             if kind=='event':
                 fields.update(end=dict(kind='utcDateTime',value='2026-09-05T13:00:00Z'),
                               recurrenceSet=dict(rrule='FREQ=DAILY;COUNT=3'))
+            uid='functional-'+kind+'-'+secrets.token_hex(4)
             result=await self.call(kind+'s.create',dict(destination=dict(mode='default'),
-                                  entity=dict(kind=kind,uid='functional-'+kind+'-'+secrets.token_hex(4),fields=fields)))
+                                  entity=dict(kind=kind,uid=uid,fields=fields)))
             snapshot=result['snapshot']
             href=snapshot['resourceRevision']['href'];self.owned.add(href)
             self.authoritative(href,'SUMMARY:Disposable functional '+kind)
@@ -94,7 +153,7 @@ class Functional:
                 for verb in ['add','exclude','restore_exclusion','cancel','restore_cancellation']:
                     snapshot=await self.read(href)
                     await self.call('calendar_occurrences.'+verb,dict(snapshot=snapshot['entityRevision'],recurrenceIdentity=identity))
-                    self.authoritative(href)
+                    self.authoritative_occurrence(href,verb,uid)
             else:
                 snapshot=await self.read(href)
                 await self.call('todos.complete',dict(snapshot=snapshot['entityRevision']))

--- a/scripts/observations/mcp-performance/functional.py
+++ b/scripts/observations/mcp-performance/functional.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Exercise the live catalog, MRTR and authoritative fixture postconditions."""
+import argparse
+import asyncio
+import json
+from pathlib import Path
+import secrets
+import urllib.parse
+from driver import Client, environment, query
+from infra import request, resource, verify
+
+SAFE_STRINGS = {'outcome','code','category','phase','state','mutationState','resultType','kind','entityKind',
+                'resultKind','completionState','mode','source','timeZone','operation','field','action',
+                'protocolVersion','supportedVersions'}
+
+
+def sanitize(value, key=''):
+    if isinstance(value,dict):
+        return {k:sanitize(v,k) for k,v in value.items()}
+    if isinstance(value,list):
+        return [sanitize(v,key) for v in value]
+    if isinstance(value,str) and key not in SAFE_STRINGS:
+        return '[redacted]'
+    return value
+
+
+class Functional:
+    def __init__(self,root,client,state):
+        self.root,self.client,self.state=root,client,state
+        self.records=[]
+        self.owned=set()
+
+    def save(self):
+        (self.root/'functional.json').write_text(json.dumps(self.records,indent=2))
+
+    async def call(self,tool,args,**continuation):
+        response,record=await self.client.call(tool,args,**continuation)
+        record.update(driver='direct_mcp', structured=sanitize(response.get('result',{})))
+        self.records.append(record)
+        self.save()
+        result=response.get('result',{})
+        if result.get('resultType')=='input_required':
+            answers={key:dict(action='accept',content={name:True for name,prop in value['params']['requestedSchema']['properties'].items()
+                         if prop.get('type')=='boolean'}) for key,value in result['inputRequests'].items()}
+            return await self.call(tool,args,requestState=result['requestState'],inputResponses=answers)
+        structured=result.get('structuredContent',{})
+        if structured.get('outcome')!='success':
+            raise RuntimeError(f'{tool}: '+json.dumps(sanitize(response)))
+        print(tool+' success',flush=True)
+        return structured
+
+    async def read(self,href):
+        return (await self.call('calendar_resources.get',dict(href=href)))['snapshot']
+
+    def authoritative(self,href,contains=None,absent=False):
+        status,data,_=request(self.state,'GET',urllib.parse.urlparse(href).path)
+        assert status==(404 if absent else 200), status
+        if contains:
+            assert contains.encode() in data
+        self.records.append(dict(authoritative=True,status=status,postcondition=True))
+        self.save()
+
+    async def run(self):
+        catalog=(await self.client.request('tools/list',{}))['result']['tools']
+        (self.root/'catalog-exact-live.json').write_text(json.dumps(catalog,indent=2))
+        await self.call('calendars.list',{})
+        for tool in ['calendar_entities.query','calendar_occurrences.query','todos.query']:
+            for size in [1,5,200]:
+                result=await self.call(tool,query(tool,size))
+                await self.call(tool,dict(cursor=result['pagination']['nextCursor'],pageSize=size))
+        for tool in ['calendar_entities.query','todos.query']:
+            await self.call(tool,query(tool,5,bounded=False))
+        href=self.state['url']+'/perftest/todos/0001.ics'
+        await self.read(href)
+        await self.call('calendar_resources.exact_get',dict(href=href))
+        for kind in ['event','todo']:
+            fields=dict(summary='Disposable functional '+kind,
+                        start=dict(kind='utcDateTime',value='2026-09-05T12:00:00Z'))
+            if kind=='event':
+                fields.update(end=dict(kind='utcDateTime',value='2026-09-05T13:00:00Z'),
+                              recurrenceSet=dict(rrule='FREQ=DAILY;COUNT=3'))
+            result=await self.call(kind+'s.create',dict(destination=dict(mode='default'),
+                                  entity=dict(kind=kind,uid='functional-'+kind+'-'+secrets.token_hex(4),fields=fields)))
+            snapshot=result['snapshot']
+            href=snapshot['resourceRevision']['href'];self.owned.add(href)
+            self.authoritative(href,'SUMMARY:Disposable functional '+kind)
+            snapshot=await self.read(href)
+            patched=await self.call(kind+'s.patch',dict(snapshot=snapshot['entityRevision'],target=dict(scope='master'),
+                patch=dict(scalars=[dict(field='summary',operation='set',value='Patched functional '+kind)])))
+            self.authoritative(href,'SUMMARY:Patched functional '+kind)
+            if kind=='event':
+                identity=dict(value=dict(kind='utcDateTime',value='2026-09-09T12:00:00Z'))
+                for verb in ['add','exclude','restore_exclusion','cancel','restore_cancellation']:
+                    snapshot=await self.read(href)
+                    await self.call('calendar_occurrences.'+verb,dict(snapshot=snapshot['entityRevision'],recurrenceIdentity=identity))
+                    self.authoritative(href)
+            else:
+                snapshot=await self.read(href)
+                await self.call('todos.complete',dict(snapshot=snapshot['entityRevision']))
+                self.authoritative(href,'STATUS:COMPLETED')
+                for destination in ['archive','todos']:
+                    snapshot=await self.read(href)
+                    moved=await self.call('calendar_resources.move',dict(revision=snapshot['entityRevision'],
+                        destination=dict(mode='selected',calendar=dict(by='href',href=self.state['url']+'/perftest/'+destination+'/'))))
+                    self.authoritative(href,absent=True);self.owned.discard(href)
+                    href=moved['snapshot']['resourceRevision']['href'];self.owned.add(href)
+                    self.authoritative(href,'STATUS:COMPLETED')
+            snapshot=await self.read(href)
+            await self.call('calendar_resources.delete',dict(revision=snapshot['entityRevision']))
+            self.authoritative(href,absent=True);self.owned.discard(href)
+        href=self.state['url']+'/perftest/events/exact-functional.ics'
+        data=resource('VEVENT',9001)
+        self.owned.add(href)
+        await self.call('calendar_resources.exact_create',dict(destinationHref=href,utf8Resource=data))
+        self.authoritative(href)
+        snapshot=await self.read(href)
+        await self.call('calendar_resources.exact_replace',dict(revision=snapshot['entityRevision'],
+                        utf8Resource=data.replace('Performance VEVENT 9001','Exact replaced')))
+        self.authoritative(href,'SUMMARY:Exact replaced')
+        snapshot=await self.read(href)
+        destination=href.replace('exact-functional','exact-moved')
+        self.owned.add(destination)
+        await self.call('calendar_resources.exact_move',dict(revision=snapshot['entityRevision'],destinationHref=destination))
+        self.authoritative(href,absent=True);self.owned.discard(href)
+        snapshot=await self.read(destination)
+        await self.call('calendar_resources.delete',dict(revision=snapshot['entityRevision']))
+        self.authoritative(destination,absent=True);self.owned.discard(destination)
+        collection=self.state['url']+'/perftest/functional-calendar/'
+        self.owned.add(collection)
+        await self.call('calendars.create',dict(displayName='Disposable functional calendar',
+                        entityKinds=['event','todo'],destinationHref=collection))
+        await self.call('calendars.delete',dict(href=collection))
+        self.authoritative(collection,absent=True);self.owned.discard(collection)
+        called={r['tool'] for r in self.records if 'tool' in r}
+        assert called=={t['name'] for t in catalog},called
+        assert verify(self.state)==dict(events=600,todos=600,archive=0)
+
+
+async def run(root,assembly):
+    state=json.loads((root/'infra-private.json').read_text())
+    async with Client(assembly,environment(state,'caldav-perf-functional',exact=True)) as client:
+        f=Functional(root,client,state)
+        try:
+            await f.run()
+        finally:
+            for href in f.owned:
+                status,_,_=request(state,'DELETE',urllib.parse.urlparse(href).path)
+                assert status in (200,204,404)
+    (root/'functional-process.json').write_text(json.dumps(client.identity,indent=2))
+
+
+if __name__=='__main__':
+    p=argparse.ArgumentParser(description=__doc__)
+    p.add_argument('root',type=Path);p.add_argument('assembly',type=Path)
+    a=p.parse_args();asyncio.run(run(a.root,a.assembly))

--- a/scripts/observations/mcp-performance/functional.py
+++ b/scripts/observations/mcp-performance/functional.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import secrets
 import urllib.parse
 from driver import Client, environment, query
-from infra import request, resource, verify
+from infra import request, resource, verify, expected_counts
 
 SAFE_STRINGS = {'outcome','code','category','phase','state','mutationState','resultType','kind','entityKind',
                 'resultKind','completionState','mode','source','timeZone','operation','field','action',
@@ -67,7 +67,8 @@ class Functional:
         for tool in ['calendar_entities.query','calendar_occurrences.query','todos.query']:
             for size in [1,5,200]:
                 result=await self.call(tool,query(tool,size))
-                await self.call(tool,dict(cursor=result['pagination']['nextCursor'],pageSize=size))
+                if result['pagination']['nextCursor'] is not None:
+                    await self.call(tool,dict(cursor=result['pagination']['nextCursor'],pageSize=size))
         for tool in ['calendar_entities.query','todos.query']:
             await self.call(tool,query(tool,5,bounded=False))
         href=self.state['url']+'/perftest/todos/0001.ics'
@@ -133,10 +134,12 @@ class Functional:
         self.authoritative(collection,absent=True);self.owned.discard(collection)
         called={r['tool'] for r in self.records if 'tool' in r}
         assert called=={t['name'] for t in catalog},called
-        assert verify(self.state)==dict(events=600,todos=600,archive=0)
+        assert verify(self.state)==expected_counts(self.root)
 
 
 async def run(root,assembly):
+    if expected_counts(root)['todos']<2:
+        raise RuntimeError('The functional matrix requires at least two seeded todos; cleanup supports any seed count')
     state=json.loads((root/'infra-private.json').read_text())
     async with Client(assembly,environment(state,'caldav-perf-functional',exact=True)) as client:
         f=Functional(root,client,state)

--- a/scripts/observations/mcp-performance/functional.py
+++ b/scripts/observations/mcp-performance/functional.py
@@ -9,6 +9,7 @@ import secrets
 import urllib.parse
 from driver import Client, environment, query
 from infra import request, resource, verify, expected_counts
+from build_manifest import prepared_input
 
 SAFE_STRINGS = {'outcome','code','category','phase','state','mutationState','resultType','kind','entityKind',
                 'resultKind','completionState','mode','source','timeZone','operation','field','action',
@@ -197,6 +198,8 @@ class Functional:
 
 
 async def run(root,assembly):
+    build_input=prepared_input(root,assembly)
+    assembly=Path(build_input['assembly'])
     if expected_counts(root)['todos']<2:
         raise RuntimeError('The functional matrix requires at least two seeded todos; cleanup supports any seed count')
     state=json.loads((root/'infra-private.json').read_text())
@@ -208,7 +211,7 @@ async def run(root,assembly):
             for href in f.owned:
                 status,_,_=request(state,'DELETE',urllib.parse.urlparse(href).path)
                 assert status in (200,204,404)
-    (root/'functional-process.json').write_text(json.dumps(client.identity,indent=2))
+    (root/'functional-process.json').write_text(json.dumps(dict(client.identity,build_input=build_input),indent=2))
 
 
 if __name__=='__main__':

--- a/scripts/observations/mcp-performance/gates.py
+++ b/scripts/observations/mcp-performance/gates.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Run repository gates and bind their artifacts to the prepared candidate."""
+import argparse
+import json
+from pathlib import Path
+import subprocess
+from build_manifest import load_builds, source_identity, runtime_files
+
+STEPS=['tool-restore','restore','build','tests','slopwatch']
+
+
+def verify_gate_identity(directory,candidate):
+    proof=json.loads((directory/'gate-source.json').read_text())
+    if (not proof['completed'] or proof['source']!=candidate['source']
+            or proof['source_after']!=candidate['source']
+            or proof['runtime_files_sha256']!=candidate['runtime_files_sha256']
+            or proof['steps']!=[dict(name=name,exit_code=0) for name in STEPS]):
+        raise RuntimeError('Gate evidence does not certify the prepared candidate source and runtime')
+
+
+def run(root,name):
+    root=root.resolve()
+    repository=Path(__file__).resolve().parents[3]
+    if root.is_relative_to(repository) or Path(name).name!=name:
+        raise ValueError('Use an external prepared root and a simple gate run name')
+    candidate=load_builds(root)['candidate']
+    source=source_identity(repository)
+    if source!=candidate['source']:
+        raise RuntimeError('Prepare the current candidate before running its gates')
+    directory=root/name
+    proof_path=root/(name+'-source.json')
+    if directory.exists() or proof_path.exists():
+        raise RuntimeError('Use a fresh gate run name; preserve previous attempts')
+    directory.mkdir()
+    proof=dict(source=source,source_after=None,runtime_files_sha256=None,steps=[],completed=False)
+    proof_path.write_text(json.dumps(proof,indent=2))
+    commands=[
+        ['dotnet','tool','restore'],['dotnet','restore'],['dotnet','build','-c','Release','--no-restore'],
+        ['bash','scripts/run-test-suite.sh','--artifacts-dir',str(directory)],
+        ['dotnet','tool','run','slopwatch','analyze','--config','.slopwatch/slopwatch.json','--fail-on','warning']]
+    assembly=repository/'src/DotnetAgents.CalDav.Mcp/bin/Release/net10.0/DotnetAgents.CalDav.Mcp.dll'
+    try:
+        for step,command in zip(STEPS,commands):
+            with (root/(name+'-'+step+'.log')).open('w') as log:
+                result=subprocess.run(command,cwd=repository,stdout=log,stderr=log)
+            proof['steps'].append(dict(name=step,exit_code=result.returncode))
+            proof_path.write_text(json.dumps(proof,indent=2))
+            if result.returncode:
+                raise RuntimeError('Gate failed: '+step)
+            if step=='build':
+                proof['runtime_files_sha256']=runtime_files(assembly)
+                if proof['runtime_files_sha256']!=candidate['runtime_files_sha256']:
+                    raise RuntimeError('Gate build differs from the prepared candidate runtime')
+        proof['source_after']=source_identity(repository)
+        if proof['source_after']!=source or runtime_files(assembly)!=candidate['runtime_files_sha256']:
+            raise RuntimeError('Candidate changed during the gate run')
+        proof['completed']=True
+    finally:
+        # The suite requires an empty artifact directory at entry. Write its
+        # portable source proof only after the runner returns or fails.
+        for path in [proof_path,directory/'gate-source.json']:
+            path.write_text(json.dumps(proof,indent=2))
+    print(json.dumps(dict(gates=str(directory),source=source['sha'],completed=True)))
+
+
+if __name__=='__main__':
+    parser=argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('root',type=Path)
+    parser.add_argument('--name',default='gates-final')
+    args=parser.parse_args()
+    run(args.root,args.name)

--- a/scripts/observations/mcp-performance/hermes.py
+++ b/scripts/observations/mcp-performance/hermes.py
@@ -8,7 +8,10 @@ p=argparse.ArgumentParser(description='Run installed Hermes against an isolated 
 p.add_argument('root',type=Path);p.add_argument('assembly',type=Path)
 p.add_argument('--source-home',type=Path,default=Path.home()/'.hermes')
 a=p.parse_args()
-root=a.root.resolve(); state=json.loads((root/'infra-private.json').read_text())
+root=a.root.resolve()
+if (root/'hermes-wire-sanitized.jsonl').exists():
+    p.error('Hermes wire evidence already exists; use a fresh evidence directory')
+state=json.loads((root/'infra-private.json').read_text())
 repo=Path(__file__).resolve().parents[3]
 sys.path.insert(0,str(repo/'scripts/observations/mcp-performance'))
 from driver import environment

--- a/scripts/observations/mcp-performance/hermes.py
+++ b/scripts/observations/mcp-performance/hermes.py
@@ -20,14 +20,16 @@ sys.path.insert(0,str(repo/'scripts/observations/mcp-performance'))
 from driver import environment
 home=root/'hermes-isolated';home.mkdir(exist_ok=True);home.chmod(0o700)
 base=yaml.safe_load((a.source_home/'config.yaml').read_text())
-assert base['model'].get('provider')=='openrouter', 'This witness uses the already configured OpenRouter provider only'
+if not (base['model'].get('provider')=='openrouter'):
+    raise RuntimeError('This witness uses the already configured OpenRouter provider only')
 config={'model':base['model'],'agent':{'reasoning_effort':base.get('agent',{}).get('reasoning_effort','medium'),'max_turns':30},
 'mcp_servers':{'perf':{'command':sys.executable,'args':[str(repo/'scripts/observations/mcp-performance/hermes_proxy.py'),str(a.assembly),str(root/'hermes-wire-sanitized.jsonl'),str(root)],
 'env':{k:v for k,v in environment(state,'caldav-perf-hermes',exact=False).items() if k.startswith(('CALDAV_','OTEL_'))},'timeout':60,'connect_timeout':60}}}
 (home/'config.yaml').write_text(yaml.safe_dump(config));(home/'config.yaml').chmod(0o600)
 secrets=dotenv_values(a.source_home/'.env')
 key=os.environ.get('OPENROUTER_API_KEY') or secrets.get('OPENROUTER_API_KEY')
-assert key,'Configured OpenRouter credential unavailable'
+if not (key):
+    raise RuntimeError('Configured OpenRouter credential unavailable')
 (home/'.env').write_text('OPENROUTER_API_KEY='+key+'\n');(home/'.env').chmod(0o600)
 model_metadata={key:config['model'][key] for key in ['provider','model','default']
                 if isinstance(config['model'].get(key),str)}

--- a/scripts/observations/mcp-performance/hermes.py
+++ b/scripts/observations/mcp-performance/hermes.py
@@ -26,7 +26,11 @@ secrets=dotenv_values(a.source_home/'.env')
 key=os.environ.get('OPENROUTER_API_KEY') or secrets.get('OPENROUTER_API_KEY')
 assert key,'Configured OpenRouter credential unavailable'
 (home/'.env').write_text('OPENROUTER_API_KEY='+key+'\n');(home/'.env').chmod(0o600)
-(root/'hermes-config-sanitized.json').write_text(json.dumps(dict(model=config['model'],agent=config['agent'],hermes_home=str(home),mcp_command=config['mcp_servers']['perf']['command'],mcp_args=config['mcp_servers']['perf']['args']),indent=2))
+model_metadata={key:config['model'][key] for key in ['provider','model','default']
+                if isinstance(config['model'].get(key),str)}
+with os.fdopen(os.open(root/'hermes-config-sanitized.json',os.O_WRONLY|os.O_CREAT|os.O_TRUNC,0o600),'w') as stream:
+ os.fchmod(stream.fileno(),0o600)
+ json.dump(dict(model=model_metadata,agent=config['agent'],hermes_home=str(home),mcp_command=config['mcp_servers']['perf']['command'],mcp_args=config['mcp_servers']['perf']['args']),stream,indent=2)
 prompt='''Execute uma prova real de integração usando somente as ferramentas MCP perf disponíveis nesta sessão persistente. Todos os calendários são fixtures locais descartáveis e as mutações abaixo estão autorizadas. Faça em sequência: 1) calendars.list. 2) calendar_entities.query com scope all, entityKinds event e todo, janela UTC 2026-07-01T00:00:00Z até 2026-12-31T00:00:00Z e pageSize 1; Continue com o cursor obtido e pageSize 5 na mesma sessão. 3) calendar_occurrences.query com a mesma janela e pageSize 1, depois Continue pageSize 5. 4) todos.query com scope all, a mesma janela e pageSize 1; Continue pageSize 5. Os valores temporais usam kind utcDateTime. 5) todos.create no calendário padrão, entity kind todo, UID hermes-perf-20260905-integration, fields summary Hermes disposable integration. 6) calendar_resources.get no href criado. 7) todos.patch usando o entityRevision recém-lido, target scope master, patch scalars field summary operation set value Hermes patched integration. 8) Releia, execute todos.complete com a revisão fresca e releia para confirmar COMPLETED persistido. 9) Tente calendar_resources.delete usando a revisão fresca. Se houver uma confirmação MRTR que a integração não consiga continuar, registre a limitação e pare sem inventar campos ou repetir tentativas. Resuma apenas chamadas realmente executadas. Não use terminal, arquivos nem ferramentas fora deste MCP.'''
 (root/'hermes-prompt.txt').write_text(prompt)
 env={k:v for k,v in os.environ.items() if not k.startswith(('HERMES_','CALDAV_','OTEL_'))}

--- a/scripts/observations/mcp-performance/hermes.py
+++ b/scripts/observations/mcp-performance/hermes.py
@@ -11,6 +11,9 @@ a=p.parse_args()
 root=a.root.resolve()
 if (root/'hermes-wire-sanitized.jsonl').exists():
     p.error('Hermes wire evidence already exists; use a fresh evidence directory')
+from build_manifest import prepared_input
+build_input=prepared_input(root,a.assembly)
+a.assembly=Path(build_input['assembly'])
 state=json.loads((root/'infra-private.json').read_text())
 repo=Path(__file__).resolve().parents[3]
 sys.path.insert(0,str(repo/'scripts/observations/mcp-performance'))
@@ -19,7 +22,7 @@ home=root/'hermes-isolated';home.mkdir(exist_ok=True);home.chmod(0o700)
 base=yaml.safe_load((a.source_home/'config.yaml').read_text())
 assert base['model'].get('provider')=='openrouter', 'This witness uses the already configured OpenRouter provider only'
 config={'model':base['model'],'agent':{'reasoning_effort':base.get('agent',{}).get('reasoning_effort','medium'),'max_turns':30},
-'mcp_servers':{'perf':{'command':sys.executable,'args':[str(repo/'scripts/observations/mcp-performance/hermes_proxy.py'),str(a.assembly.resolve()),str(root/'hermes-wire-sanitized.jsonl')],
+'mcp_servers':{'perf':{'command':sys.executable,'args':[str(repo/'scripts/observations/mcp-performance/hermes_proxy.py'),str(a.assembly),str(root/'hermes-wire-sanitized.jsonl'),str(root)],
 'env':{k:v for k,v in environment(state,'caldav-perf-hermes',exact=False).items() if k.startswith(('CALDAV_','OTEL_'))},'timeout':60,'connect_timeout':60}}}
 (home/'config.yaml').write_text(yaml.safe_dump(config));(home/'config.yaml').chmod(0o600)
 secrets=dotenv_values(a.source_home/'.env')
@@ -31,6 +34,7 @@ model_metadata={key:config['model'][key] for key in ['provider','model','default
 with os.fdopen(os.open(root/'hermes-config-sanitized.json',os.O_WRONLY|os.O_CREAT|os.O_TRUNC,0o600),'w') as stream:
  os.fchmod(stream.fileno(),0o600)
  json.dump(dict(model=model_metadata,agent=config['agent'],hermes_home=str(home),mcp_command=config['mcp_servers']['perf']['command'],mcp_args=config['mcp_servers']['perf']['args']),stream,indent=2)
+(root/'hermes-build.json').write_text(json.dumps(build_input,indent=2))
 prompt='''Execute uma prova real de integração usando somente as ferramentas MCP perf disponíveis nesta sessão persistente. Todos os calendários são fixtures locais descartáveis e as mutações abaixo estão autorizadas. Faça em sequência: 1) calendars.list. 2) calendar_entities.query com scope all, entityKinds event e todo, janela UTC 2026-07-01T00:00:00Z até 2026-12-31T00:00:00Z e pageSize 1; Continue com o cursor obtido e pageSize 5 na mesma sessão. 3) calendar_occurrences.query com a mesma janela e pageSize 1, depois Continue pageSize 5. 4) todos.query com scope all, a mesma janela e pageSize 1; Continue pageSize 5. Os valores temporais usam kind utcDateTime. 5) todos.create no calendário padrão, entity kind todo, UID hermes-perf-20260905-integration, fields summary Hermes disposable integration. 6) calendar_resources.get no href criado. 7) todos.patch usando o entityRevision recém-lido, target scope master, patch scalars field summary operation set value Hermes patched integration. 8) Releia, execute todos.complete com a revisão fresca e releia para confirmar COMPLETED persistido. 9) Tente calendar_resources.delete usando a revisão fresca. Se houver uma confirmação MRTR que a integração não consiga continuar, registre a limitação e pare sem inventar campos ou repetir tentativas. Resuma apenas chamadas realmente executadas. Não use terminal, arquivos nem ferramentas fora deste MCP.'''
 (root/'hermes-prompt.txt').write_text(prompt)
 env={k:v for k,v in os.environ.items() if not k.startswith(('HERMES_','CALDAV_','OTEL_'))}

--- a/scripts/observations/mcp-performance/hermes.py
+++ b/scripts/observations/mcp-performance/hermes.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+import json,os,subprocess,sys
+from pathlib import Path
+import yaml
+from dotenv import dotenv_values
+import argparse, shutil
+p=argparse.ArgumentParser(description='Run installed Hermes against an isolated checkout MCP configuration (OpenRouter profile).')
+p.add_argument('root',type=Path);p.add_argument('assembly',type=Path)
+p.add_argument('--source-home',type=Path,default=Path.home()/'.hermes')
+a=p.parse_args()
+root=a.root.resolve(); state=json.loads((root/'infra-private.json').read_text())
+repo=Path(__file__).resolve().parents[3]
+sys.path.insert(0,str(repo/'scripts/observations/mcp-performance'))
+from driver import environment
+home=root/'hermes-isolated';home.mkdir(exist_ok=True);home.chmod(0o700)
+base=yaml.safe_load((a.source_home/'config.yaml').read_text())
+assert base['model'].get('provider')=='openrouter', 'This witness uses the already configured OpenRouter provider only'
+config={'model':base['model'],'agent':{'reasoning_effort':base.get('agent',{}).get('reasoning_effort','medium'),'max_turns':30},
+'mcp_servers':{'perf':{'command':sys.executable,'args':[str(repo/'scripts/observations/mcp-performance/hermes_proxy.py'),str(a.assembly.resolve()),str(root/'hermes-wire-sanitized.jsonl')],
+'env':{k:v for k,v in environment(state,'caldav-perf-hermes',exact=False).items() if k.startswith(('CALDAV_','OTEL_'))},'timeout':60,'connect_timeout':60}}}
+(home/'config.yaml').write_text(yaml.safe_dump(config));(home/'config.yaml').chmod(0o600)
+secrets=dotenv_values(a.source_home/'.env')
+key=os.environ.get('OPENROUTER_API_KEY') or secrets.get('OPENROUTER_API_KEY')
+assert key,'Configured OpenRouter credential unavailable'
+(home/'.env').write_text('OPENROUTER_API_KEY='+key+'\n');(home/'.env').chmod(0o600)
+(root/'hermes-config-sanitized.json').write_text(json.dumps(dict(model=config['model'],agent=config['agent'],hermes_home=str(home),mcp_command=config['mcp_servers']['perf']['command'],mcp_args=config['mcp_servers']['perf']['args']),indent=2))
+prompt='''Execute uma prova real de integração usando somente as ferramentas MCP perf disponíveis nesta sessão persistente. Todos os calendários são fixtures locais descartáveis e as mutações abaixo estão autorizadas. Faça em sequência: 1) calendars.list. 2) calendar_entities.query com scope all, entityKinds event e todo, janela UTC 2026-07-01T00:00:00Z até 2026-12-31T00:00:00Z e pageSize 1; Continue com o cursor obtido e pageSize 5 na mesma sessão. 3) calendar_occurrences.query com a mesma janela e pageSize 1, depois Continue pageSize 5. 4) todos.query com scope all, a mesma janela e pageSize 1; Continue pageSize 5. Os valores temporais usam kind utcDateTime. 5) todos.create no calendário padrão, entity kind todo, UID hermes-perf-20260905-integration, fields summary Hermes disposable integration. 6) calendar_resources.get no href criado. 7) todos.patch usando o entityRevision recém-lido, target scope master, patch scalars field summary operation set value Hermes patched integration. 8) Releia, execute todos.complete com a revisão fresca e releia para confirmar COMPLETED persistido. 9) Tente calendar_resources.delete usando a revisão fresca. Se houver uma confirmação MRTR que a integração não consiga continuar, registre a limitação e pare sem inventar campos ou repetir tentativas. Resuma apenas chamadas realmente executadas. Não use terminal, arquivos nem ferramentas fora deste MCP.'''
+(root/'hermes-prompt.txt').write_text(prompt)
+env={k:v for k,v in os.environ.items() if not k.startswith(('HERMES_','CALDAV_','OTEL_'))}
+env['HERMES_HOME']=str(home)
+with (root/'hermes-run-private.log').open('w') as log:
+ result=subprocess.run([shutil.which('hermes'),'--ignore-rules','-t','perf','--usage-file',str(root/'hermes-usage.json'),'-z',prompt],cwd=home,env=env,stdout=log,stderr=log,timeout=600)
+print(json.dumps({'exit_code':result.returncode,'wire_evidence_exists':(root/'hermes-wire-sanitized.jsonl').exists()}))

--- a/scripts/observations/mcp-performance/hermes.py
+++ b/scripts/observations/mcp-performance/hermes.py
@@ -31,3 +31,4 @@ env['HERMES_HOME']=str(home)
 with (root/'hermes-run-private.log').open('w') as log:
  result=subprocess.run([shutil.which('hermes'),'--ignore-rules','-t','perf','--usage-file',str(root/'hermes-usage.json'),'-z',prompt],cwd=home,env=env,stdout=log,stderr=log,timeout=600)
 print(json.dumps({'exit_code':result.returncode,'wire_evidence_exists':(root/'hermes-wire-sanitized.jsonl').exists()}))
+sys.exit(result.returncode)

--- a/scripts/observations/mcp-performance/hermes_proxy.py
+++ b/scripts/observations/mcp-performance/hermes_proxy.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 """Transparent stdio witness for Hermes; never changes MCP bytes or confirmations."""
-import hashlib
 import json
 import os
 from pathlib import Path
@@ -11,9 +10,13 @@ import sys
 import threading
 import time
 from functional import sanitize
+from build_manifest import prepared_input
 
 assembly=Path(sys.argv[1]).resolve()
 evidence=Path(sys.argv[2])
+if evidence.exists():
+    raise FileExistsError('Hermes wire evidence already exists')
+build_input=prepared_input(Path(sys.argv[3]),assembly)
 evidence.touch(exist_ok=False)
 child=subprocess.Popen([str(Path(shutil.which('dotnet')).resolve()),str(assembly)],
                        stdin=subprocess.PIPE,stdout=subprocess.PIPE,stderr=subprocess.PIPE)
@@ -26,8 +29,8 @@ def record(value):
         out.write(json.dumps(dict(timestamp_ns=time.time_ns(),pid=child.pid,**value))+'\n')
 
 
-record(dict(event='launch',assembly=str(assembly),sha256=hashlib.sha256(assembly.read_bytes()).hexdigest(),
-            core_sha256=hashlib.sha256(assembly.with_name('DotnetAgents.CalDav.Core.dll').read_bytes()).hexdigest()))
+record(dict(event='launch',**build_input,sha256=build_input['assembly_sha256']['DotnetAgents.CalDav.Mcp.dll'],
+            core_sha256=build_input['assembly_sha256']['DotnetAgents.CalDav.Core.dll']))
 
 
 def incoming():

--- a/scripts/observations/mcp-performance/hermes_proxy.py
+++ b/scripts/observations/mcp-performance/hermes_proxy.py
@@ -59,7 +59,8 @@ def terminate(*_):
 
 signal.signal(signal.SIGTERM,terminate)
 threading.Thread(target=incoming,daemon=True).start()
-threading.Thread(target=errors,daemon=True).start()
+error_thread=threading.Thread(target=errors,daemon=True)
+error_thread.start()
 for line in child.stdout:
     value=json.loads(line)
     request=pending.pop(value.get('id'),None)
@@ -73,4 +74,6 @@ for line in child.stdout:
                     assembly_mapped=str(assembly) in Path(f'/proc/{child.pid}/maps').read_text()))
     sys.stdout.buffer.write(line);sys.stdout.buffer.flush()
 child.wait()
+error_thread.join()
 record(dict(event='exit',code=child.returncode))
+sys.exit(child.returncode)

--- a/scripts/observations/mcp-performance/hermes_proxy.py
+++ b/scripts/observations/mcp-performance/hermes_proxy.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Transparent stdio witness for Hermes; never changes MCP bytes or confirmations."""
+import hashlib
+import json
+import os
+from pathlib import Path
+import shutil
+import signal
+import subprocess
+import sys
+import threading
+import time
+from functional import sanitize
+
+assembly=Path(sys.argv[1]).resolve()
+evidence=Path(sys.argv[2])
+child=subprocess.Popen([str(Path(shutil.which('dotnet')).resolve()),str(assembly)],
+                       stdin=subprocess.PIPE,stdout=subprocess.PIPE,stderr=subprocess.PIPE)
+pending={}
+lock=threading.Lock()
+
+
+def record(value):
+    with lock, evidence.open('a') as out:
+        out.write(json.dumps(dict(timestamp_ns=time.time_ns(),pid=child.pid,**value))+'\n')
+
+
+record(dict(event='launch',assembly=str(assembly),sha256=hashlib.sha256(assembly.read_bytes()).hexdigest(),
+            core_sha256=hashlib.sha256(assembly.with_name('DotnetAgents.CalDav.Core.dll').read_bytes()).hexdigest()))
+
+
+def incoming():
+    for line in sys.stdin.buffer:
+        value=json.loads(line)
+        if 'id' in value:
+            params=value.get('params',{})
+            pending[value['id']]=dict(method=value.get('method'),tool=params.get('name'),started=time.time_ns(),
+                                      continuing='requestState' in params,
+                                      protocol=params.get('_meta',{}).get('io.modelcontextprotocol/protocolVersion'),
+                                      cursor_call='cursor' in params.get('arguments',{}))
+            if value.get('method')=='initialize':
+                record(dict(event='initialize_request',protocol=params.get('protocolVersion'),
+                            capabilities=params.get('capabilities')))
+        child.stdin.write(line);child.stdin.flush()
+    child.stdin.close()
+
+
+def errors():
+    data=child.stderr.read()
+    record(dict(event='stderr',bytes=len(data)))
+    if data:
+        sys.stderr.buffer.write(data);sys.stderr.buffer.flush()
+
+
+def terminate(*_):
+    child.terminate()
+
+
+signal.signal(signal.SIGTERM,terminate)
+threading.Thread(target=incoming,daemon=True).start()
+threading.Thread(target=errors,daemon=True).start()
+for line in child.stdout:
+    value=json.loads(line)
+    request=pending.pop(value.get('id'),None)
+    if request:
+        started=request.pop('started')
+        result=value.get('result',{})
+        record(dict(event='response',**request,elapsed_ms=(time.time_ns()-started)/1e6,
+                    structured=sanitize(result),rpc_error='error' in value,
+                    catalog_names=[tool['name'] for tool in result.get('tools',[])],
+                    command=Path(f'/proc/{child.pid}/cmdline').read_bytes().decode().split('\0')[:-1],
+                    assembly_mapped=str(assembly) in Path(f'/proc/{child.pid}/maps').read_text()))
+    sys.stdout.buffer.write(line);sys.stdout.buffer.flush()
+child.wait()
+record(dict(event='exit',code=child.returncode))

--- a/scripts/observations/mcp-performance/hermes_proxy.py
+++ b/scripts/observations/mcp-performance/hermes_proxy.py
@@ -14,6 +14,7 @@ from functional import sanitize
 
 assembly=Path(sys.argv[1]).resolve()
 evidence=Path(sys.argv[2])
+evidence.touch(exist_ok=False)
 child=subprocess.Popen([str(Path(shutil.which('dotnet')).resolve()),str(assembly)],
                        stdin=subprocess.PIPE,stdout=subprocess.PIPE,stderr=subprocess.PIPE)
 pending={}

--- a/scripts/observations/mcp-performance/infra.py
+++ b/scripts/observations/mcp-performance/infra.py
@@ -149,6 +149,8 @@ def resource(kind, index):
 
 
 def seed(root, count):
+    if count<0:
+        raise ValueError('Seed count cannot be negative')
     state = json.loads((root / 'infra-private.json').read_text())
     principal = '/' + state['username'] + '/'
     assert request(state, 'MKCOL', principal)[0] in (201, 405)
@@ -203,6 +205,14 @@ def verify(state):
             raise RuntimeError(f'Seed corpus content or membership changed in {name}')
         result[name]=len(observed)
     return result
+
+
+def expected_counts(root):
+    counts=json.loads((root/'corpus.json').read_text())['resources']
+    if (set(counts)!={'events','todos','archive'}
+            or any(type(value) is not int or value<0 for value in counts.values())):
+        raise RuntimeError('Invalid seeded corpus counts')
+    return counts
 
 
 def down(root):

--- a/scripts/observations/mcp-performance/infra.py
+++ b/scripts/observations/mcp-performance/infra.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+"""Owned, disposable Radicale/Aspire infrastructure; no production configuration."""
+import argparse
+import base64
+import datetime as dt
+import hashlib
+import json
+import os
+from pathlib import Path
+import secrets
+import subprocess
+import time
+import urllib.error
+import urllib.request
+import xml.etree.ElementTree as ET
+
+RADICALE = 'ghcr.io/kozea/radicale@sha256:3a0080ea51ac69dcd74e345b9587dc14a8c8af0652046069005749f9a75c5c80'
+DASHBOARD = 'mcr.microsoft.com/dotnet/aspire-dashboard:13.4.2@sha256:76d05882595dd43e708d6ef3e269d98ca763694c0c822bbe98edc99790eaad1b'
+
+
+def docker(*args):
+    return subprocess.check_output(['docker', *args], text=True).strip()
+
+
+def request(state, method, path, body=None, headers=None):
+    auth = base64.b64encode(f"{state['username']}:{state['password']}".encode()).decode()
+    h = {'Authorization': 'Basic ' + auth, 'Content-Type': 'application/xml', **(headers or {})}
+    req = urllib.request.Request(state['url'] + path, data=body.encode() if isinstance(body, str) else body,
+                                 headers=h, method=method)
+    try:
+        with urllib.request.urlopen(req, timeout=60) as response:
+            return response.status, response.read(), dict(response.headers)
+    except urllib.error.HTTPError as error:
+        return error.code, error.read(), dict(error.headers)
+
+
+def up(root):
+    root.mkdir(parents=True, exist_ok=True)
+    path = root / 'infra-private.json'
+    if path.exists():
+        raise RuntimeError('Infrastructure manifest already exists; use its owned resources or clean first.')
+    run = 'caldav-perf-' + secrets.token_hex(4)
+    state = dict(run=run, username='perftest', password=secrets.token_hex(16),
+                 api_key=secrets.token_hex(24), containers=[])
+    def save():
+        path.write_text(json.dumps(state, indent=2))
+        path.chmod(0o600)
+    save()
+    config = root / 'radicale-config'
+    config.mkdir()
+    (config / 'config').write_text('''[server]
+hosts = 0.0.0.0:5232
+[auth]
+type = htpasswd
+htpasswd_filename = /config/users
+htpasswd_encryption = plain
+[rights]
+type = owner_write
+[storage]
+filesystem_folder = /var/lib/radicale/collections
+[web]
+type = internal
+[logging]
+level = warning
+''')
+    (config / 'users').write_text(state['username'] + ':' + state['password'])
+    for suffix, image, ports, extra in [
+        ('radicale', RADICALE, ['127.0.0.1::5232'], ['--env', 'TZ=UTC', '--mount',
+         f'type=bind,source={config},target=/config,readonly']),
+        ('dashboard', DASHBOARD, ['127.0.0.1::18888', '127.0.0.1::18890'], ['--env',
+         'DASHBOARD__API__PRIMARYAPIKEY=' + state['api_key'], '--env',
+         'DASHBOARD__TELEMETRYLIMITS__MAXTRACECOUNT=50000', '--env',
+         'DASHBOARD__TELEMETRYLIMITS__MAXLOGCOUNT=100000'])]:
+        name = run + '-' + suffix
+        args = ['run', '-d', '--name', name, '--label', 'caldav.performance.owner=' + run,
+                '--cpus', '4', '--memory', '2g']
+        for port in ports:
+            args += ['-p', port]
+        args += extra + [image]
+        if suffix == 'radicale':
+            args += ['--config', '/config/config', '--hosts', '0.0.0.0:5232,[::]:5232']
+        state['containers'].append(name)
+        save()
+        docker(*args)
+    def endpoint(suffix, port):
+        return 'http://' + docker('port', run + '-' + suffix, str(port) + '/tcp')
+    state.update(url=endpoint('radicale', 5232), dashboard=endpoint('dashboard', 18888),
+                 otlp=endpoint('dashboard', 18890))
+    save()
+    for _ in range(60):
+        try:
+            if request(state, 'OPTIONS', '/')[0] == 200:
+                break
+        except OSError:
+            pass
+        time.sleep(0.5)
+    else:
+        raise RuntimeError('Radicale readiness timed out')
+    print(json.dumps({k: state[k] for k in ['run', 'url', 'dashboard', 'otlp', 'containers']}))
+
+
+def resource(kind, index):
+    date = dt.datetime(2026, 7, 1, 12, tzinfo=dt.timezone.utc) + dt.timedelta(days=index % 180)
+    stamp = lambda x: x.strftime('%Y%m%dT%H%M%SZ')
+    lines = ['BEGIN:VCALENDAR', 'VERSION:2.0', 'PRODID:-//CalDAV performance seed 20260905//EN',
+             'BEGIN:' + kind, f'UID:perf-20260905-{kind.lower()}-{index:04d}',
+             'DTSTAMP:20260701T000000Z', f'SUMMARY:Performance {kind} {index:04d}',
+             'CATEGORIES:PERFORMANCE,DISPOSABLE']
+    if kind == 'VEVENT':
+        if index % 20 == 1:
+            lines += ['DTSTART;VALUE=DATE:' + date.strftime('%Y%m%d'),
+                      'DTEND;VALUE=DATE:' + (date + dt.timedelta(days=1)).strftime('%Y%m%d')]
+        else:
+            lines += ['DTSTART:' + stamp(date), 'DTEND:' + stamp(date + dt.timedelta(hours=1))]
+        lines += ['LOCATION:Local fixture']
+        if index % 50 == 2:
+            lines += ['STATUS:CANCELLED']
+    else:
+        lines += ['DTSTART:' + stamp(date), 'DUE:' + stamp(date + dt.timedelta(hours=2)),
+                  'PRIORITY:' + str(index % 9 + 1)]
+        if index % 20 < 6:
+            lines += ['STATUS:COMPLETED', 'PERCENT-COMPLETE:100', 'COMPLETED:' + stamp(date)]
+        elif index % 20 == 6:
+            lines += ['STATUS:CANCELLED']
+        else:
+            lines += ['STATUS:NEEDS-ACTION']
+    if index % 10 == 0:
+        lines += ['RRULE:FREQ=WEEKLY;COUNT=' + ('20' if kind == 'VEVENT' else '12')]
+    return '\r\n'.join(lines + ['END:' + kind, 'END:VCALENDAR', ''])
+
+
+def seed(root, count):
+    state = json.loads((root / 'infra-private.json').read_text())
+    principal = '/' + state['username'] + '/'
+    assert request(state, 'MKCOL', principal)[0] in (201, 405)
+    digest = hashlib.sha256()
+    for name, kind, n in [('events', 'VEVENT', count), ('todos', 'VTODO', count), ('archive', 'VTODO', 0)]:
+        path = principal + name + '/'
+        body = f'''<D:mkcol xmlns:D="DAV:" xmlns:C="urn:ietf:params:xml:ns:caldav"><D:set><D:prop>
+<D:resourcetype><D:collection/><C:calendar/></D:resourcetype><D:displayname>Performance {name}</D:displayname>
+<C:supported-calendar-component-set><C:comp name="{kind}"/></C:supported-calendar-component-set>
+</D:prop></D:set></D:mkcol>'''
+        assert request(state, 'MKCOL', path, body)[0] == 201
+        for i in range(n):
+            data = resource(kind, i)
+            digest.update(data.encode())
+            assert request(state, 'PUT', path + f'{i:04d}.ics', data,
+                           {'Content-Type': 'text/calendar', 'If-None-Match': '*'})[0] == 201
+        print(f'Seeded {name}: {n}', flush=True)
+    counts = verify(state)
+    assert counts == {'events': count, 'todos': count, 'archive': 0}, counts
+    (root / 'corpus.json').write_text(json.dumps(dict(seed=20260905, resources=counts,
+         authored_sha256=digest.hexdigest(), window=['2026-07-01T00:00:00Z','2026-12-31T00:00:00Z'],
+         timezone='America/Sao_Paulo'), indent=2))
+
+
+def verify(state):
+    result = {}
+    for name in ['events', 'todos', 'archive']:
+        body = '<D:propfind xmlns:D="DAV:"><D:prop><D:getetag/></D:prop></D:propfind>'
+        status, data, _ = request(state, 'PROPFIND', f"/{state['username']}/{name}/", body, {'Depth':'1'})
+        assert status == 207
+        result[name] = sum(1 for x in ET.fromstring(data).findall('{DAV:}response')
+                           if x.findtext('{DAV:}href', '').endswith('.ics'))
+    return result
+
+
+def down(root):
+    path = root / 'infra-private.json'
+    state = json.loads(path.read_text())
+    for name in reversed(state['containers']):
+        if not docker('ps', '-aq', '--filter', 'name=^/' + name + '$'):
+            continue
+        owner = docker('inspect', '--format', '{{index .Config.Labels "caldav.performance.owner"}}', name)
+        assert owner == state['run']
+        docker('rm', '-fv', name)
+    path.unlink()
+    import shutil
+    shutil.rmtree(root / 'radicale-config')
+    (root / 'cleanup.json').write_text(json.dumps(dict(containers_removed=state['containers'], complete=True)))
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('action', choices=['up', 'seed', 'verify', 'down'])
+    parser.add_argument('root', type=Path)
+    parser.add_argument('--count', type=int, default=600)
+    args = parser.parse_args()
+    if args.action == 'seed':
+        seed(args.root, args.count)
+    elif args.action == 'verify':
+        print(json.dumps(verify(json.loads((args.root / 'infra-private.json').read_text()))))
+    else:
+        globals()[args.action](args.root)

--- a/scripts/observations/mcp-performance/infra.py
+++ b/scripts/observations/mcp-performance/infra.py
@@ -153,7 +153,8 @@ def seed(root, count):
         raise ValueError('Seed count cannot be negative')
     state = json.loads((root / 'infra-private.json').read_text())
     principal = '/' + state['username'] + '/'
-    assert request(state, 'MKCOL', principal)[0] in (201, 405)
+    if not (request(state, 'MKCOL', principal)[0] in (201, 405)):
+        raise RuntimeError('Seed principal creation failed')
     digest = hashlib.sha256()
     expected={}
     for name, kind, n in [('events', 'VEVENT', count), ('todos', 'VTODO', count), ('archive', 'VTODO', 0)]:
@@ -162,7 +163,8 @@ def seed(root, count):
 <D:resourcetype><D:collection/><C:calendar/></D:resourcetype><D:displayname>Performance {name}</D:displayname>
 <C:supported-calendar-component-set><C:comp name="{kind}"/></C:supported-calendar-component-set>
 </D:prop></D:set></D:mkcol>'''
-        assert request(state, 'MKCOL', path, body)[0] == 201
+        if not (request(state, 'MKCOL', path, body)[0] == 201):
+            raise RuntimeError('Seed calendar creation failed')
         expected[name]={}
         for i in range(n):
             data = resource(kind, i)
@@ -170,7 +172,8 @@ def seed(root, count):
             href=path+f'{i:04d}.ics'
             status,_,headers=request(state,'PUT',href,data,
                                      {'Content-Type':'text/calendar','If-None-Match':'*'})
-            assert status==201
+            if not (status==201):
+                raise RuntimeError('Seed resource creation failed')
             etag={key.lower():value for key,value in headers.items()}.get('etag')
             if not etag or etag.startswith('W/'):
                 raise RuntimeError('Seed PUT did not return a strong ETag')
@@ -179,7 +182,8 @@ def seed(root, count):
     state['corpus_etags']=expected
     save_private_state(root/'infra-private.json',state)
     counts = verify(state)
-    assert counts == {'events': count, 'todos': count, 'archive': 0}, counts
+    if not (counts == {'events': count, 'todos': count, 'archive': 0}):
+        raise RuntimeError('Seed counts differ')
     (root / 'corpus.json').write_text(json.dumps(dict(seed=20260905, resources=counts,
          authored_sha256=digest.hexdigest(), window=['2026-07-01T00:00:00Z','2026-12-31T00:00:00Z'],
          timezone='America/Sao_Paulo'), indent=2))
@@ -192,7 +196,8 @@ def verify(state):
     for name in ['events', 'todos', 'archive']:
         body = '<D:propfind xmlns:D="DAV:"><D:prop><D:getetag/></D:prop></D:propfind>'
         status, data, _ = request(state, 'PROPFIND', f"/{state['username']}/{name}/", body, {'Depth':'1'})
-        assert status == 207
+        if not (status == 207):
+            raise RuntimeError('Corpus listing failed')
         observed={}
         for response in ET.fromstring(data).findall('{DAV:}response'):
             href=urllib.parse.unquote(urllib.parse.urlsplit(response.findtext('{DAV:}href','')).path)
@@ -225,7 +230,8 @@ def down(root):
         if not docker('ps', '-aq', '--filter', 'name=^/' + name + '$'):
             continue
         owner = docker('inspect', '--format', '{{index .Config.Labels "caldav.performance.owner"}}', name)
-        assert owner == state['run']
+        if not (owner == state['run']):
+            raise RuntimeError('Container ownership differs')
         docker('rm', '-fv', name)
     path.unlink()
     import shutil

--- a/scripts/observations/mcp-performance/infra.py
+++ b/scripts/observations/mcp-performance/infra.py
@@ -12,6 +12,7 @@ import subprocess
 import time
 import urllib.error
 import urllib.request
+import urllib.parse
 import xml.etree.ElementTree as ET
 
 RADICALE = 'ghcr.io/kozea/radicale@sha256:3a0080ea51ac69dcd74e345b9587dc14a8c8af0652046069005749f9a75c5c80'
@@ -34,20 +35,21 @@ def request(state, method, path, body=None, headers=None):
         return error.code, error.read(), dict(error.headers)
 
 
-def up(root):
-    root.mkdir(parents=True, exist_ok=True)
-    path = root / 'infra-private.json'
-    if path.exists():
-        raise RuntimeError('Infrastructure manifest already exists; use its owned resources or clean first.')
-    run = 'caldav-perf-' + secrets.token_hex(4)
-    state = dict(run=run, username='perftest', password=secrets.token_hex(16),
-                 api_key=secrets.token_hex(24), containers=[])
-    def save():
-        path.write_text(json.dumps(state, indent=2))
-        path.chmod(0o600)
-    save()
-    config = root / 'radicale-config'
+def save_private_state(path,state):
+    descriptor=os.open(path,os.O_WRONLY | os.O_CREAT | os.O_TRUNC,0o600)
+    with os.fdopen(descriptor,'w') as stream:
+        os.fchmod(stream.fileno(),0o600)
+        json.dump(state,stream,indent=2)
+
+
+def radicale_config(root,state):
+    # The pinned image runs as its own non-root user. Protect the host parent,
+    # while allowing that user to read the inner directory mounted at /config.
+    private=root/'radicale-private'
+    private.mkdir(mode=0o700)
+    config=private/'config'
     config.mkdir()
+    config.chmod(0o755)
     (config / 'config').write_text('''[server]
 hosts = 0.0.0.0:5232
 [auth]
@@ -64,6 +66,23 @@ type = internal
 level = warning
 ''')
     (config / 'users').write_text(state['username'] + ':' + state['password'])
+    for name in ['config','users']:
+        (config/name).chmod(0o644)
+    return config
+
+
+def up(root):
+    root.mkdir(parents=True, exist_ok=True)
+    path = root / 'infra-private.json'
+    if path.exists():
+        raise RuntimeError('Infrastructure manifest already exists; use its owned resources or clean first.')
+    run = 'caldav-perf-' + secrets.token_hex(4)
+    state = dict(run=run, username='perftest', password=secrets.token_hex(16),
+                 api_key=secrets.token_hex(24), containers=[],config_directory='radicale-private')
+    def save():
+        save_private_state(path,state)
+    save()
+    config=radicale_config(root,state)
     for suffix, image, ports, extra in [
         ('radicale', RADICALE, ['127.0.0.1::5232'], ['--env', 'TZ=UTC', '--mount',
          f'type=bind,source={config},target=/config,readonly']),
@@ -134,6 +153,7 @@ def seed(root, count):
     principal = '/' + state['username'] + '/'
     assert request(state, 'MKCOL', principal)[0] in (201, 405)
     digest = hashlib.sha256()
+    expected={}
     for name, kind, n in [('events', 'VEVENT', count), ('todos', 'VTODO', count), ('archive', 'VTODO', 0)]:
         path = principal + name + '/'
         body = f'''<D:mkcol xmlns:D="DAV:" xmlns:C="urn:ietf:params:xml:ns:caldav"><D:set><D:prop>
@@ -141,12 +161,21 @@ def seed(root, count):
 <C:supported-calendar-component-set><C:comp name="{kind}"/></C:supported-calendar-component-set>
 </D:prop></D:set></D:mkcol>'''
         assert request(state, 'MKCOL', path, body)[0] == 201
+        expected[name]={}
         for i in range(n):
             data = resource(kind, i)
             digest.update(data.encode())
-            assert request(state, 'PUT', path + f'{i:04d}.ics', data,
-                           {'Content-Type': 'text/calendar', 'If-None-Match': '*'})[0] == 201
+            href=path+f'{i:04d}.ics'
+            status,_,headers=request(state,'PUT',href,data,
+                                     {'Content-Type':'text/calendar','If-None-Match':'*'})
+            assert status==201
+            etag={key.lower():value for key,value in headers.items()}.get('etag')
+            if not etag or etag.startswith('W/'):
+                raise RuntimeError('Seed PUT did not return a strong ETag')
+            expected[name][href]=etag
         print(f'Seeded {name}: {n}', flush=True)
+    state['corpus_etags']=expected
+    save_private_state(root/'infra-private.json',state)
     counts = verify(state)
     assert counts == {'events': count, 'todos': count, 'archive': 0}, counts
     (root / 'corpus.json').write_text(json.dumps(dict(seed=20260905, resources=counts,
@@ -155,19 +184,33 @@ def seed(root, count):
 
 
 def verify(state):
+    if 'corpus_etags' not in state:
+        raise RuntimeError('Seed ETag manifest is missing; prepare a fresh seeded run')
     result = {}
     for name in ['events', 'todos', 'archive']:
         body = '<D:propfind xmlns:D="DAV:"><D:prop><D:getetag/></D:prop></D:propfind>'
         status, data, _ = request(state, 'PROPFIND', f"/{state['username']}/{name}/", body, {'Depth':'1'})
         assert status == 207
-        result[name] = sum(1 for x in ET.fromstring(data).findall('{DAV:}response')
-                           if x.findtext('{DAV:}href', '').endswith('.ics'))
+        observed={}
+        for response in ET.fromstring(data).findall('{DAV:}response'):
+            href=urllib.parse.unquote(urllib.parse.urlsplit(response.findtext('{DAV:}href','')).path)
+            if href.endswith('/'):
+                continue
+            if not href or href in observed:
+                raise RuntimeError('Invalid or duplicate href in corpus verification')
+            observed[href]=response.findtext('.//{DAV:}getetag')
+        if observed!=state['corpus_etags'][name]:
+            raise RuntimeError(f'Seed corpus content or membership changed in {name}')
+        result[name]=len(observed)
     return result
 
 
 def down(root):
     path = root / 'infra-private.json'
     state = json.loads(path.read_text())
+    config_directory=state.get('config_directory','radicale-config')
+    if config_directory not in ['radicale-private','radicale-config']:
+        raise RuntimeError('Unknown owned configuration directory')
     for name in reversed(state['containers']):
         if not docker('ps', '-aq', '--filter', 'name=^/' + name + '$'):
             continue
@@ -176,7 +219,8 @@ def down(root):
         docker('rm', '-fv', name)
     path.unlink()
     import shutil
-    shutil.rmtree(root / 'radicale-config')
+    if (root/config_directory).exists():
+        shutil.rmtree(root/config_directory)
     (root / 'cleanup.json').write_text(json.dumps(dict(containers_removed=state['containers'], complete=True)))
 
 

--- a/scripts/observations/mcp-performance/package.sh
+++ b/scripts/observations/mcp-performance/package.sh
@@ -3,15 +3,20 @@ set -euo pipefail
 [[ $# == 1 ]] || { echo 'Usage: package.sh <external-run-directory>' >&2; exit 64; }
 results_directory=$(realpath -- "$1")
 repository_root=$(git rev-parse --show-toplevel)
+case "$results_directory/" in "$repository_root/"*) echo 'Use an external directory' >&2; exit 65;; esac
 package_checkout="$results_directory/package-checkout"
 package_version=0.0.0-perf.20260905
-git diff HEAD --binary -- src > "$results_directory/package-source.patch"
+git diff HEAD --binary > "$results_directory/package-source.patch"
 git clone --shared --no-checkout -- "$repository_root" "$package_checkout"
 git -C "$package_checkout" checkout --detach "$(git rev-parse HEAD)"
 git -C "$package_checkout" remote set-url origin "$(git -C "$repository_root" remote get-url origin)"
 if [[ -s "$results_directory/package-source.patch" ]]; then
   git -C "$package_checkout" apply "$results_directory/package-source.patch"
 fi
+while IFS= read -r -d '' added_path; do
+  mkdir -p -- "$package_checkout/$(dirname -- "$added_path")"
+  cp -a -- "$repository_root/$added_path" "$package_checkout/$added_path"
+done < <(git ls-files --others --exclude-standard -z)
 cd -- "$package_checkout"
 metadata_path="$results_directory/package-metadata/server.json"
 bash scripts/prepare-release-metadata.sh "v$package_version" "$metadata_path"

--- a/scripts/observations/mcp-performance/package.sh
+++ b/scripts/observations/mcp-performance/package.sh
@@ -3,7 +3,9 @@ set -euo pipefail
 [[ $# == 1 ]] || { echo 'Usage: package.sh <external-run-directory>' >&2; exit 64; }
 results_directory=$(realpath -- "$1")
 repository_root=$(git rev-parse --show-toplevel)
+manifest_tool="$(dirname -- "$(realpath -- "$0")")/build_manifest.py"
 case "$results_directory/" in "$repository_root/"*) echo 'Use an external directory' >&2; exit 65;; esac
+python3 "$manifest_tool" verify-source "$repository_root" "$results_directory/candidate-build.json"
 package_checkout="$results_directory/package-checkout"
 package_version=0.0.0-perf.20260905
 git diff HEAD --binary > "$results_directory/package-source.patch"
@@ -17,6 +19,7 @@ while IFS= read -r -d '' added_path; do
   mkdir -p -- "$package_checkout/$(dirname -- "$added_path")"
   cp -a -- "$repository_root/$added_path" "$package_checkout/$added_path"
 done < <(git ls-files --others --exclude-standard -z)
+python3 "$manifest_tool" verify-source "$package_checkout" "$results_directory/candidate-build.json"
 cd -- "$package_checkout"
 metadata_path="$results_directory/package-metadata/server.json"
 bash scripts/prepare-release-metadata.sh "v$package_version" "$metadata_path"
@@ -27,3 +30,4 @@ dotnet pack src/DotnetAgents.CalDav.Mcp/DotnetAgents.CalDav.Mcp.csproj -c Releas
   "/p:Version=$package_version" "/p:McpServerMetadataPath=$metadata_path" \
   --include-symbols -p:SymbolPackageFormat=snupkg -o "$results_directory/packages"
 bash scripts/verify-release-package.sh "$package_version" "$results_directory/packages"
+python3 "$manifest_tool" verify-source "$package_checkout" "$results_directory/candidate-build.json"

--- a/scripts/observations/mcp-performance/package.sh
+++ b/scripts/observations/mcp-performance/package.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+[[ $# == 1 ]] || { echo 'Usage: package.sh <external-run-directory>' >&2; exit 64; }
+results_directory=$(realpath -- "$1")
+repository_root=$(git rev-parse --show-toplevel)
+package_checkout="$results_directory/package-checkout"
+package_version=0.0.0-perf.20260905
+git diff HEAD --binary -- src > "$results_directory/package-source.patch"
+git clone --shared --no-checkout -- "$repository_root" "$package_checkout"
+git -C "$package_checkout" checkout --detach "$(git rev-parse HEAD)"
+git -C "$package_checkout" remote set-url origin "$(git -C "$repository_root" remote get-url origin)"
+if [[ -s "$results_directory/package-source.patch" ]]; then
+  git -C "$package_checkout" apply "$results_directory/package-source.patch"
+fi
+cd -- "$package_checkout"
+metadata_path="$results_directory/package-metadata/server.json"
+bash scripts/prepare-release-metadata.sh "v$package_version" "$metadata_path"
+dotnet tool restore
+dotnet restore
+dotnet build -c Release --no-restore "/p:Version=$package_version" "/p:McpServerMetadataPath=$metadata_path"
+dotnet pack src/DotnetAgents.CalDav.Mcp/DotnetAgents.CalDav.Mcp.csproj -c Release --no-build --no-restore \
+  "/p:Version=$package_version" "/p:McpServerMetadataPath=$metadata_path" \
+  --include-symbols -p:SymbolPackageFormat=snupkg -o "$results_directory/packages"
+bash scripts/verify-release-package.sh "$package_version" "$results_directory/packages"

--- a/scripts/observations/mcp-performance/prepare.sh
+++ b/scripts/observations/mcp-performance/prepare.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 results_directory=$(realpath -m -- "$1")
 baseline_revision=$2
 repository_root=$(git rev-parse --show-toplevel)
+manifest_script="$repository_root/scripts/observations/mcp-performance/build_manifest.py"
 case "$results_directory/" in "$repository_root/"*) echo 'Use an external directory' >&2; exit 65;; esac
 mkdir -- "$results_directory"
 git status --porcelain=v1 > "$results_directory/initial-git-status.txt"
@@ -16,16 +17,20 @@ aspire --version > "$results_directory/aspire-version.txt" 2>&1
 git clone --shared --no-checkout -- "$repository_root" "$results_directory/baseline-checkout"
 git -C "$results_directory/baseline-checkout" checkout --detach "$baseline_revision"
 git -C "$results_directory/baseline-checkout" remote set-url origin "$(git -C "$repository_root" remote get-url origin)"
+python3 "$manifest_script" capture "$results_directory/baseline-checkout" "$results_directory/baseline-build.json"
 (
   cd -- "$results_directory/baseline-checkout"
   dotnet tool restore
   dotnet restore
   dotnet build -c Release --no-restore
 ) > "$results_directory/baseline-build.log" 2>&1
+python3 "$manifest_script" capture "$repository_root" "$results_directory/candidate-build.json"
 dotnet tool restore > "$results_directory/candidate-build.log" 2>&1
 dotnet restore >> "$results_directory/candidate-build.log" 2>&1
 dotnet build -c Release --no-restore >> "$results_directory/candidate-build.log" 2>&1
 mkdir -- "$results_directory/baseline" "$results_directory/candidate"
 cp -a -- "$results_directory/baseline-checkout/src/DotnetAgents.CalDav.Mcp/bin/Release/net10.0/." "$results_directory/baseline/"
 cp -a -- "$repository_root/src/DotnetAgents.CalDav.Mcp/bin/Release/net10.0/." "$results_directory/candidate/"
+python3 "$manifest_script" finalize "$results_directory/baseline-checkout" "$results_directory/baseline-build.json" "$results_directory/baseline"
+python3 "$manifest_script" finalize "$repository_root" "$results_directory/candidate-build.json" "$results_directory/candidate"
 sha256sum "$results_directory/"{baseline,candidate}/DotnetAgents.CalDav.{Core,Mcp}.dll > "$results_directory/assembly-hashes.txt"

--- a/scripts/observations/mcp-performance/prepare.sh
+++ b/scripts/observations/mcp-performance/prepare.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+[[ $# == 2 ]] || { echo 'Usage: prepare.sh <new-external-directory> <baseline-sha>' >&2; exit 64; }
+results_directory=$(realpath -m -- "$1")
+baseline_revision=$2
+repository_root=$(git rev-parse --show-toplevel)
+case "$results_directory/" in "$repository_root/"*) echo 'Use an external directory' >&2; exit 65;; esac
+mkdir -- "$results_directory"
+git status --porcelain=v1 > "$results_directory/initial-git-status.txt"
+git rev-parse HEAD > "$results_directory/initial-sha.txt"
+dotnet --info > "$results_directory/dotnet-info.txt"
+lscpu > "$results_directory/cpu.txt"
+free -b > "$results_directory/memory.txt"
+hermes --version > "$results_directory/hermes-version.txt"
+aspire --version > "$results_directory/aspire-version.txt" 2>&1
+git clone --shared --no-checkout -- "$repository_root" "$results_directory/baseline-checkout"
+git -C "$results_directory/baseline-checkout" checkout --detach "$baseline_revision"
+git -C "$results_directory/baseline-checkout" remote set-url origin "$(git -C "$repository_root" remote get-url origin)"
+(
+  cd -- "$results_directory/baseline-checkout"
+  dotnet tool restore
+  dotnet restore
+  dotnet build -c Release --no-restore
+) > "$results_directory/baseline-build.log" 2>&1
+dotnet tool restore > "$results_directory/candidate-build.log" 2>&1
+dotnet restore >> "$results_directory/candidate-build.log" 2>&1
+dotnet build -c Release --no-restore >> "$results_directory/candidate-build.log" 2>&1
+mkdir -- "$results_directory/baseline" "$results_directory/candidate"
+cp -a -- "$results_directory/baseline-checkout/src/DotnetAgents.CalDav.Mcp/bin/Release/net10.0/." "$results_directory/baseline/"
+cp -a -- "$repository_root/src/DotnetAgents.CalDav.Mcp/bin/Release/net10.0/." "$results_directory/candidate/"
+sha256sum "$results_directory/"{baseline,candidate}/DotnetAgents.CalDav.{Core,Mcp}.dll > "$results_directory/assembly-hashes.txt"

--- a/scripts/observations/mcp-performance/profile.py
+++ b/scripts/observations/mcp-performance/profile.py
@@ -2,33 +2,76 @@
 """Diagnostic EventPipe capture, separate from the latency comparison."""
 import argparse
 import asyncio
+from contextlib import suppress
 import json
 from pathlib import Path
 from driver import Client,environment,query
 
 
+def save_record(path,records,record,warmup):
+    records.append(dict(record,warmup=warmup))
+    path.write_text(json.dumps(records,indent=2))
+    if record['outcome']!='success' or record.get('is_error'):
+        raise RuntimeError('Profile call failed: '+record['outcome'])
+
+
+async def stop_collectors(collectors):
+    for process in collectors:
+        if process.returncode is None:
+            with suppress(ProcessLookupError):
+                process.terminate()
+            try:
+                await asyncio.wait_for(process.wait(),5)
+            except TimeoutError:
+                with suppress(ProcessLookupError):
+                    process.kill()
+                await process.wait()
+
+
+async def capture(a,client,cursor,records,samples):
+    collectors=[]
+    with (a.root/(a.name+'-profile.log')).open('w') as log:
+        try:
+            collectors.append(await asyncio.create_subprocess_exec(str(a.profilers/'dotnet-trace'),'collect',
+                '--process-id',str(client.process.pid),'--profile','dotnet-sampled-thread-time',
+                '--duration','00:00:20','--output',str(a.root/(a.name+'.nettrace')),stdout=log,stderr=log))
+            collectors.append(await asyncio.create_subprocess_exec(str(a.profilers/'dotnet-counters'),'collect',
+                '--process-id',str(client.process.pid),'--counters','System.Runtime','--format','json',
+                '--duration','00:00:20','--output',str(a.root/(a.name+'-counters.json')),stdout=log,stderr=log))
+            for _ in range(5 if a.mode=='start' else 60):
+                arguments=query(a.tool,200) if a.mode=='start' else dict(cursor=cursor,pageSize=200)
+                _,record=await client.call(a.tool,arguments)
+                save_record(samples,records,record,False)
+            for process in collectors:
+                if await asyncio.wait_for(process.wait(),25)!=0:
+                    raise RuntimeError('Diagnostic collector failed; inspect the profile log')
+        finally:
+            await stop_collectors(collectors)
+
+
 async def run(a):
+    suffixes=['-profile-samples.json','-profile-process.json','-profile.log','.nettrace','-counters.json']
+    if any((a.root/(a.name+suffix)).exists() for suffix in suffixes):
+        raise RuntimeError('Use a new profile name; preserve previous attempts')
     state=json.loads((a.root/'infra-private.json').read_text())
+    samples=a.root/(a.name+'-profile-samples.json')
     records=[]
-    async with Client(a.assembly,environment(state,'caldav-perf-profile-'+a.name)) as c:
-        for _ in range(5):
-            response,record=await c.call(a.tool,query(a.tool,200))
-            assert record['outcome']=='success'
-        cursor=response['result']['structuredContent']['pagination']['nextCursor']
-        with (a.root/(a.name+'-profile.log')).open('w') as log:
-            tracer=await asyncio.create_subprocess_exec(str(a.profilers/'dotnet-trace'),'collect',
-                '--process-id',str(c.process.pid),'--profile','dotnet-sampled-thread-time',
-                '--duration','00:00:20','--output',str(a.root/(a.name+'.nettrace')),stdout=log,stderr=log)
-            counters=await asyncio.create_subprocess_exec(str(a.profilers/'dotnet-counters'),'collect',
-                '--process-id',str(c.process.pid),'--counters','System.Runtime','--format','json',
-                '--duration','00:00:20','--output',str(a.root/(a.name+'-counters.json')),stdout=log,stderr=log)
-            for _ in range(10 if a.mode=='start' else 60):
-                args=query(a.tool,200) if a.mode=='start' else dict(cursor=cursor,pageSize=200)
-                _,record=await c.call(a.tool,args);records.append(record)
-            assert await tracer.wait()==0
-            assert await counters.wait()==0
-    (a.root/(a.name+'-profile-samples.json')).write_text(json.dumps(records,indent=2))
-    (a.root/(a.name+'-profile-process.json')).write_text(json.dumps(c.identity,indent=2))
+    client=Client(a.assembly,environment(state,'caldav-perf-profile-'+a.name))
+    completed=False
+    try:
+        async with client as c:
+            for _ in range(5):
+                response,record=await c.call(a.tool,query(a.tool,200))
+                save_record(samples,records,record,True)
+            cursor=response['result']['structuredContent']['pagination']['nextCursor']
+            if a.mode=='continue' and cursor is None:
+                raise RuntimeError('Continue profiling requires a paginated result')
+            await capture(a,c,cursor,records,samples)
+        completed=True
+    finally:
+        if hasattr(client,'identity'):
+            (a.root/(a.name+'-profile-process.json')).write_text(json.dumps(
+                dict(client.identity,profile_completed=completed),indent=2))
 
 
 if __name__=='__main__':

--- a/scripts/observations/mcp-performance/profile.py
+++ b/scripts/observations/mcp-performance/profile.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""Diagnostic EventPipe capture, separate from the latency comparison."""
+import argparse
+import asyncio
+import json
+from pathlib import Path
+from driver import Client,environment,query
+
+
+async def run(a):
+    state=json.loads((a.root/'infra-private.json').read_text())
+    records=[]
+    async with Client(a.assembly,environment(state,'caldav-perf-profile-'+a.name)) as c:
+        for _ in range(5):
+            response,record=await c.call(a.tool,query(a.tool,200))
+            assert record['outcome']=='success'
+        cursor=response['result']['structuredContent']['pagination']['nextCursor']
+        with (a.root/(a.name+'-profile.log')).open('w') as log:
+            tracer=await asyncio.create_subprocess_exec(str(a.profilers/'dotnet-trace'),'collect',
+                '--process-id',str(c.process.pid),'--profile','dotnet-sampled-thread-time',
+                '--duration','00:00:20','--output',str(a.root/(a.name+'.nettrace')),stdout=log,stderr=log)
+            counters=await asyncio.create_subprocess_exec(str(a.profilers/'dotnet-counters'),'collect',
+                '--process-id',str(c.process.pid),'--counters','System.Runtime','--format','json',
+                '--duration','00:00:20','--output',str(a.root/(a.name+'-counters.json')),stdout=log,stderr=log)
+            for _ in range(10 if a.mode=='start' else 60):
+                args=query(a.tool,200) if a.mode=='start' else dict(cursor=cursor,pageSize=200)
+                _,record=await c.call(a.tool,args);records.append(record)
+            assert await tracer.wait()==0
+            assert await counters.wait()==0
+    (a.root/(a.name+'-profile-samples.json')).write_text(json.dumps(records,indent=2))
+    (a.root/(a.name+'-profile-process.json')).write_text(json.dumps(c.identity,indent=2))
+
+
+if __name__=='__main__':
+    p=argparse.ArgumentParser(description=__doc__)
+    p.add_argument('root',type=Path);p.add_argument('assembly',type=Path);p.add_argument('profilers',type=Path)
+    p.add_argument('--name',required=True);p.add_argument('--tool',default='calendar_occurrences.query')
+    p.add_argument('--mode',choices=['start','continue'],default='continue')
+    asyncio.run(run(p.parse_args()))

--- a/scripts/observations/mcp-performance/profile.py
+++ b/scripts/observations/mcp-performance/profile.py
@@ -6,6 +6,7 @@ from contextlib import suppress
 import json
 from pathlib import Path
 from driver import Client,environment,query
+from build_manifest import prepared_input
 
 
 def save_record(path,records,record,warmup):
@@ -50,6 +51,8 @@ async def capture(a,client,cursor,records,samples):
 
 
 async def run(a):
+    build_input=prepared_input(a.root,a.assembly,a.build)
+    a.assembly=Path(build_input['assembly'])
     suffixes=['-profile-samples.json','-profile-process.json','-profile.log','.nettrace','-counters.json']
     if any((a.root/(a.name+suffix)).exists() for suffix in suffixes):
         raise RuntimeError('Use a new profile name; preserve previous attempts')
@@ -71,12 +74,13 @@ async def run(a):
     finally:
         if hasattr(client,'identity'):
             (a.root/(a.name+'-profile-process.json')).write_text(json.dumps(
-                dict(client.identity,profile_completed=completed),indent=2))
+                dict(client.identity,profile_completed=completed,build_input=build_input),indent=2))
 
 
 if __name__=='__main__':
     p=argparse.ArgumentParser(description=__doc__)
     p.add_argument('root',type=Path);p.add_argument('assembly',type=Path);p.add_argument('profilers',type=Path)
     p.add_argument('--name',required=True);p.add_argument('--tool',default='calendar_occurrences.query')
+    p.add_argument('--build',choices=['baseline','candidate'],default='candidate')
     p.add_argument('--mode',choices=['start','continue'],default='continue')
     asyncio.run(run(p.parse_args()))

--- a/scripts/observations/mcp-performance/schema-observation/Program.cs
+++ b/scripts/observations/mcp-performance/schema-observation/Program.cs
@@ -1,0 +1,51 @@
+using System.Diagnostics;
+using System.Reflection;
+using System.Runtime.Loader;
+using System.Security.Cryptography;
+using System.Text.Json;
+
+// Run a copy of this project outside the repository. Resolve the exact build's
+// dependencies and invoke its unmodified internal guard on a real MCP result.
+var directory = Path.GetFullPath(args[0]);
+var payload = File.ReadAllBytes(args[1]);
+AssemblyLoadContext.Default.Resolving += (_, name) =>
+    AssemblyLoadContext.Default.LoadFromAssemblyPath(Path.Combine(directory, name.Name + ".dll"));
+var assemblyPath = Path.Combine(directory, "DotnetAgents.CalDav.Mcp.dll");
+var assembly = AssemblyLoadContext.Default.LoadFromAssemblyPath(assemblyPath);
+var method = assembly.GetType("DotnetAgents.CalDav.Mcp.Hosting.CalendarOutputSchemaGuard", true)!
+    .GetMethod("Validate", BindingFlags.Static | BindingFlags.NonPublic)!;
+var resultType = method.GetParameters()[1].ParameterType;
+var result = Activator.CreateInstance(resultType)!;
+using var document = JsonDocument.Parse(payload);
+resultType.GetProperty("StructuredContent")!.SetValue(result, document.RootElement.Clone());
+object?[] parameters = [args[2], result];
+for (var i = 0; i < 20; i++)
+    method.Invoke(null, parameters);
+var samples = new List<object>();
+for (var i = 0; i < 100; i++)
+{
+    var allocated = GC.GetAllocatedBytesForCurrentThread();
+    var gen0 = GC.CollectionCount(0);
+    var gen1 = GC.CollectionCount(1);
+    var gen2 = GC.CollectionCount(2);
+    var start = Stopwatch.GetTimestamp();
+    method.Invoke(null, parameters);
+    var elapsed = Stopwatch.GetElapsedTime(start);
+    samples.Add(new
+    {
+        elapsedMilliseconds = elapsed.TotalMilliseconds,
+        allocatedBytes = GC.GetAllocatedBytesForCurrentThread() - allocated,
+        gen0 = GC.CollectionCount(0) - gen0,
+        gen1 = GC.CollectionCount(1) - gen1,
+        gen2 = GC.CollectionCount(2) - gen2
+    });
+}
+Console.WriteLine(JsonSerializer.Serialize(new
+{
+    runtime = Environment.Version.ToString(),
+    assemblySha256 = Convert.ToHexStringLower(SHA256.HashData(File.ReadAllBytes(assemblyPath))),
+    payloadSha256 = Convert.ToHexStringLower(SHA256.HashData(payload)),
+    tool = args[2],
+    boundary = "CalendarOutputSchemaGuard.Validate via reflection; no transport; current-thread allocations",
+    samples
+}));

--- a/scripts/observations/mcp-performance/schema-observation/Program.cs
+++ b/scripts/observations/mcp-performance/schema-observation/Program.cs
@@ -4,15 +4,34 @@ using System.Runtime.Loader;
 using System.Security.Cryptography;
 using System.Text.Json;
 
+if (args.Length != 4)
+{
+    Console.Error.WriteLine("Usage: SchemaObservation <assembly-directory> <page-json> <tool-name> <build-manifest>");
+    return 64;
+}
+
 // Run a copy of this project outside the repository. Resolve the exact build's
 // dependencies and invoke its unmodified internal guard on a real MCP result.
 var directory = Path.GetFullPath(args[0]);
 var payload = File.ReadAllBytes(args[1]);
-Dictionary<string, string> RuntimeFiles() => Directory.EnumerateFiles(directory, "*", SearchOption.AllDirectories)
-    .OrderBy(path => path, StringComparer.Ordinal)
-    .ToDictionary(path => Path.GetRelativePath(directory, path).Replace(Path.DirectorySeparatorChar, '/'),
-        path => Convert.ToHexStringLower(SHA256.HashData(File.ReadAllBytes(path))), StringComparer.Ordinal);
+using var manifest = JsonDocument.Parse(File.ReadAllBytes(args[3]));
+var expectedFiles = JsonSerializer.Deserialize<Dictionary<string, string>>(
+    manifest.RootElement.GetProperty("runtime_files_sha256").GetRawText())!;
+string RuntimePath(string name)
+{
+    var path = Path.GetFullPath(Path.Combine(directory, name));
+    var relative = Path.GetRelativePath(directory, path);
+    if (Path.IsPathRooted(relative) || relative == ".." || relative.StartsWith(".." + Path.DirectorySeparatorChar, StringComparison.Ordinal))
+        throw new InvalidOperationException("Runtime manifest path escapes its assembly directory.");
+    return path;
+}
+Dictionary<string, string> RuntimeFiles() => expectedFiles.Keys.OrderBy(name => name, StringComparer.Ordinal)
+    .ToDictionary(name => name, name => Convert.ToHexStringLower(SHA256.HashData(File.ReadAllBytes(RuntimePath(name)))), StringComparer.Ordinal);
+bool SameFiles(Dictionary<string, string> left, Dictionary<string, string> right) =>
+    left.Count == right.Count && left.All(item => right.TryGetValue(item.Key, out var value) && value == item.Value);
 var runtimeFiles = RuntimeFiles();
+if (!SameFiles(runtimeFiles, expectedFiles))
+    throw new InvalidOperationException("Schema observation runtime differs from the prepared build.");
 AssemblyLoadContext.Default.Resolving += (_, name) =>
     AssemblyLoadContext.Default.LoadFromAssemblyPath(Path.Combine(directory, name.Name + ".dll"));
 var assemblyPath = Path.Combine(directory, "DotnetAgents.CalDav.Mcp.dll");
@@ -45,7 +64,7 @@ for (var i = 0; i < 100; i++)
         gen2 = GC.CollectionCount(2) - gen2
     });
 }
-if (!runtimeFiles.SequenceEqual(RuntimeFiles()))
+if (!SameFiles(runtimeFiles, RuntimeFiles()))
     throw new InvalidOperationException("Runtime files changed during schema observation.");
 Console.WriteLine(JsonSerializer.Serialize(new
 {
@@ -57,3 +76,4 @@ Console.WriteLine(JsonSerializer.Serialize(new
     boundary = "CalendarOutputSchemaGuard.Validate via reflection; no transport; current-thread allocations",
     samples
 }));
+return 0;

--- a/scripts/observations/mcp-performance/schema-observation/Program.cs
+++ b/scripts/observations/mcp-performance/schema-observation/Program.cs
@@ -8,6 +8,11 @@ using System.Text.Json;
 // dependencies and invoke its unmodified internal guard on a real MCP result.
 var directory = Path.GetFullPath(args[0]);
 var payload = File.ReadAllBytes(args[1]);
+Dictionary<string, string> RuntimeFiles() => Directory.EnumerateFiles(directory, "*", SearchOption.AllDirectories)
+    .OrderBy(path => path, StringComparer.Ordinal)
+    .ToDictionary(path => Path.GetRelativePath(directory, path).Replace(Path.DirectorySeparatorChar, '/'),
+        path => Convert.ToHexStringLower(SHA256.HashData(File.ReadAllBytes(path))), StringComparer.Ordinal);
+var runtimeFiles = RuntimeFiles();
 AssemblyLoadContext.Default.Resolving += (_, name) =>
     AssemblyLoadContext.Default.LoadFromAssemblyPath(Path.Combine(directory, name.Name + ".dll"));
 var assemblyPath = Path.Combine(directory, "DotnetAgents.CalDav.Mcp.dll");
@@ -40,10 +45,13 @@ for (var i = 0; i < 100; i++)
         gen2 = GC.CollectionCount(2) - gen2
     });
 }
+if (!runtimeFiles.SequenceEqual(RuntimeFiles()))
+    throw new InvalidOperationException("Runtime files changed during schema observation.");
 Console.WriteLine(JsonSerializer.Serialize(new
 {
     runtime = Environment.Version.ToString(),
     assemblySha256 = Convert.ToHexStringLower(SHA256.HashData(File.ReadAllBytes(assemblyPath))),
+    runtimeFilesSha256 = runtimeFiles,
     payloadSha256 = Convert.ToHexStringLower(SHA256.HashData(payload)),
     tool = args[2],
     boundary = "CalendarOutputSchemaGuard.Validate via reflection; no transport; current-thread allocations",

--- a/scripts/observations/mcp-performance/schema-observation/SchemaObservation.csproj
+++ b/scripts/observations/mcp-performance/schema-observation/SchemaObservation.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+</Project>

--- a/scripts/observations/mcp-performance/telemetry.py
+++ b/scripts/observations/mcp-performance/telemetry.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Export Aspire's supported telemetry API and reject truncated captures."""
+import argparse
+import collections
+import json
+from pathlib import Path
+import subprocess
+import urllib.parse
+import urllib.request
+
+
+def fetch(state, endpoint, **params):
+    url = state['dashboard'] + '/api/telemetry/' + endpoint + '?' + urllib.parse.urlencode(params)
+    req = urllib.request.Request(url, headers={'x-api-key':state['api_key']})
+    with urllib.request.urlopen(req, timeout=60) as response:
+        return json.load(response)
+
+
+def spans(data):
+    for resource in data['data']['resourceSpans']:
+        resource_tags=attributes(resource['resource'])
+        for scope in resource['scopeSpans']:
+            for span in scope['spans']:
+                yield dict(span, resource_service=resource_tags.get('service.name'),
+                           resource_instance=resource_tags.get('service.instance.id'))
+
+
+def attributes(span):
+    return {a['key']:next(iter(a['value'].values())) for a in span.get('attributes',[])}
+
+
+def export(root, name, resource=None):
+    state = json.loads((root/'infra-private.json').read_text())
+    params = dict(limit=1000000)
+    if resource:
+        params['resource'] = resource
+    data = fetch(state, 'spans', **params)
+    if data['totalCount'] != data['returnedCount']:
+        raise RuntimeError(f"Truncated export: {data['returnedCount']} of {data['totalCount']}")
+    (root/(name+'-spans.json')).write_text(json.dumps(data))
+    traces = collections.defaultdict(list)
+    for span in spans(data):
+        traces[span['traceId']].append(span)
+    summaries = []
+    for trace, group in traces.items():
+        operations = [s for s in group if s['name']=='caldav.operation']
+        if not operations:
+            continue
+        operation = operations[0]
+        duration = lambda s:(int(s['endTimeUnixNano'])-int(s['startTimeUnixNano']))/1e6
+        phases = collections.defaultdict(float)
+        http = collections.Counter()
+        statuses = collections.Counter()
+        retries = 0
+        error_spans = 0
+        for span in group:
+            tags = attributes(span)
+            if 'http.request.method' in tags:
+                http[tags['http.request.method']] += 1
+                statuses[str(tags.get('http.response.status_code','unavailable'))] += 1
+                retries += int(tags.get('http.request.resend_count',0)) > 0
+            error_spans += span.get('status',{}).get('code') in (2,'STATUS_CODE_ERROR')
+            if span['name'].startswith(('caldav.phase', 'caldav.query.phase')):
+                phases[span['name']] += duration(span)
+        summaries.append(dict(trace_id=trace, start_ns=operation['startTimeUnixNano'],
+            service=operation['resource_service'], instance=operation['resource_instance'],
+            operation_ms=duration(operation), outer_ms=max(map(duration,group)),
+            http=dict(http), http_statuses=dict(statuses), retries=retries, error_spans=error_spans,
+            phases=dict(phases), attributes=attributes(operation)))
+    (root/(name+'-traces.json')).write_text(json.dumps(summaries,indent=2))
+    print(json.dumps(dict(export=name, spans=data['returnedCount'], traces=len(summaries))))
+    return summaries
+
+
+def cli_export(root, name):
+    state = json.loads((root/'infra-private.json').read_text())
+    command = ['aspire','export','--dashboard-url',state['dashboard'],'--api-key',state['api_key'],
+               '--output',str(root/(name+'.zip')),'--non-interactive']
+    result = subprocess.run(command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    text = result.stdout.decode().replace(state['api_key'],'[redacted]')
+    (root/(name+'-export.log')).write_text(text)
+    if result.returncode:
+        raise RuntimeError('Aspire CLI export failed; inspect sanitized log')
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('root',type=Path)
+    parser.add_argument('name')
+    parser.add_argument('--resource')
+    parser.add_argument('--zip',action='store_true')
+    args = parser.parse_args()
+    export(args.root,args.name,args.resource)
+    if args.zip:
+        cli_export(args.root,args.name)

--- a/scripts/observations/mcp-performance/test_harness.py
+++ b/scripts/observations/mcp-performance/test_harness.py
@@ -120,6 +120,9 @@ class BuildIdentityTests(unittest.TestCase):
             otlp = benchmark_inputs(builds, candidate, candidate, compare_otlp=True)
             self.assertEqual(expected['candidate'], otlp['baseline']['source']['sha'])
             self.assertEqual(otlp['baseline'], otlp['candidate'])
+            publish=root/'candidate'/'publish';publish.mkdir()
+            (publish/ASSEMBLIES[0]).write_bytes(b'unrelated published copy')
+            self.assertEqual(builds,load_builds(root))
             dependency=root/'candidate'/'Example.Dependency.dll'
             original=dependency.read_bytes()
             dependency.write_bytes(b'stale dependency with unchanged first-party assemblies')

--- a/scripts/observations/mcp-performance/test_harness.py
+++ b/scripts/observations/mcp-performance/test_harness.py
@@ -25,6 +25,7 @@ import driver
 import gates
 from functional import verify_occurrence_fixture
 from edges import record_scale
+import edges
 
 HARNESS = Path(__file__).resolve().parent
 ASSEMBLIES = ['DotnetAgents.CalDav.Mcp.dll', 'DotnetAgents.CalDav.Core.dll']
@@ -158,6 +159,35 @@ class BuildIdentityTests(unittest.TestCase):
 
 
 class CommandTests(unittest.TestCase):
+    def test_otlp_process_control_is_rejected_even_with_python_optimization(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root=Path(temporary)
+            for flags in [[],['-O']]:
+                with self.subTest(flags=flags):
+                    result=subprocess.run([sys.executable,*flags,str(HARNESS/'benchmark.py'),str(root),
+                        'baseline.dll','candidate.dll','--name','invalid','--mode','continue',
+                        '--compare-otlp','--topology','processes'],capture_output=True,text=True)
+                    self.assertEqual(2,result.returncode,result.stderr)
+                    self.assertIn('single_session',result.stderr)
+                    self.assertNotIn('Traceback',result.stderr)
+                    self.assertEqual([],list(root.iterdir()))
+
+    def test_edge_inputs_reject_swapped_or_stale_builds_before_infrastructure(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root=Path(temporary);repo=repository(root)
+            for label in ['baseline','candidate']:
+                directory=root/label;directory.mkdir();runtime_fixture(directory,label)
+                manifest=root/(label+'-build.json');capture(repo,manifest);finalize(repo,manifest,directory)
+            baseline=root/'baseline'/ASSEMBLIES[0];candidate=root/'candidate'/ASSEMBLIES[0]
+            with patch.object(edges,'expected_counts',side_effect=AssertionError('Infrastructure reached')):
+                with self.assertRaisesRegex(RuntimeError,'baseline input'):
+                    asyncio.run(edges.run(root,candidate,baseline))
+                (root/'candidate'/'Example.Dependency.dll').write_text('stale')
+                with self.assertRaisesRegex(RuntimeError,'dependency set differs'):
+                    asyncio.run(edges.run(root,baseline,candidate))
+            self.assertFalse((root/'edges-manifest.json').exists())
+            self.assertFalse((root/'edges.jsonl').exists())
+
     def test_proxy_propagates_child_status_after_forwarding_stderr(self):
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)
@@ -240,6 +270,7 @@ class CommandTests(unittest.TestCase):
                         (repo / 'src' / 'removed.cs').unlink()
                     output = root / ('dirty' if dirty else 'clean')
                     output.mkdir()
+                    capture(repo,output/'candidate-build.json')
                     result = subprocess.run(['bash', str(HARNESS / 'package.sh'), str(output)],
                         cwd=repo, env=env, capture_output=True, text=True)
                     self.assertEqual(0, result.returncode, result.stderr)
@@ -250,12 +281,31 @@ class CommandTests(unittest.TestCase):
                     if dirty:
                         self.assertEqual('untracked source', (clone / 'src' / 'added.cs').read_text())
 
+    def test_package_rejects_source_changes_since_preparation_before_cloning(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root=Path(temporary);repo=repository(root)
+            for changed_commit in [False,True]:
+                with self.subTest(changed_commit=changed_commit):
+                    output=root/str(changed_commit);output.mkdir()
+                    capture(repo,output/'candidate-build.json')
+                    (repo/'Directory.Packages.props').write_text('changed '+str(changed_commit))
+                    if changed_commit:
+                        commit(repo)
+                    result=subprocess.run(['bash',str(HARNESS/'package.sh'),str(output)],
+                        cwd=repo,capture_output=True,text=True)
+                    self.assertNotEqual(0,result.returncode)
+                    self.assertIn('Source does not match',result.stderr)
+                    self.assertFalse((output/'package-checkout').exists())
+                    self.assertFalse((output/'package-source.patch').exists())
+
     def test_hermes_exit_status_reaches_the_shell_after_summary(self):
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)
             source = root / 'source-home'
             source.mkdir()
-            (source / 'config.yaml').write_text(json.dumps({'model': {'provider': 'openrouter', 'model': 'test'}}))
+            (source / 'config.yaml').write_text(json.dumps({'model': {'provider': 'openrouter', 'model': 'test',
+                'api_key':'inline-secret-marker','headers':{'Authorization':'header-secret-marker'},
+                'base_url':'https://url-secret-marker@example.invalid','options':{'credential':'nested-secret-marker'}}}))
             (source / '.env').write_text('OPENROUTER_API_KEY=test-only-placeholder\n')
             (root / 'infra-private.json').write_text(json.dumps(dict(
                 url='http://127.0.0.1:1', username='test', password='test-only', otlp='http://127.0.0.1:1')))
@@ -273,6 +323,10 @@ class CommandTests(unittest.TestCase):
                         env=env, capture_output=True, text=True)
                     self.assertEqual(exit_code, result.returncode, result.stderr)
                     self.assertEqual(exit_code, json.loads(result.stdout)['exit_code'])
+                    sanitized=root/'hermes-config-sanitized.json'
+                    self.assertEqual({'provider':'openrouter','model':'test'},json.loads(sanitized.read_text())['model'])
+                    self.assertNotIn('secret-marker',sanitized.read_text())
+                    self.assertEqual(0o600,stat.S_IMODE(sanitized.stat().st_mode))
 
 
 class EvidenceTests(unittest.TestCase):
@@ -282,14 +336,15 @@ class EvidenceTests(unittest.TestCase):
             builds={label:dict(assembly_sha256={ASSEMBLIES[0]:label},runtime_files_sha256={'dependency':label})
                     for label in ['baseline','candidate']}
             sources={label:dict(assemblySha256=label,tool='todos.query',payloadSha256='same-payload',
-                runtimeFilesSha256=builds[label]['runtime_files_sha256'],
+                runtimeFilesSha256=builds[label]['runtime_files_sha256'],runtime='10.0.0',
                 samples=[dict(elapsedMilliseconds=1,allocatedBytes=100,gen0=0,gen1=0,gen2=0)])
                 for label in builds}
             for label,source in sources.items():
                 (root/('schema-'+label+'.json')).write_text(json.dumps(source))
             self.assertEqual(2,len(schema_observations(root,builds)))
             for field,value in [('assemblySha256','baseline'),('tool','calendar_entities.query'),
-                                ('payloadSha256','different-payload'),('runtimeFilesSha256',{'dependency':'stale'})]:
+                                ('payloadSha256','different-payload'),('runtimeFilesSha256',{'dependency':'stale'}),
+                                ('runtime','10.0.1')]:
                 with self.subTest(field=field):
                     (root/'schema-candidate.json').write_text(json.dumps(dict(sources['candidate'],**{field:value})))
                     with self.assertRaises(RuntimeError):

--- a/scripts/observations/mcp-performance/test_harness.py
+++ b/scripts/observations/mcp-performance/test_harness.py
@@ -19,6 +19,7 @@ from build_manifest import capture, finalize, load_builds, source_identity, benc
 from aggregate import load_traces, schema_observations
 from infra import radicale_config, save_private_state, verify
 import benchmark
+import driver
 
 HARNESS = Path(__file__).resolve().parent
 ASSEMBLIES = ['DotnetAgents.CalDav.Mcp.dll', 'DotnetAgents.CalDav.Core.dll']
@@ -320,6 +321,42 @@ class EvidenceTests(unittest.TestCase):
                     self.assertTrue(any(row['label'] == 'candidate' for row in rows))
                     if variation == 'timeout':
                         self.assertTrue(rows[-1]['timed_out'])
+
+
+class StartupCleanupTests(unittest.IsolatedAsyncioTestCase):
+    async def test_failed_negotiation_reaps_the_child_and_reader_tasks(self):
+        for kind,error in [('legacy',AssertionError),('malformed',TypeError),
+                           ('timeout',TimeoutError),('cancelled',asyncio.CancelledError)]:
+            with self.subTest(kind=kind), tempfile.TemporaryDirectory() as temporary:
+                root=Path(temporary)
+                server=root/'dotnet'
+                server.write_text('#!'+sys.executable+'\n'+'''import json, pathlib, sys, time
+kind=pathlib.Path(sys.argv[1]).stem
+if kind in ('timeout','cancelled'):
+    time.sleep(60)
+else:
+    for line in sys.stdin:
+        request=json.loads(line)
+        result=[] if kind=='malformed' else {'supportedVersions':['legacy'], 'capabilities':{'tools':{}}}
+        print(json.dumps({'jsonrpc':'2.0','id':request['id'],'result':result}),flush=True)
+''')
+                server.chmod(0o755)
+                client=driver.Client(root/(kind+'.dll'),dict(os.environ))
+                timeout=0.1 if kind=='timeout' else 45
+                with patch.object(driver.shutil,'which',return_value=str(server)), \
+                        patch.object(driver,'REQUEST_TIMEOUT_SECONDS',timeout), \
+                        patch.object(driver,'SHUTDOWN_TIMEOUT_SECONDS',0.1):
+                    task=asyncio.create_task(client.__aenter__())
+                    if kind=='cancelled':
+                        while not hasattr(client,'reader'):
+                            await asyncio.sleep(0.001)
+                        task.cancel()
+                    with self.assertRaises(error):
+                        await task
+                self.assertIsNotNone(client.process.returncode)
+                self.assertTrue(client.reader.done())
+                self.assertTrue(client.stderr.done())
+                self.assertEqual({},client.pending)
 
 
 class InfrastructureTests(unittest.TestCase):

--- a/scripts/observations/mcp-performance/test_harness.py
+++ b/scripts/observations/mcp-performance/test_harness.py
@@ -115,6 +115,25 @@ class BuildIdentityTests(unittest.TestCase):
 
 
 class CommandTests(unittest.TestCase):
+    def test_proxy_propagates_child_status_after_forwarding_stderr(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            for name in ASSEMBLIES:
+                (root / name).write_bytes(b'test-only placeholder')
+            env = dict(os.environ, PATH=str(root) + os.pathsep + os.environ['PATH'])
+            for code in [0, 17]:
+                with self.subTest(code=code):
+                    executable(root / 'dotnet', "echo 'child diagnostic' >&2\nexit " + str(code))
+                    wire = root / ('wire-' + str(code) + '.jsonl')
+                    result = subprocess.run([sys.executable, str(HARNESS / 'hermes_proxy.py'),
+                        str(root / ASSEMBLIES[0]), str(wire)], env=env, input='', capture_output=True, text=True)
+                    self.assertEqual(code, result.returncode, result.stderr)
+                    self.assertIn('child diagnostic', result.stderr)
+                    rows = [json.loads(line) for line in wire.read_text().splitlines()]
+                    self.assertEqual('exit', rows[-1]['event'])
+                    self.assertEqual(code, rows[-1]['code'])
+                    self.assertTrue(any(row['event'] == 'stderr' and row['bytes'] > 0 for row in rows))
+
     def test_existing_hermes_wire_is_preserved_and_rejected_before_launch(self):
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)
@@ -135,7 +154,8 @@ class CommandTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)
             for options in [('--samples', '7'), ('--samples', '1'), ('--samples', '0'),
-                            ('--cohort-samples', '0'), ('--blocks', '-1'), ('--concurrency', '2')]:
+                            ('--cohort-samples', '0'), ('--blocks', '-1'), ('--concurrency', '2'),
+                            ('--cohort-samples', '12', '--samples', '12')]:
                 with self.subTest(options=options):
                     result = subprocess.run([sys.executable, str(HARNESS / 'benchmark.py'), str(root),
                         'baseline.dll', 'candidate.dll', '--name', 'invalid', '--mode', 'start', *options],
@@ -143,6 +163,14 @@ class CommandTests(unittest.TestCase):
                     self.assertEqual(2, result.returncode, result.stderr)
                     self.assertNotIn('Traceback', result.stderr)
                     self.assertEqual([], list(root.iterdir()))
+
+    def test_start_count_boundary_reserves_five_warmup_snapshots(self):
+        args = SimpleNamespace(blocks=1, samples=11, cohort_samples=11, mode='start',
+                               topology='single_session', concurrency=1)
+        benchmark.validate_args(args)
+        args.samples = args.cohort_samples = 12
+        with self.assertRaisesRegex(ValueError, 'at most 11'):
+            benchmark.validate_args(args)
 
     def test_package_uses_clean_commit_or_complete_dirty_candidate(self):
         with tempfile.TemporaryDirectory() as temporary:

--- a/scripts/observations/mcp-performance/test_harness.py
+++ b/scripts/observations/mcp-performance/test_harness.py
@@ -15,7 +15,7 @@ import xml.etree.ElementTree as ET
 from types import SimpleNamespace
 from unittest.mock import patch
 
-from build_manifest import capture, finalize, load_builds, source_identity, benchmark_inputs, verify_process_inputs, runtime_files
+from build_manifest import capture, finalize, load_builds, source_identity, benchmark_inputs, verify_process_inputs, runtime_files, prepared_input
 from aggregate import load_traces, schema_observations, validate_gates
 from infra import radicale_config, save_private_state, verify, expected_counts
 import cleanup as cleanup_module
@@ -65,6 +65,13 @@ def runtime_fixture(directory,label):
     deps=dict(runtimeTarget=dict(name='test'),targets={'test':{'app':{'runtime':{name:{} for name in names}}}})
     (directory/'DotnetAgents.CalDav.Mcp.deps.json').write_text(json.dumps(deps))
     (directory/'DotnetAgents.CalDav.Mcp.runtimeconfig.json').write_text('{}')
+
+
+def prepared_fixture(root):
+    repo=repository(root)
+    for label in ['baseline','candidate']:
+        directory=root/label;directory.mkdir();runtime_fixture(directory,label)
+        manifest=root/(label+'-build.json');capture(repo,manifest);finalize(repo,manifest,directory)
 
 
 class BuildIdentityTests(unittest.TestCase):
@@ -159,6 +166,35 @@ class BuildIdentityTests(unittest.TestCase):
 
 
 class CommandTests(unittest.TestCase):
+    def test_single_build_commands_reject_wrong_inputs_before_fixture_or_client_access(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root=Path(temporary);prepared_fixture(root)
+            stubs=root/'stubs';stubs.mkdir()
+            (stubs/'yaml.py').write_text('')
+            (stubs/'dotenv.py').write_text('def dotenv_values(path): return {}\n')
+            candidate=root/'candidate'/ASSEMBLIES[0]
+            good=prepared_input(root,candidate)
+            self.assertEqual('candidate',good['label'])
+            self.assertEqual('baseline',prepared_input(root,root/'baseline'/ASSEMBLIES[0],'baseline')['label'])
+            for variation in ['baseline','stale-dependency']:
+                assembly=root/'baseline'/ASSEMBLIES[0] if variation=='baseline' else candidate
+                if variation=='stale-dependency':
+                    (candidate.parent/'Example.Dependency.dll').write_text('replaced after preparation')
+                for script,arguments in [
+                    ('functional.py',[str(root),str(assembly)]),
+                    ('hermes.py',[str(root),str(assembly)]),
+                    ('hermes_proxy.py',[str(assembly),str(root/'wire.jsonl'),str(root)]),
+                    ('verify_hermes.py',[str(root),str(assembly)]),
+                    ('driver.py',[str(root),str(assembly)]),
+                    ('profile.py',[str(root),str(assembly),str(root),'--name','rejected'])]:
+                    with self.subTest(variation=variation,script=script):
+                        before=set(root.iterdir())
+                        result=subprocess.run([sys.executable,str(HARNESS/script),*arguments],
+                            env=dict(os.environ,PYTHONPATH=str(stubs)),capture_output=True,text=True)
+                        self.assertNotEqual(0,result.returncode)
+                        self.assertIn('candidate input does not match its prepared build',result.stderr)
+                        self.assertEqual(before,set(root.iterdir()))
+
     def test_otlp_process_control_is_rejected_even_with_python_optimization(self):
         with tempfile.TemporaryDirectory() as temporary:
             root=Path(temporary)
@@ -191,21 +227,22 @@ class CommandTests(unittest.TestCase):
     def test_proxy_propagates_child_status_after_forwarding_stderr(self):
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)
-            for name in ASSEMBLIES:
-                (root / name).write_bytes(b'test-only placeholder')
+            prepared_fixture(root)
             env = dict(os.environ, PATH=str(root) + os.pathsep + os.environ['PATH'])
             for code in [0, 17]:
                 with self.subTest(code=code):
                     executable(root / 'dotnet', "echo 'child diagnostic' >&2\nexit " + str(code))
                     wire = root / ('wire-' + str(code) + '.jsonl')
                     result = subprocess.run([sys.executable, str(HARNESS / 'hermes_proxy.py'),
-                        str(root / ASSEMBLIES[0]), str(wire)], env=env, input='', capture_output=True, text=True)
+                        str(root/'candidate'/ASSEMBLIES[0]), str(wire),str(root)], env=env, input='', capture_output=True, text=True)
                     self.assertEqual(code, result.returncode, result.stderr)
                     self.assertIn('child diagnostic', result.stderr)
                     rows = [json.loads(line) for line in wire.read_text().splitlines()]
                     self.assertEqual('exit', rows[-1]['event'])
                     self.assertEqual(code, rows[-1]['code'])
                     self.assertTrue(any(row['event'] == 'stderr' and row['bytes'] > 0 for row in rows))
+                    self.assertEqual(prepared_input(root,root/'candidate'/ASSEMBLIES[0])['runtime_files_sha256'],
+                                     rows[0]['runtime_files_sha256'])
 
     def test_existing_hermes_wire_is_preserved_and_rejected_before_launch(self):
         with tempfile.TemporaryDirectory() as temporary:
@@ -301,6 +338,7 @@ class CommandTests(unittest.TestCase):
     def test_hermes_exit_status_reaches_the_shell_after_summary(self):
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)
+            prepared_fixture(root)
             source = root / 'source-home'
             source.mkdir()
             (source / 'config.yaml').write_text(json.dumps({'model': {'provider': 'openrouter', 'model': 'test',
@@ -319,7 +357,7 @@ class CommandTests(unittest.TestCase):
                 with self.subTest(exit_code=exit_code):
                     executable(stubs / 'hermes', 'exit ' + str(exit_code))
                     result = subprocess.run([sys.executable, str(HARNESS / 'hermes.py'), str(root),
-                        str(root / 'candidate.dll'), '--source-home', str(source)],
+                        str(root/'candidate'/ASSEMBLIES[0]), '--source-home', str(source)],
                         env=env, capture_output=True, text=True)
                     self.assertEqual(exit_code, result.returncode, result.stderr)
                     self.assertEqual(exit_code, json.loads(result.stdout)['exit_code'])
@@ -327,6 +365,9 @@ class CommandTests(unittest.TestCase):
                     self.assertEqual({'provider':'openrouter','model':'test'},json.loads(sanitized.read_text())['model'])
                     self.assertNotIn('secret-marker',sanitized.read_text())
                     self.assertEqual(0o600,stat.S_IMODE(sanitized.stat().st_mode))
+                    self.assertEqual(prepared_input(root,root/'candidate'/ASSEMBLIES[0]),
+                                     json.loads((root/'hermes-build.json').read_text()))
+                    self.assertEqual(str(root),json.loads(sanitized.read_text())['mcp_args'][-1])
 
 
 class EvidenceTests(unittest.TestCase):
@@ -447,9 +488,10 @@ class ProfileTests(unittest.IsolatedAsyncioTestCase):
                 async def spawn(*args,**kwargs):
                     if variation=='collector-start-failure' and collectors: raise OSError('collector unavailable')
                     process=Collector();collectors.append(process);return process
-                args=SimpleNamespace(root=root,assembly=root/'server.dll',profilers=root,name='capture',
+                args=SimpleNamespace(root=root,assembly=root/'server.dll',profilers=root,name='capture',build='candidate',
                                      mode='start',tool='calendar_occurrences.query')
-                with patch.object(profiling,'Client',FakeClient), patch.object(profiling.asyncio,'create_subprocess_exec',side_effect=spawn):
+                with patch.object(profiling,'Client',FakeClient), patch.object(profiling.asyncio,'create_subprocess_exec',side_effect=spawn), \
+                     patch.object(profiling,'prepared_input',return_value=dict(assembly=str(args.assembly),label='candidate')):
                     if variation=='success':
                         await profiling.run(args)
                     else:

--- a/scripts/observations/mcp-performance/test_harness.py
+++ b/scripts/observations/mcp-performance/test_harness.py
@@ -22,6 +22,9 @@ import cleanup as cleanup_module
 import profile as profiling
 import benchmark
 import driver
+import gates
+from functional import verify_occurrence_fixture
+from edges import record_scale
 
 HARNESS = Path(__file__).resolve().parent
 ASSEMBLIES = ['DotnetAgents.CalDav.Mcp.dll', 'DotnetAgents.CalDav.Core.dll']
@@ -64,6 +67,17 @@ def runtime_fixture(directory,label):
 
 
 class BuildIdentityTests(unittest.TestCase):
+    def test_otlp_comparison_rejects_different_dependency_closures(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root=Path(temporary);builds={}
+            for label in ['baseline','candidate']:
+                directory=root/label;directory.mkdir();runtime_fixture(directory,'same')
+                (directory/'Example.Dependency.dll').write_text(label)
+                hashes={name:hashlib.sha256((directory/name).read_bytes()).hexdigest() for name in ASSEMBLIES}
+                builds[label]=dict(source=dict(sha=label),assembly_sha256=hashes,
+                                   runtime_files_sha256=runtime_files(directory/ASSEMBLIES[0]))
+            with self.assertRaisesRegex(RuntimeError,'same build'):
+                benchmark_inputs(builds,root/'baseline'/ASSEMBLIES[0],root/'candidate'/ASSEMBLIES[0],True)
     def test_prepared_revisions_survive_later_commits_and_working_directory_changes(self):
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)
@@ -396,10 +410,40 @@ class ProfileTests(unittest.IsolatedAsyncioTestCase):
 
 
 class GateEvidenceTests(unittest.TestCase):
+    def test_gate_runner_records_source_and_only_completes_all_steps(self):
+        for failure in [None,'tests']:
+            with self.subTest(failure=failure), tempfile.TemporaryDirectory() as temporary:
+                root=Path(temporary)
+                candidate=dict(source=dict(sha='candidate',dirty=False),runtime_files_sha256={'runtime':'hash'})
+                calls=[]
+                def command(argv,**kwargs):
+                    name=gates.STEPS[len(calls)];calls.append(name)
+                    return SimpleNamespace(returncode=1 if name==failure else 0)
+                with patch.object(gates,'load_builds',return_value={'candidate':candidate}), \
+                        patch.object(gates,'source_identity',return_value=candidate['source']), \
+                        patch.object(gates,'runtime_files',return_value=candidate['runtime_files_sha256']), \
+                        patch.object(gates.subprocess,'run',side_effect=command):
+                    if failure:
+                        with self.assertRaisesRegex(RuntimeError,'Gate failed'):
+                            gates.run(root,'evidence')
+                    else:
+                        gates.run(root,'evidence')
+                proof=json.loads((root/'evidence/gate-source.json').read_text())
+                self.assertEqual(failure is None,proof['completed'])
+                self.assertEqual(gates.STEPS if failure is None else gates.STEPS[:4],calls)
+                if failure:
+                    with self.assertRaises(RuntimeError): gates.verify_gate_identity(root/'evidence',candidate)
+                else:
+                    gates.verify_gate_identity(root/'evidence',candidate)
+
     def test_complete_gates_are_required_before_aggregation(self):
         manifest=json.loads((HARNESS.parents[1]/'test-suite-manifest.json').read_text())
         with tempfile.TemporaryDirectory() as temporary:
             root=Path(temporary)
+            candidate=dict(source=dict(sha='candidate',dirty=False),runtime_files_sha256={'runtime':'hash'})
+            proof=dict(completed=True,source=candidate['source'],source_after=candidate['source'],
+                runtime_files_sha256=candidate['runtime_files_sha256'],steps=[dict(name=name,exit_code=0) for name in gates.STEPS])
+            (root/'gate-source.json').write_text(json.dumps(proof))
             for item in manifest['artifacts']:
                 trx=ET.Element('TestRun')
                 results=ET.SubElement(trx,'Results')
@@ -414,19 +458,59 @@ class GateEvidenceTests(unittest.TestCase):
                         (root/(item['coveragePrefix']+'.coverage.'+form+'.test.xml')).write_text('<coverage/>')
             coverage=root/'coverage-report';coverage.mkdir()
             (coverage/'Cobertura.xml').write_text('<coverage line-rate="1" branch-rate="1"/>')
-            validate_gates(root)
+            validate_gates(root,candidate)
+            for field,value in [('source',dict(sha='old',dirty=False)),
+                                ('source_after',dict(sha='candidate',dirty=True)),
+                                ('runtime_files_sha256',{'runtime':'stale'}),('completed',False)]:
+                with self.subTest(field=field):
+                    (root/'gate-source.json').write_text(json.dumps(dict(proof,**{field:value})))
+                    with self.assertRaises(RuntimeError): validate_gates(root,candidate)
+            (root/'gate-source.json').write_text(json.dumps(proof))
             strict=root/'strict-preconditions.trx';saved=strict.read_bytes();strict.unlink()
-            with self.assertRaises(RuntimeError): validate_gates(root)
+            with self.assertRaises(RuntimeError): validate_gates(root,candidate)
             strict.write_bytes(saved)
             core=root/'main-core.trx';original=core.read_bytes()
             for counter in ['failed','notExecuted','warning']:
                 with self.subTest(counter=counter):
                     trx=ET.fromstring(original);trx.find('.//Counters').set(counter,'1')
                     core.write_bytes(ET.tostring(trx))
-                    with self.assertRaises(RuntimeError): validate_gates(root)
+                    with self.assertRaises(RuntimeError): validate_gates(root,candidate)
             core.write_bytes(original)
             (coverage/'Cobertura.xml').write_text('<coverage line-rate="0.1" branch-rate="1"/>')
-            with self.assertRaises(RuntimeError): validate_gates(root)
+            with self.assertRaises(RuntimeError): validate_gates(root,candidate)
+
+
+class PersistedEvidenceTests(unittest.TestCase):
+    def test_failed_scale_is_recorded_and_rejected(self):
+        records=[]
+        record_scale(records.append,dict(outcome='success'),corpus_resources=600)
+        with self.assertRaisesRegex(RuntimeError,'Scale query failed'):
+            record_scale(records.append,dict(outcome='limit_exhausted',is_error=True),corpus_resources=6000)
+        self.assertEqual('limit_exhausted',records[-1]['outcome'])
+        self.assertEqual(6000,records[-1]['corpus_resources'])
+
+    def test_occurrence_checks_reject_noops_and_wrong_instances(self):
+        target='20260909T120000Z'
+        def fixture(verb):
+            lines=['BEGIN:VCALENDAR','BEGIN:VEVENT','UID:fixture','DTSTART:20260905T120000Z',
+                   'DTEND:20260905T130000Z','RRULE:FREQ=DAILY;COUNT=3']
+            if verb!='initial': lines.append('RDATE:'+target)
+            if verb=='exclude': lines.append('EXDATE:'+target)
+            lines.append('END:VEVENT')
+            if verb in ['cancel','restore_cancellation']:
+                lines+=['BEGIN:VEVENT','UID:fixture','RECURRENCE-ID:'+target]
+                if verb=='cancel': lines.append('STATUS:CANCELLED')
+                lines.append('END:VEVENT')
+            return ('\r\n'.join(lines+['END:VCALENDAR',''])).encode()
+        previous='initial'
+        for verb in ['add','exclude','restore_exclusion','cancel','restore_cancellation']:
+            with self.subTest(verb=verb):
+                data=fixture(verb)
+                verify_occurrence_fixture(data,verb,'fixture')
+                with self.assertRaises(RuntimeError): verify_occurrence_fixture(fixture(previous),verb,'fixture')
+                with self.assertRaises(RuntimeError):
+                    verify_occurrence_fixture(data.replace(target.encode(),b'20260910T120000Z'),verb,'fixture')
+                previous=verb
 
 
 class StartupCleanupTests(unittest.IsolatedAsyncioTestCase):

--- a/scripts/observations/mcp-performance/test_harness.py
+++ b/scripts/observations/mcp-performance/test_harness.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 """Harness regressions; temporary Git repositories and stub external executables."""
 import contextlib
+import asyncio
+import hashlib
 import json
 import os
 from pathlib import Path
@@ -8,8 +10,12 @@ import subprocess
 import sys
 import tempfile
 import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
 
-from build_manifest import capture, finalize, load_builds, source_identity
+from build_manifest import capture, finalize, load_builds, source_identity, benchmark_inputs, verify_process_inputs
+from aggregate import load_traces
+import benchmark
 
 HARNESS = Path(__file__).resolve().parent
 ASSEMBLIES = ['DotnetAgents.CalDav.Mcp.dll', 'DotnetAgents.CalDav.Core.dll']
@@ -68,6 +74,23 @@ class BuildIdentityTests(unittest.TestCase):
             for label in expected:
                 self.assertEqual(expected[label], builds[label]['source']['sha'])
                 self.assertFalse(builds[label]['source']['dirty'])
+            baseline = root / 'baseline' / ASSEMBLIES[0]
+            candidate = root / 'candidate' / ASSEMBLIES[0]
+            inputs = benchmark_inputs(builds, baseline, candidate)
+            manifest = dict(baseline=str(baseline), candidate=str(candidate), compare_otlp=False, build_inputs=inputs)
+            (root / 'paired-manifest.json').write_text(json.dumps(manifest))
+            processes = [dict(label=label, assembly=value['assembly'],
+                sha256=value['assembly_sha256'][ASSEMBLIES[0]], core_sha256=value['assembly_sha256'][ASSEMBLIES[1]])
+                for label, value in inputs.items()]
+            verify_process_inputs(root, 'paired', processes, builds)
+            with self.assertRaisesRegex(RuntimeError, 'prepared build'):
+                benchmark_inputs(builds, candidate, baseline)
+            processes[0]['assembly'] = str(candidate)
+            with self.assertRaisesRegex(RuntimeError, 'declared benchmark input'):
+                verify_process_inputs(root, 'paired', processes, builds)
+            otlp = benchmark_inputs(builds, candidate, candidate, compare_otlp=True)
+            self.assertEqual(expected['candidate'], otlp['baseline']['source']['sha'])
+            self.assertEqual(otlp['baseline'], otlp['candidate'])
             (root / 'candidate' / ASSEMBLIES[0]).write_bytes(b'replaced binary')
             with self.assertRaisesRegex(RuntimeError, 'differs'):
                 load_builds(root)
@@ -92,6 +115,22 @@ class BuildIdentityTests(unittest.TestCase):
 
 
 class CommandTests(unittest.TestCase):
+    def test_existing_hermes_wire_is_preserved_and_rejected_before_launch(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            wire = root / 'hermes-wire-sanitized.jsonl'
+            wire.write_text('previous attempt\n')
+            for script, arguments in [('hermes.py', [str(root), 'missing.dll']),
+                                      ('hermes_proxy.py', ['missing.dll', str(wire)])]:
+                with self.subTest(script=script):
+                    (root / 'yaml.py').write_text('')
+                    (root / 'dotenv.py').write_text('def dotenv_values(path): return {}\n')
+                    result = subprocess.run([sys.executable, str(HARNESS / script), *arguments],
+                        env=dict(os.environ, PYTHONPATH=str(root)), capture_output=True, text=True)
+                    self.assertNotEqual(0, result.returncode)
+                    self.assertTrue('already exists' in result.stderr or 'FileExistsError' in result.stderr, result.stderr)
+                    self.assertEqual('previous attempt\n', wire.read_text())
+
     def test_invalid_start_counts_fail_before_opening_infrastructure(self):
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)
@@ -162,6 +201,69 @@ class CommandTests(unittest.TestCase):
                         env=env, capture_output=True, text=True)
                     self.assertEqual(exit_code, result.returncode, result.stderr)
                     self.assertEqual(exit_code, json.loads(result.stdout)['exit_code'])
+
+
+class EvidenceTests(unittest.TestCase):
+    def test_named_trace_exports_merge_without_silent_conflicts(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            first, second = root / 'complete-traces.json', root / 'earlier-traces.json'
+            trace = dict(trace_id='test-a', operation_ms=1)
+            first.write_text(json.dumps([trace]))
+            second.write_text(json.dumps([trace, dict(trace_id='test-b', operation_ms=2)]))
+            self.assertEqual(2, len(load_traces([first, second])))
+            second.write_text(json.dumps([dict(trace, operation_ms=3)]))
+            with self.assertRaisesRegex(RuntimeError, 'Conflicting exports'):
+                load_traces([first, second])
+
+    def test_both_topologies_compare_build_results_and_retain_failures(self):
+        for topology in ['single_session', 'processes']:
+            for variation in ['equal', 'different', 'timeout']:
+                with self.subTest(topology=topology, variation=variation), tempfile.TemporaryDirectory() as temporary:
+                    root = Path(temporary)
+                    (root / 'infra-private.json').write_text(json.dumps(dict(
+                        url='http://127.0.0.1:1', username='test', password='test-only', otlp='http://127.0.0.1:1')))
+                    args = SimpleNamespace(root=root, baseline=root/'baseline.dll', candidate=root/'candidate.dll',
+                        name='check', mode='continue', no_otlp=True, compare_otlp=False, topology=topology,
+                        concurrency=2, blocks=1, tools=['todos.query'], samples=2, sizes=[5], cohort_samples=5)
+
+                    class FakeClient:
+                        def __init__(self, assembly, env):
+                            self.label = assembly.stem
+                            self.process = SimpleNamespace(pid=1)
+                            self.identity = {}
+
+                        async def __aenter__(self):
+                            return self
+
+                        async def __aexit__(self, *args):
+                            pass
+
+                        async def request(self, *args):
+                            return dict(result=dict(tools=[dict(name=tool) for tool in benchmark.TOOLS]))
+
+                        async def call(self, tool, arguments):
+                            failed = variation == 'timeout' and self.label == 'candidate' and 'cursor' in arguments
+                            items = [2 if variation == 'different' and self.label == 'candidate' else 1]
+                            record = dict(outcome='client_timeout' if failed else 'success', is_error=failed,
+                                timed_out=failed, item_sha256=hashlib.sha256(json.dumps(items).encode()).hexdigest(),
+                                items=1, elapsed_ms=1, cpu_ms=0, rss_bytes=1)
+                            response = {} if failed else dict(result=dict(structuredContent=dict(
+                                items=items, pagination=dict(nextCursor='test-cursor'))))
+                            return response, record
+
+                    with patch.object(benchmark, 'Client', FakeClient), patch.object(benchmark, 'load_builds', return_value={}), \
+                            patch.object(benchmark, 'benchmark_inputs', return_value={}):
+                        if variation == 'equal':
+                            asyncio.run(benchmark.run(args))
+                            self.assertTrue((root/'check-summary.json').exists())
+                        else:
+                            with self.assertRaisesRegex(RuntimeError, 'content/order|client_timeout'):
+                                asyncio.run(benchmark.run(args))
+                    rows = [json.loads(line) for line in (root/'check-samples.jsonl').read_text().splitlines()]
+                    self.assertTrue(any(row['label'] == 'candidate' for row in rows))
+                    if variation == 'timeout':
+                        self.assertTrue(rows[-1]['timed_out'])
 
 
 if __name__ == '__main__':

--- a/scripts/observations/mcp-performance/test_harness.py
+++ b/scripts/observations/mcp-performance/test_harness.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Harness regressions; temporary Git repositories and stub external executables."""
+import contextlib
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+
+from build_manifest import capture, finalize, load_builds, source_identity
+
+HARNESS = Path(__file__).resolve().parent
+ASSEMBLIES = ['DotnetAgents.CalDav.Mcp.dll', 'DotnetAgents.CalDav.Core.dll']
+
+
+def git(repository, *args):
+    return subprocess.check_output(['git', '-C', str(repository), *args], stderr=subprocess.DEVNULL).decode().strip()
+
+
+def repository(root):
+    repo = root / 'repository'
+    repo.mkdir()
+    git(repo, 'init', '--quiet')
+    git(repo, 'config', 'user.name', 'Harness Test')
+    git(repo, 'config', 'user.email', 'harness@example.invalid')
+    git(repo, 'config', 'commit.gpgsign', 'false')
+    git(repo, 'remote', 'add', 'origin', 'https://example.invalid/harness.git')
+    (repo / 'Directory.Packages.props').write_text('original')
+    commit(repo)
+    return repo
+
+
+def commit(repo):
+    git(repo, 'add', '.')
+    git(repo, 'commit', '--quiet', '-m', 'Test fixture')
+
+
+def executable(path, contents):
+    path.write_text('#!/bin/sh\n' + contents + '\n')
+    path.chmod(0o755)
+
+
+class BuildIdentityTests(unittest.TestCase):
+    def test_prepared_revisions_survive_later_commits_and_working_directory_changes(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            repo = repository(root)
+            expected = {}
+            for label in ['baseline', 'candidate']:
+                if label == 'candidate':
+                    (repo / 'Directory.Packages.props').write_text('candidate')
+                    commit(repo)
+                expected[label] = git(repo, 'rev-parse', 'HEAD')
+                manifest = root / (label + '-build.json')
+                capture(repo, manifest)
+                assembly_dir = root / label
+                assembly_dir.mkdir()
+                for name in ASSEMBLIES:
+                    (assembly_dir / name).write_bytes(('test-only-' + label + name).encode())
+                finalize(repo, manifest, assembly_dir)
+            (repo / 'Directory.Packages.props').write_text('later revision')
+            commit(repo)
+            with contextlib.chdir(root):
+                builds = load_builds(root)
+            self.assertNotEqual(expected['baseline'], expected['candidate'])
+            for label in expected:
+                self.assertEqual(expected[label], builds[label]['source']['sha'])
+                self.assertFalse(builds[label]['source']['dirty'])
+            (root / 'candidate' / ASSEMBLIES[0]).write_bytes(b'replaced binary')
+            with self.assertRaisesRegex(RuntimeError, 'differs'):
+                load_builds(root)
+
+    def test_staged_and_untracked_changes_are_captured_and_mid_build_edits_rejected(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            repo = repository(root)
+            clean = source_identity(repo)
+            (repo / 'Directory.Packages.props').write_text('staged dependency change')
+            git(repo, 'add', 'Directory.Packages.props')
+            (repo / 'added.cs').write_text('new source')
+            dirty = source_identity(repo)
+            self.assertTrue(dirty['dirty'])
+            self.assertNotEqual(clean['working_tree_patch_sha256'], dirty['working_tree_patch_sha256'])
+            self.assertIn('added.cs', dirty['untracked_file_sha256'])
+            manifest = root / 'candidate-build.json'
+            capture(repo, manifest)
+            (repo / 'added.cs').write_text('changed during build')
+            with self.assertRaisesRegex(RuntimeError, 'Source changed'):
+                finalize(repo, manifest, root)
+
+
+class CommandTests(unittest.TestCase):
+    def test_invalid_start_counts_fail_before_opening_infrastructure(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            for options in [('--samples', '7'), ('--samples', '1'), ('--samples', '0'),
+                            ('--cohort-samples', '0'), ('--blocks', '-1'), ('--concurrency', '2')]:
+                with self.subTest(options=options):
+                    result = subprocess.run([sys.executable, str(HARNESS / 'benchmark.py'), str(root),
+                        'baseline.dll', 'candidate.dll', '--name', 'invalid', '--mode', 'start', *options],
+                        capture_output=True, text=True)
+                    self.assertEqual(2, result.returncode, result.stderr)
+                    self.assertNotIn('Traceback', result.stderr)
+                    self.assertEqual([], list(root.iterdir()))
+
+    def test_package_uses_clean_commit_or_complete_dirty_candidate(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            repo = repository(root)
+            scripts = repo / 'scripts'
+            scripts.mkdir()
+            for name in ['prepare-release-metadata.sh', 'verify-release-package.sh']:
+                (scripts / name).write_text('exit 0\n')
+            (repo / 'src').mkdir()
+            (repo / 'src' / 'removed.cs').write_text('remove in candidate')
+            commit(repo)
+            bin_dir = root / 'bin'
+            bin_dir.mkdir()
+            executable(bin_dir / 'dotnet', 'exit 0')
+            env = dict(os.environ, PATH=str(bin_dir) + os.pathsep + os.environ['PATH'])
+            for dirty in [False, True]:
+                with self.subTest(dirty=dirty):
+                    if dirty:
+                        (repo / 'Directory.Packages.props').write_text('new dependency version')
+                        git(repo, 'add', 'Directory.Packages.props')
+                        (repo / 'src' / 'added.cs').write_text('untracked source')
+                        (repo / 'src' / 'removed.cs').unlink()
+                    output = root / ('dirty' if dirty else 'clean')
+                    output.mkdir()
+                    result = subprocess.run(['bash', str(HARNESS / 'package.sh'), str(output)],
+                        cwd=repo, env=env, capture_output=True, text=True)
+                    self.assertEqual(0, result.returncode, result.stderr)
+                    clone = output / 'package-checkout'
+                    self.assertEqual((repo / 'Directory.Packages.props').read_bytes(),
+                                     (clone / 'Directory.Packages.props').read_bytes())
+                    self.assertEqual(not dirty, (clone / 'src' / 'removed.cs').exists())
+                    if dirty:
+                        self.assertEqual('untracked source', (clone / 'src' / 'added.cs').read_text())
+
+    def test_hermes_exit_status_reaches_the_shell_after_summary(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            source = root / 'source-home'
+            source.mkdir()
+            (source / 'config.yaml').write_text(json.dumps({'model': {'provider': 'openrouter', 'model': 'test'}}))
+            (source / '.env').write_text('OPENROUTER_API_KEY=test-only-placeholder\n')
+            (root / 'infra-private.json').write_text(json.dumps(dict(
+                url='http://127.0.0.1:1', username='test', password='test-only', otlp='http://127.0.0.1:1')))
+            stubs = root / 'stubs'
+            stubs.mkdir()
+            # Replace optional Hermes dependencies; this tests process handling, not the client SDK.
+            (stubs / 'yaml.py').write_text('import json\nsafe_load = json.loads\nsafe_dump = json.dumps\n')
+            (stubs / 'dotenv.py').write_text("def dotenv_values(path): return dict(line.split('=', 1) for line in path.read_text().splitlines())\n")
+            env = dict(os.environ, PATH=str(stubs) + os.pathsep + os.environ['PATH'], PYTHONPATH=str(stubs))
+            for exit_code in [0, 17]:
+                with self.subTest(exit_code=exit_code):
+                    executable(stubs / 'hermes', 'exit ' + str(exit_code))
+                    result = subprocess.run([sys.executable, str(HARNESS / 'hermes.py'), str(root),
+                        str(root / 'candidate.dll'), '--source-home', str(source)],
+                        env=env, capture_output=True, text=True)
+                    self.assertEqual(exit_code, result.returncode, result.stderr)
+                    self.assertEqual(exit_code, json.loads(result.stdout)['exit_code'])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/scripts/observations/mcp-performance/test_harness.py
+++ b/scripts/observations/mcp-performance/test_harness.py
@@ -15,9 +15,11 @@ import xml.etree.ElementTree as ET
 from types import SimpleNamespace
 from unittest.mock import patch
 
-from build_manifest import capture, finalize, load_builds, source_identity, benchmark_inputs, verify_process_inputs
-from aggregate import load_traces, schema_observations
-from infra import radicale_config, save_private_state, verify
+from build_manifest import capture, finalize, load_builds, source_identity, benchmark_inputs, verify_process_inputs, runtime_files
+from aggregate import load_traces, schema_observations, validate_gates
+from infra import radicale_config, save_private_state, verify, expected_counts
+import cleanup as cleanup_module
+import profile as profiling
 import benchmark
 import driver
 
@@ -52,6 +54,15 @@ def executable(path, contents):
     path.chmod(0o755)
 
 
+def runtime_fixture(directory,label):
+    names=ASSEMBLIES+['Example.Dependency.dll']
+    for name in names:
+        (directory/name).write_bytes(('test-only-'+label+name).encode())
+    deps=dict(runtimeTarget=dict(name='test'),targets={'test':{'app':{'runtime':{name:{} for name in names}}}})
+    (directory/'DotnetAgents.CalDav.Mcp.deps.json').write_text(json.dumps(deps))
+    (directory/'DotnetAgents.CalDav.Mcp.runtimeconfig.json').write_text('{}')
+
+
 class BuildIdentityTests(unittest.TestCase):
     def test_prepared_revisions_survive_later_commits_and_working_directory_changes(self):
         with tempfile.TemporaryDirectory() as temporary:
@@ -67,8 +78,7 @@ class BuildIdentityTests(unittest.TestCase):
                 capture(repo, manifest)
                 assembly_dir = root / label
                 assembly_dir.mkdir()
-                for name in ASSEMBLIES:
-                    (assembly_dir / name).write_bytes(('test-only-' + label + name).encode())
+                runtime_fixture(assembly_dir,label)
                 finalize(repo, manifest, assembly_dir)
             (repo / 'Directory.Packages.props').write_text('later revision')
             commit(repo)
@@ -84,6 +94,7 @@ class BuildIdentityTests(unittest.TestCase):
             manifest = dict(baseline=str(baseline), candidate=str(candidate), compare_otlp=False, build_inputs=inputs)
             (root / 'paired-manifest.json').write_text(json.dumps(manifest))
             processes = [dict(label=label, assembly=value['assembly'],
+                runtime_files_sha256=value['runtime_files_sha256'],
                 sha256=value['assembly_sha256'][ASSEMBLIES[0]], core_sha256=value['assembly_sha256'][ASSEMBLIES[1]])
                 for label, value in inputs.items()]
             verify_process_inputs(root, 'paired', processes, builds)
@@ -95,6 +106,17 @@ class BuildIdentityTests(unittest.TestCase):
             otlp = benchmark_inputs(builds, candidate, candidate, compare_otlp=True)
             self.assertEqual(expected['candidate'], otlp['baseline']['source']['sha'])
             self.assertEqual(otlp['baseline'], otlp['candidate'])
+            dependency=root/'candidate'/'Example.Dependency.dll'
+            original=dependency.read_bytes()
+            dependency.write_bytes(b'stale dependency with unchanged first-party assemblies')
+            with self.assertRaisesRegex(RuntimeError,'dependency set differs'):
+                load_builds(root)
+            with self.assertRaisesRegex(RuntimeError,'prepared build'):
+                benchmark_inputs(builds,baseline,candidate)
+            dependency.unlink()
+            with self.assertRaisesRegex(RuntimeError,'Missing app-local runtime dependency'):
+                runtime_files(candidate)
+            dependency.write_bytes(original)
             (root / 'candidate' / ASSEMBLIES[0]).write_bytes(b'replaced binary')
             with self.assertRaisesRegex(RuntimeError, 'differs'):
                 load_builds(root)
@@ -240,15 +262,17 @@ class EvidenceTests(unittest.TestCase):
     def test_schema_observations_require_correct_build_and_identical_workload(self):
         with tempfile.TemporaryDirectory() as temporary:
             root=Path(temporary)
-            builds={label:dict(assembly_sha256={ASSEMBLIES[0]:label}) for label in ['baseline','candidate']}
+            builds={label:dict(assembly_sha256={ASSEMBLIES[0]:label},runtime_files_sha256={'dependency':label})
+                    for label in ['baseline','candidate']}
             sources={label:dict(assemblySha256=label,tool='todos.query',payloadSha256='same-payload',
+                runtimeFilesSha256=builds[label]['runtime_files_sha256'],
                 samples=[dict(elapsedMilliseconds=1,allocatedBytes=100,gen0=0,gen1=0,gen2=0)])
                 for label in builds}
             for label,source in sources.items():
                 (root/('schema-'+label+'.json')).write_text(json.dumps(source))
             self.assertEqual(2,len(schema_observations(root,builds)))
             for field,value in [('assemblySha256','baseline'),('tool','calendar_entities.query'),
-                                ('payloadSha256','different-payload')]:
+                                ('payloadSha256','different-payload'),('runtimeFilesSha256',{'dependency':'stale'})]:
                 with self.subTest(field=field):
                     (root/'schema-candidate.json').write_text(json.dumps(dict(sources['candidate'],**{field:value})))
                     with self.assertRaises(RuntimeError):
@@ -323,6 +347,88 @@ class EvidenceTests(unittest.TestCase):
                         self.assertTrue(rows[-1]['timed_out'])
 
 
+class ProfileTests(unittest.IsolatedAsyncioTestCase):
+    async def test_start_profiles_bound_calls_and_retain_failures(self):
+        for variation in ['success','busy','collector-start-failure']:
+            with self.subTest(variation=variation), tempfile.TemporaryDirectory() as temporary:
+                root=Path(temporary)
+                (root/'infra-private.json').write_text(json.dumps(dict(
+                    url='http://127.0.0.1:1',username='test',password='test',otlp='http://127.0.0.1:1')))
+                clients=[];collectors=[]
+                class FakeClient:
+                    def __init__(self,*args):
+                        self.calls=0;self.closed=False;self.identity={};self.process=SimpleNamespace(pid=1)
+                        clients.append(self)
+                    async def __aenter__(self): return self
+                    async def __aexit__(self,*args): self.closed=True
+                    async def call(self,*args):
+                        self.calls+=1
+                        outcome='busy' if variation=='busy' and self.calls==8 else 'success'
+                        return dict(result=dict(structuredContent=dict(pagination=dict(nextCursor='cursor')))),dict(outcome=outcome)
+                class Collector:
+                    returncode=None
+                    def terminate(self): self.returncode=-15
+                    def kill(self): self.returncode=-9
+                    async def wait(self):
+                        if self.returncode is None: self.returncode=0
+                        return self.returncode
+                async def spawn(*args,**kwargs):
+                    if variation=='collector-start-failure' and collectors: raise OSError('collector unavailable')
+                    process=Collector();collectors.append(process);return process
+                args=SimpleNamespace(root=root,assembly=root/'server.dll',profilers=root,name='capture',
+                                     mode='start',tool='calendar_occurrences.query')
+                with patch.object(profiling,'Client',FakeClient), patch.object(profiling.asyncio,'create_subprocess_exec',side_effect=spawn):
+                    if variation=='success':
+                        await profiling.run(args)
+                    else:
+                        with self.assertRaises((RuntimeError,OSError)):
+                            await profiling.run(args)
+                records=json.loads((root/'capture-profile-samples.json').read_text())
+                identity=json.loads((root/'capture-profile-process.json').read_text())
+                self.assertTrue(clients[0].closed)
+                self.assertTrue(all(p.returncode is not None for p in collectors))
+                self.assertEqual(variation=='success',identity['profile_completed'])
+                if variation=='success':
+                    self.assertEqual(10,clients[0].calls)
+                    self.assertEqual(5,sum(not r['warmup'] for r in records))
+                elif variation=='busy':
+                    self.assertEqual('busy',records[-1]['outcome'])
+
+
+class GateEvidenceTests(unittest.TestCase):
+    def test_complete_gates_are_required_before_aggregation(self):
+        manifest=json.loads((HARNESS.parents[1]/'test-suite-manifest.json').read_text())
+        with tempfile.TemporaryDirectory() as temporary:
+            root=Path(temporary)
+            for item in manifest['artifacts']:
+                trx=ET.Element('TestRun')
+                results=ET.SubElement(trx,'Results')
+                ET.SubElement(results,'UnitTestResult',executionId='execution',testId='test',testName='test',outcome='Passed')
+                definition=ET.SubElement(ET.SubElement(trx,'TestDefinitions'),'UnitTest',id='test')
+                ET.SubElement(definition,'TestMethod',className=item.get('requiredResult',{}).get('className','Synthetic.Tests'))
+                ET.SubElement(ET.SubElement(trx,'TestEntries'),'TestEntry',executionId='execution',testId='test')
+                ET.SubElement(ET.SubElement(trx,'ResultSummary',outcome='Completed'),'Counters',total='1',executed='1',passed='1')
+                (root/item['trx']).write_bytes(ET.tostring(trx))
+                if 'coveragePrefix' in item:
+                    for form in ['cobertura','opencover']:
+                        (root/(item['coveragePrefix']+'.coverage.'+form+'.test.xml')).write_text('<coverage/>')
+            coverage=root/'coverage-report';coverage.mkdir()
+            (coverage/'Cobertura.xml').write_text('<coverage line-rate="1" branch-rate="1"/>')
+            validate_gates(root)
+            strict=root/'strict-preconditions.trx';saved=strict.read_bytes();strict.unlink()
+            with self.assertRaises(RuntimeError): validate_gates(root)
+            strict.write_bytes(saved)
+            core=root/'main-core.trx';original=core.read_bytes()
+            for counter in ['failed','notExecuted','warning']:
+                with self.subTest(counter=counter):
+                    trx=ET.fromstring(original);trx.find('.//Counters').set(counter,'1')
+                    core.write_bytes(ET.tostring(trx))
+                    with self.assertRaises(RuntimeError): validate_gates(root)
+            core.write_bytes(original)
+            (coverage/'Cobertura.xml').write_text('<coverage line-rate="0.1" branch-rate="1"/>')
+            with self.assertRaises(RuntimeError): validate_gates(root)
+
+
 class StartupCleanupTests(unittest.IsolatedAsyncioTestCase):
     async def test_failed_negotiation_reaps_the_child_and_reader_tasks(self):
         for kind,error in [('legacy',AssertionError),('malformed',TypeError),
@@ -360,6 +466,21 @@ else:
 
 
 class InfrastructureTests(unittest.TestCase):
+    def test_cleanup_accepts_the_custom_seed_manifest(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root=Path(temporary);counts=dict(events=2,todos=2,archive=0)
+            (root/'corpus.json').write_text(json.dumps(dict(resources=counts)))
+            (root/'infra-private.json').write_text('{}')
+            (root/'hermes-isolated').mkdir()
+            def remove_owned(path):
+                (path/'infra-private.json').unlink()
+                (path/'cleanup.json').write_text(json.dumps(dict(complete=True)))
+            self.assertEqual(counts,expected_counts(root))
+            with patch.object(cleanup_module,'verify',return_value=counts),patch.object(cleanup_module,'down',side_effect=remove_owned):
+                cleanup_module.cleanup(root)
+            self.assertFalse((root/'hermes-isolated').exists())
+            self.assertEqual(counts,json.loads((root/'cleanup.json').read_text())['final_corpus_before_container_removal'])
+
     def test_private_host_parent_protects_nonroot_container_credentials(self):
         for mask in [0o022,0o077]:
             with self.subTest(umask=mask), tempfile.TemporaryDirectory() as temporary:

--- a/scripts/observations/mcp-performance/test_harness.py
+++ b/scripts/observations/mcp-performance/test_harness.py
@@ -10,11 +10,14 @@ import subprocess
 import sys
 import tempfile
 import unittest
+import stat
+import xml.etree.ElementTree as ET
 from types import SimpleNamespace
 from unittest.mock import patch
 
 from build_manifest import capture, finalize, load_builds, source_identity, benchmark_inputs, verify_process_inputs
-from aggregate import load_traces
+from aggregate import load_traces, schema_observations
+from infra import radicale_config, save_private_state, verify
 import benchmark
 
 HARNESS = Path(__file__).resolve().parent
@@ -155,7 +158,8 @@ class CommandTests(unittest.TestCase):
             root = Path(temporary)
             for options in [('--samples', '7'), ('--samples', '1'), ('--samples', '0'),
                             ('--cohort-samples', '0'), ('--blocks', '-1'), ('--concurrency', '2'),
-                            ('--cohort-samples', '12', '--samples', '12')]:
+                            ('--cohort-samples', '12', '--samples', '12'),
+                            ('--compare-otlp', '--no-otlp')]:
                 with self.subTest(options=options):
                     result = subprocess.run([sys.executable, str(HARNESS / 'benchmark.py'), str(root),
                         'baseline.dll', 'candidate.dll', '--name', 'invalid', '--mode', 'start', *options],
@@ -166,7 +170,7 @@ class CommandTests(unittest.TestCase):
 
     def test_start_count_boundary_reserves_five_warmup_snapshots(self):
         args = SimpleNamespace(blocks=1, samples=11, cohort_samples=11, mode='start',
-                               topology='single_session', concurrency=1)
+                               topology='single_session', concurrency=1, compare_otlp=False, no_otlp=False)
         benchmark.validate_args(args)
         args.samples = args.cohort_samples = 12
         with self.assertRaisesRegex(ValueError, 'at most 11'):
@@ -232,6 +236,23 @@ class CommandTests(unittest.TestCase):
 
 
 class EvidenceTests(unittest.TestCase):
+    def test_schema_observations_require_correct_build_and_identical_workload(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root=Path(temporary)
+            builds={label:dict(assembly_sha256={ASSEMBLIES[0]:label}) for label in ['baseline','candidate']}
+            sources={label:dict(assemblySha256=label,tool='todos.query',payloadSha256='same-payload',
+                samples=[dict(elapsedMilliseconds=1,allocatedBytes=100,gen0=0,gen1=0,gen2=0)])
+                for label in builds}
+            for label,source in sources.items():
+                (root/('schema-'+label+'.json')).write_text(json.dumps(source))
+            self.assertEqual(2,len(schema_observations(root,builds)))
+            for field,value in [('assemblySha256','baseline'),('tool','calendar_entities.query'),
+                                ('payloadSha256','different-payload')]:
+                with self.subTest(field=field):
+                    (root/'schema-candidate.json').write_text(json.dumps(dict(sources['candidate'],**{field:value})))
+                    with self.assertRaises(RuntimeError):
+                        schema_observations(root,builds)
+
     def test_named_trace_exports_merge_without_silent_conflicts(self):
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)
@@ -285,6 +306,13 @@ class EvidenceTests(unittest.TestCase):
                         if variation == 'equal':
                             asyncio.run(benchmark.run(args))
                             self.assertTrue((root/'check-summary.json').exists())
+                            summaries=json.loads((root/'check-summary.json').read_text())
+                            for summary in summaries:
+                                if topology=='single_session':
+                                    self.assertIsNone(summary['mean_cpu_ms'])
+                                    self.assertIn('overlapping',summary['cpu_measurement_scope'])
+                                else:
+                                    self.assertEqual(0,summary['mean_cpu_ms'])
                         else:
                             with self.assertRaisesRegex(RuntimeError, 'content/order|client_timeout'):
                                 asyncio.run(benchmark.run(args))
@@ -292,6 +320,50 @@ class EvidenceTests(unittest.TestCase):
                     self.assertTrue(any(row['label'] == 'candidate' for row in rows))
                     if variation == 'timeout':
                         self.assertTrue(rows[-1]['timed_out'])
+
+
+class InfrastructureTests(unittest.TestCase):
+    def test_private_host_parent_protects_nonroot_container_credentials(self):
+        for mask in [0o022,0o077]:
+            with self.subTest(umask=mask), tempfile.TemporaryDirectory() as temporary:
+                root=Path(temporary)
+                previous=os.umask(mask)
+                try:
+                    state=dict(username='test',password='test-only')
+                    config=radicale_config(root,state)
+                    manifest=root/'infra-private.json'
+                    save_private_state(manifest,state)
+                finally:
+                    os.umask(previous)
+                self.assertEqual(0o700,stat.S_IMODE(config.parent.stat().st_mode))
+                self.assertEqual(0o600,stat.S_IMODE(manifest.stat().st_mode))
+                self.assertEqual(0o755,stat.S_IMODE(config.stat().st_mode))
+                self.assertEqual(0o644,stat.S_IMODE((config/'users').stat().st_mode))
+
+    def test_corpus_verification_rejects_same_count_content_and_membership_changes(self):
+        state=dict(username='test',corpus_etags={
+            'events':{'/test/events/0000.ics':'"event-seed"'},
+            'todos':{'/test/todos/0000.ics':'"todo-seed"'},'archive':{}})
+        observed={name:dict(values) for name,values in state['corpus_etags'].items()}
+        def response(state,method,path,*args):
+            name=path.rstrip('/').split('/')[-1]
+            xml=ET.Element('{DAV:}multistatus')
+            for href,etag in {path:None,**observed[name]}.items():
+                item=ET.SubElement(xml,'{DAV:}response')
+                ET.SubElement(item,'{DAV:}href').text=href
+                if etag:
+                    ET.SubElement(ET.SubElement(item,'{DAV:}prop'),'{DAV:}getetag').text=etag
+            return 207,ET.tostring(xml),{}
+        with patch('infra.request',side_effect=response):
+            self.assertEqual(dict(events=1,todos=1,archive=0),verify(state))
+            observed['events']['/test/events/0000.ics']='"edited-content"'
+            with self.assertRaisesRegex(RuntimeError,'content or membership changed'):
+                verify(state)
+            observed['events']={'/test/events/replacement.ics':'"event-seed"'}
+            with self.assertRaisesRegex(RuntimeError,'content or membership changed'):
+                verify(state)
+            with self.assertRaisesRegex(RuntimeError,'manifest is missing'):
+                verify(dict(username='test'))
 
 
 if __name__ == '__main__':

--- a/scripts/observations/mcp-performance/test_harness.py
+++ b/scripts/observations/mcp-performance/test_harness.py
@@ -16,7 +16,8 @@ from types import SimpleNamespace
 from unittest.mock import patch
 
 from build_manifest import capture, finalize, load_builds, source_identity, benchmark_inputs, verify_process_inputs, runtime_files, prepared_input
-from aggregate import load_traces, schema_observations, validate_gates
+from aggregate import load_traces, schema_observations, validate_gates, join_run
+import aggregate
 from infra import radicale_config, save_private_state, verify, expected_counts
 import cleanup as cleanup_module
 import profile as profiling
@@ -166,6 +167,22 @@ class BuildIdentityTests(unittest.TestCase):
 
 
 class CommandTests(unittest.TestCase):
+    def test_eof_control_requires_empty_streams_success_and_bounded_shutdown(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root=Path(temporary)
+            for code in ['exit 0','echo unexpected','echo diagnostic >&2','exit 17','exec sleep 60']:
+                with self.subTest(code=code):
+                    executable(root/'dotnet',code)
+                    with patch.dict(os.environ,PATH=str(root)+os.pathsep+os.environ['PATH']), \
+                         patch.object(edges,'EOF_TIMEOUT_SECONDS',0.1):
+                        probe=edges.eof_control(root/'server.dll',dict(os.environ))
+                        if code=='exit 0':
+                            asyncio.run(probe)
+                        else:
+                            error=TimeoutError if code=='exec sleep 60' else RuntimeError
+                            with self.assertRaises(error):
+                                asyncio.run(probe)
+
     def test_single_build_commands_reject_wrong_inputs_before_fixture_or_client_access(self):
         with tempfile.TemporaryDirectory() as temporary:
             root=Path(temporary);prepared_fixture(root)
@@ -371,6 +388,19 @@ class CommandTests(unittest.TestCase):
 
 
 class EvidenceTests(unittest.TestCase):
+    def test_missing_trace_matches_cannot_produce_a_successful_aggregate(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root=Path(temporary)
+            (root/'incomplete-processes.jsonl').write_text('')
+            (root/'incomplete-summary.json').write_text(json.dumps([
+                dict(label='baseline',tool='todos.query',size=1,mode='continue')]))
+            sample=dict(label='baseline',tool='todos.query',size=1,warmup=False,block=0,cohort=0,
+                        otlp=True,timestamp_ns=100,elapsed_ms=1,service='test-service')
+            (root/'incomplete-samples.jsonl').write_text(json.dumps(sample)+'\n')
+            with patch.object(aggregate,'verify_process_inputs',return_value={}):
+                with self.assertRaisesRegex(RuntimeError,'Incomplete trace matches.*found 0, expected 1'):
+                    join_run(root,'incomplete',[],{})
+
     def test_schema_observations_require_correct_build_and_identical_workload(self):
         with tempfile.TemporaryDirectory() as temporary:
             root=Path(temporary)
@@ -615,7 +645,7 @@ class PersistedEvidenceTests(unittest.TestCase):
 
 class StartupCleanupTests(unittest.IsolatedAsyncioTestCase):
     async def test_failed_negotiation_reaps_the_child_and_reader_tasks(self):
-        for kind,error in [('legacy',AssertionError),('malformed',TypeError),
+        for kind,error in [('legacy',RuntimeError),('malformed',TypeError),
                            ('timeout',TimeoutError),('cancelled',asyncio.CancelledError)]:
             with self.subTest(kind=kind), tempfile.TemporaryDirectory() as temporary:
                 root=Path(temporary)

--- a/scripts/observations/mcp-performance/verify_hermes.py
+++ b/scripts/observations/mcp-performance/verify_hermes.py
@@ -8,7 +8,7 @@ import urllib.parse
 import xml.etree.ElementTree as ET
 from driver import Client,environment
 from functional import Functional
-from infra import request,verify
+from infra import request,verify,expected_counts
 
 
 async def run(root,assembly):
@@ -34,7 +34,7 @@ async def run(root,assembly):
         await f.call('calendar_resources.delete',dict(revision=snapshot['entityRevision']))
         f.authoritative(href,absent=True)
     (output/'process.json').write_text(json.dumps(c.identity,indent=2))
-    assert verify(state)==dict(events=600,todos=600,archive=0)
+    assert verify(state)==expected_counts(root)
 
 
 if __name__=='__main__':

--- a/scripts/observations/mcp-performance/verify_hermes.py
+++ b/scripts/observations/mcp-performance/verify_hermes.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Verify Hermes's disposable To-do at Radicale, then finish cleanup via direct MRTR."""
+import argparse
+import asyncio
+import json
+from pathlib import Path
+import urllib.parse
+import xml.etree.ElementTree as ET
+from driver import Client,environment
+from functional import Functional
+from infra import request,verify
+
+
+async def run(root,assembly):
+    state=json.loads((root/'infra-private.json').read_text())
+    uid='hermes-perf-20260905-integration'
+    body=f'''<C:calendar-query xmlns:D="DAV:" xmlns:C="urn:ietf:params:xml:ns:caldav"><D:prop>
+<D:getetag/><C:calendar-data/></D:prop><C:filter><C:comp-filter name="VCALENDAR"><C:comp-filter name="VTODO">
+<C:prop-filter name="UID"><C:text-match collation="i;octet">{uid}</C:text-match></C:prop-filter>
+</C:comp-filter></C:comp-filter></C:filter></C:calendar-query>'''
+    status,data,_=request(state,'REPORT','/perftest/todos/',body,{'Depth':'1'})
+    assert status==207
+    matches=[x for x in ET.fromstring(data).findall('{DAV:}response') if uid in ''.join(x.itertext())]
+    checks=[dict(completed='STATUS:COMPLETED' in ''.join(x.itertext()),
+                 summary_patched='SUMMARY:Hermes patched integration' in ''.join(x.itertext())) for x in matches]
+    assert len(checks)==1 and all(checks[0].values()),checks
+    (root/'hermes-authoritative.json').write_text(json.dumps(dict(http_status=status,matching_resources=1,checks=checks),indent=2))
+    output=root/'hermes-direct-cleanup-final';output.mkdir()
+    async with Client(assembly,environment(state,'caldav-perf-hermes-direct-cleanup-final')) as c:
+        f=Functional(output,c,state)
+        href=urllib.parse.urljoin(state['url'],matches[0].findtext('{DAV:}href'))
+        snapshot=await f.read(href)
+        assert snapshot['entityRevision']['entityUid']==uid
+        await f.call('calendar_resources.delete',dict(revision=snapshot['entityRevision']))
+        f.authoritative(href,absent=True)
+    (output/'process.json').write_text(json.dumps(c.identity,indent=2))
+    assert verify(state)==dict(events=600,todos=600,archive=0)
+
+
+if __name__=='__main__':
+    p=argparse.ArgumentParser(description=__doc__)
+    p.add_argument('root',type=Path);p.add_argument('assembly',type=Path)
+    a=p.parse_args();asyncio.run(run(a.root,a.assembly))

--- a/scripts/observations/mcp-performance/verify_hermes.py
+++ b/scripts/observations/mcp-performance/verify_hermes.py
@@ -9,9 +9,12 @@ import xml.etree.ElementTree as ET
 from driver import Client,environment
 from functional import Functional
 from infra import request,verify,expected_counts
+from build_manifest import prepared_input
 
 
 async def run(root,assembly):
+    build_input=prepared_input(root,assembly)
+    assembly=Path(build_input['assembly'])
     state=json.loads((root/'infra-private.json').read_text())
     uid='hermes-perf-20260905-integration'
     body=f'''<C:calendar-query xmlns:D="DAV:" xmlns:C="urn:ietf:params:xml:ns:caldav"><D:prop>
@@ -33,7 +36,7 @@ async def run(root,assembly):
         assert snapshot['entityRevision']['entityUid']==uid
         await f.call('calendar_resources.delete',dict(revision=snapshot['entityRevision']))
         f.authoritative(href,absent=True)
-    (output/'process.json').write_text(json.dumps(c.identity,indent=2))
+    (output/'process.json').write_text(json.dumps(dict(c.identity,build_input=build_input),indent=2))
     assert verify(state)==expected_counts(root)
 
 

--- a/scripts/observations/mcp-performance/verify_hermes.py
+++ b/scripts/observations/mcp-performance/verify_hermes.py
@@ -22,22 +22,26 @@ async def run(root,assembly):
 <C:prop-filter name="UID"><C:text-match collation="i;octet">{uid}</C:text-match></C:prop-filter>
 </C:comp-filter></C:comp-filter></C:filter></C:calendar-query>'''
     status,data,_=request(state,'REPORT','/perftest/todos/',body,{'Depth':'1'})
-    assert status==207
+    if not (status==207):
+        raise RuntimeError('Hermes fixture lookup failed')
     matches=[x for x in ET.fromstring(data).findall('{DAV:}response') if uid in ''.join(x.itertext())]
     checks=[dict(completed='STATUS:COMPLETED' in ''.join(x.itertext()),
                  summary_patched='SUMMARY:Hermes patched integration' in ''.join(x.itertext())) for x in matches]
-    assert len(checks)==1 and all(checks[0].values()),checks
+    if not (len(checks)==1 and all(checks[0].values())):
+        raise RuntimeError('Hermes persisted todo checks failed')
     (root/'hermes-authoritative.json').write_text(json.dumps(dict(http_status=status,matching_resources=1,checks=checks),indent=2))
     output=root/'hermes-direct-cleanup-final';output.mkdir()
     async with Client(assembly,environment(state,'caldav-perf-hermes-direct-cleanup-final')) as c:
         f=Functional(output,c,state)
         href=urllib.parse.urljoin(state['url'],matches[0].findtext('{DAV:}href'))
         snapshot=await f.read(href)
-        assert snapshot['entityRevision']['entityUid']==uid
+        if not (snapshot['entityRevision']['entityUid']==uid):
+            raise RuntimeError('Hermes fixture UID differs')
         await f.call('calendar_resources.delete',dict(revision=snapshot['entityRevision']))
         f.authoritative(href,absent=True)
     (output/'process.json').write_text(json.dumps(dict(c.identity,build_input=build_input),indent=2))
-    assert verify(state)==expected_counts(root)
+    if not (verify(state)==expected_counts(root)):
+        raise RuntimeError('Corpus restoration failed')
 
 
 if __name__=='__main__':

--- a/src/DotnetAgents.CalDav.Mcp/Hosting/CalendarOutputSchemaGuard.cs
+++ b/src/DotnetAgents.CalDav.Mcp/Hosting/CalendarOutputSchemaGuard.cs
@@ -27,7 +27,9 @@ internal static class CalendarOutputSchemaGuard
             JsonSchema.FromText(CalendarToolContract.GetOutputSchema(name).GetRawText()));
         var evaluation = schema.Evaluate(
             result.StructuredContent.Value,
-            new EvaluationOptions { OutputFormat = OutputFormat.List });
+            // The guard consumes only validity. Detailed evaluation trees are neither
+            // returned nor logged, and retaining them scales with the entire page.
+            new EvaluationOptions { OutputFormat = OutputFormat.Flag });
         if (!evaluation.IsValid)
             throw new InvalidOperationException("A Calendar tool returned output that violates its advertised schema.");
     }

--- a/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/CalendarOutputSchemaGuardTests.cs
+++ b/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/CalendarOutputSchemaGuardTests.cs
@@ -1,5 +1,7 @@
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using DotnetAgents.CalDav.Mcp.Hosting;
+using Json.Schema;
 using ModelContextProtocol.Protocol;
 using Shouldly;
 using Xunit;
@@ -8,6 +10,55 @@ namespace DotnetAgents.CalDav.Mcp.Tests.Unit;
 
 public sealed class CalendarOutputSchemaGuardTests
 {
+    [Theory]
+    [InlineData("valid", true)]
+    [InlineData("late-invalid-enum", false)]
+    [InlineData("late-extra-property", false)]
+    [InlineData("late-wrong-revision-kind", false)]
+    [InlineData("late-invalid-percentage", false)]
+    public void Validate_ChecksTheEntirePageAndNestedReferences(string variation, bool valid)
+    {
+        var item = JsonNode.Parse("""
+            {"resultKind":"entity","completionState":"open","percentComplete":0,
+             "completionTarget":{"kind":"direct","entityRevision":{
+               "href":"https://cal.example/todos/one.ics","entityUid":"one",
+               "entityKind":"todo","entityTag":"\"strong\""}},"diagnostics":[]}
+            """)!;
+        var items = new JsonArray(Enumerable.Range(0, 200).Select(_ => item.DeepClone()).ToArray());
+        CorruptLastItem(items[199]!, variation);
+        var result = Result(new JsonObject
+        {
+            ["outcome"] = "success",
+            ["items"] = items,
+            ["diagnostics"] = new JsonArray(),
+            ["excludedIndeterminateCount"] = 0,
+            ["pagination"] = new JsonObject { ["mode"] = "query_result_snapshot", ["nextCursor"] = null },
+            ["temporalEvaluationContext"] = new JsonObject
+            {
+                ["timeZone"] = "America/Sao_Paulo", ["source"] = "configuration"
+            }
+        }.ToJsonString());
+        var schema = JsonSchema.FromText(CalendarToolContract.GetOutputSchema("todos.query").GetRawText());
+        schema.Evaluate(result.StructuredContent!.Value,
+            new EvaluationOptions { OutputFormat = OutputFormat.List }).IsValid.ShouldBe(valid);
+
+        if (valid)
+            Should.NotThrow(() => CalendarOutputSchemaGuard.Validate("todos.query", result));
+        else
+            Should.Throw<InvalidOperationException>(() => CalendarOutputSchemaGuard.Validate("todos.query", result));
+    }
+
+    private static void CorruptLastItem(JsonNode item, string variation)
+    {
+        switch (variation)
+        {
+            case "late-invalid-enum": item["completionState"] = "done"; break;
+            case "late-extra-property": item["completionTarget"]!["extra"] = true; break;
+            case "late-wrong-revision-kind": item["completionTarget"]!["entityRevision"]!["entityKind"] = "event"; break;
+            case "late-invalid-percentage": item["percentComplete"] = 101; break;
+        }
+    }
+
     [Fact]
     public void Validate_AcceptsSchemaValidToolOutput()
     {


### PR DESCRIPTION
The MCP output guard built a detailed JSON Schema evaluation tree for every response, then consumed only `IsValid`. Large query pages paid for diagnostics that were never returned or logged. Use `OutputFormat.Flag` with the same schema evaluation and exception behavior, and add regression cases that reject invalid fields in the final item of a 200-item page.

The paired baseline/candidate experiment used real MCP stdio processes, a deterministic 600-event/600-todo corpus, digest-pinned Radicale and an authenticated Aspire Dashboard. For Continue with 200 items, client p95 fell from 261.6 to 57.0 ms for entities, 307.9 to 75.8 ms for occurrences, and 121.9 to 67.3 ms for todos. All 11,232 measured calls completed without errors or timeouts; results and order matched. Start improved 5.8–7.0%, below the 30% target. These are workload-specific measurements on a shared workstation, not a global latency claim.

Includes the reproducible local harness, a [performance report](https://github.com/Jhonattan-Souza/dotnet-agents-caldav/blob/feat/schema-validation-performance/docs/performance-schema-validation-2026-09-05.md), and [sanitized structured evidence](https://github.com/Jhonattan-Souza/dotnet-agents-caldav/blob/feat/schema-validation-performance/docs/performance-schema-validation-2026-09-05-results.json). Full raw evidence was retained locally; the committed report identifies assembly hashes, sample counts, limitations, and representative trace IDs. The measured baseline is `37cdba56f3c957ee8f241eadf1e55b883e950458`. This PR is rebased onto `180312a`; the historical measurements are not relabeled as benchmarks of the rebased binary.

Validation of the measured candidate: Release build, 3,592 tests without skips, 94.49% line / 86.05% branch coverage, Slopwatch with zero issues, and a local package/install/MCP smoke test. All 23 live tools passed direct-client functional checks. Hermes performed real queries, pagination, and persisted todo mutations; its MRTR continuation remained unsupported, and the direct MCP client completed that flow separately. Aspire API/ZIP exports matched at 124,729 spans. Owned fixtures, containers, volumes, and temporary client configuration were cleaned up.

Validation after rebasing: the local Release build and all 3,570 tests passed without skips, with 94.48% line / 86.04% branch coverage and zero Slopwatch issues. The local gate wrapper was verified against the exact clean source and runtime of `0170f36`. The source-bound package/install/MCP smoke gate passed on `f3c8430`. Subsequent changes affect only the local harness. GitHub CI passed on `79a63b1`; Codex completed code and security re-reviews and reacted with 👍 on that revision.

The harness has 27 regression tests, passing under both normal Python and `python -O`, covering source and runtime attribution, gates, sample counts and limits, result equivalence, process lifecycle cleanup, packaging, telemetry exports, and authoritative mutation checks. All MCP entry points validate the selected prepared build before accessing fixtures, and the Hermes proxy records the complete runtime identity. Additional real checks exercised both concurrency topologies and the same-build OTLP control, all 23 tools with persisted recurrence postconditions, corpus ETags, custom seed cleanup, and the proxy. These checks validate the harness and do not replace the historical paired performance experiment. Owned infrastructure was cleaned up.

Historical shared-session concurrent CPU deltas are identified as overlapping process windows, without per-operation CPU attribution. The report distinguishes the original count-only corpus and HTTP-only recurrence checks from the stronger checks now provided by the harness. Runtime manifests cover declared dependencies and configuration; schema comparisons require the same .NET runtime. Sanitized Hermes metadata uses a restricted model-field allowlist and mode 0600.

Harness evidence checks remain active under optimized Python: EOF rejects either output stream, failure or timeout, and aggregation rejects missing traces. The optimized real 23-tool matrix and all three OTLP EOF controls passed; traces were exported and owned containers cleaned up.
