### PR TITLE
fix: expose complete MCP JSON results and require installation time zone

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ client-specific commands.
 | `CALDAV_CALENDAR_HREFS` | No | Comma-separated exact canonical Calendar href allowlist; omit to discover every Calendar |
 | `CALDAV_DEFAULT_TODO_CALENDAR_NAME` | No | Display name of the default Calendar for To-do operations |
 | `CALDAV_DEFAULT_EVENT_CALENDAR_NAME` | No | Display name of the default Calendar for Event operations |
-| `CALDAV_EVALUATION_TIME_ZONE` | No | Exact IANA zone used as the configured Temporal Evaluation Context for bounded Calendar Entity Starts and every Occurrence or To-do Start; invalid values fail startup and a caller `evaluationTimeZone` override wins |
+| `CALDAV_EVALUATION_TIME_ZONE` | Yes (installation) | Exact IANA zone used as the configured Temporal Evaluation Context for bounded Calendar Entity Starts and every Occurrence or To-do Start; invalid values fail startup and a caller `evaluationTimeZone` override wins. Manual runs may omit it when the call supplies an IANA identifier; To-do Starts require context even without a window |
 | `CALDAV_INTEROPERABILITY_PROFILE` | No | Set to `radicale-3.7.8` only for that verified runtime; otherwise server-authoritative Move fails closed with `unsupported_capability` |
 | `CALDAV_EXPOSE_EXACT_TOOLS` | No | Set to `true` to expose protected exact Calendar Object Resource tools |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | No | Non-empty OTLP endpoint that opts into telemetry export; no exporter is registered when omitted |

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,6 +20,7 @@ describes the shipped tool surface. Find behavioral regressions in
 - [Query module and immutable result snapshots](adr/0004-deep-query-result-snapshot-module.md)
 - [Configured temporal evaluation context](adr/0005-configured-temporal-evaluation-context.md)
 - [Server-authoritative Move](adr/0006-server-authoritative-semantic-move.md)
+- [Complete MCP JSON presentation and result budgets](adr/0007-mcp-json-compatibility-results.md)
 
 ## Historical performance observations
 

--- a/docs/adr/0007-mcp-json-compatibility-results.md
+++ b/docs/adr/0007-mcp-json-compatibility-results.md
@@ -1,0 +1,37 @@
+# ADR 0007: Complete JSON presentation and result budgets
+
+Status: Accepted
+
+All 23 tools return compact JSON in a TextContent block, semantically identical to
+structuredContent, following the MCP structured-content compatibility recommendation:
+https://modelcontextprotocol.io/specification/draft/server/tools#structured-content.
+This includes errors, no_change and confirmation_declined. Resource links, public
+schemas and MRTR remain unchanged. QueryPage.HumanText retains its signature and
+now carries this compatibility JSON.
+
+Finalization enriches validation errors before generating text, checks budgets,
+and observes the facts of the result actually returned. The serialized SDK
+CallToolResult must fit within 4 MiB, including structured JSON, escaped textual
+JSON and additional content blocks. Results are never truncated to fit. Oversized
+results become payload_too_large; mutations retain their actual mutationState.
+The replacement error is measured as well.
+
+The separate 64 KiB human-information budget counts serialized messages,
+violations, additional text and diagnostics at their contract-defined root, snapshot,
+items[*] and items[*].snapshot locations.
+Calendar properties and projections are arbitrary data and are not searched for
+human-looking field names. Compatibility JSON does not consume this budget again.
+
+Snapshot preparation measures the escaped contribution of each serialized item
+once, retaining only its byte count. Page admission includes both representations,
+separators, cursor and fixed metadata, and reduces page size as needed. An empty
+envelope or individual item that cannot fit fails admission. Continue uses stored
+items and does no CalDAV or semantic evaluation.
+
+Installation metadata requires CALDAV_EVALUATION_TIME_ZONE. Manual runs can omit
+it when the caller supplies evaluationTimeZone. The explicit argument takes
+precedence over validated configuration; invalid arguments fail without fallback.
+Missing context identifies both ways to supply an IANA identifier. Every To-do
+Start requires context, including queries without a window. Unbounded Entity
+queries keep their existing rule. No process-zone inference or MRTR is added.
+Historical contracts and source package versions remain unchanged.

--- a/docs/adr/0007-mcp-json-compatibility-results.md
+++ b/docs/adr/0007-mcp-json-compatibility-results.md
@@ -2,7 +2,7 @@
 
 Status: Accepted
 
-All 23 tools return compact JSON in a TextContent block, semantically identical to
+All 27 tools return compact JSON in a TextContent block, semantically identical to
 structuredContent, following the MCP structured-content compatibility recommendation:
 https://modelcontextprotocol.io/specification/draft/server/tools#structured-content.
 This includes errors, no_change and confirmation_declined. Resource links, public

--- a/src/DotnetAgents.CalDav.Core/Internal/CalendarEntityQueryPageCodec.cs
+++ b/src/DotnetAgents.CalDav.Core/Internal/CalendarEntityQueryPageCodec.cs
@@ -19,7 +19,6 @@ internal sealed class CalendarEntityQueryPageCodec : ICalendarQueryPageCodec<Cal
     internal const int MaximumPageSize = 200;
     internal const int MaximumCallToolResultBytes = 4 * 1024 * 1024;
     internal const int MaximumHumanReadableBytes = 64 * 1024;
-    internal const string SuccessText = "Calendar Entity query completed.";
     private static readonly CalendarQueryPageConstraints PageConstraints = new(
         DefaultPageSize,
         MaximumPageSize,
@@ -83,7 +82,7 @@ internal sealed class CalendarEntityQueryPageCodec : ICalendarQueryPageCodec<Cal
             diagnostics,
             plan.NextCursor,
             structuredContent,
-            SuccessText,
+            structuredContent.GetRawText(),
             plan.MeasuredCallToolResultBytes,
             TemporalEvaluationContext: CalendarTemporalEvaluationContextCodec.Decode(
                 snapshot.TemporalEvaluationContextUtf8));
@@ -93,37 +92,10 @@ internal sealed class CalendarEntityQueryPageCodec : ICalendarQueryPageCodec<Cal
         ReadOnlyMemory<byte> diagnosticsUtf8,
         ReadOnlyMemory<byte> temporalEvaluationContextUtf8)
     {
-        var callToolResult = new ArrayBufferWriter<byte>();
-        using (var writer = new Utf8JsonWriter(callToolResult))
-        {
-            writer.WriteStartObject();
-            writer.WritePropertyName("content");
-            writer.WriteStartArray();
-            writer.WriteStartObject();
-            writer.WriteString("type", "text");
-            writer.WriteString("text", SuccessText);
-            writer.WriteEndObject();
-            writer.WriteEndArray();
-            writer.WritePropertyName("structuredContent");
+        var structured = new ArrayBufferWriter<byte>();
+        using (var writer = new Utf8JsonWriter(structured))
             WriteEmptyStructuredContent(writer, diagnosticsUtf8, temporalEvaluationContextUtf8);
-            writer.WriteBoolean("isError", false);
-            writer.WriteNull("_meta");
-            writer.WriteNull("resultType");
-            writer.WriteEndObject();
-        }
-        var human = new ArrayBufferWriter<byte>();
-        using (var writer = new Utf8JsonWriter(human))
-        {
-            writer.WriteStartObject();
-            writer.WritePropertyName("Text");
-            writer.WriteStartArray();
-            writer.WriteStringValue(SuccessText);
-            writer.WriteEndArray();
-            writer.WritePropertyName("Diagnostics");
-            writer.WriteRawValue(diagnosticsUtf8.Span, skipInputValidation: true);
-            writer.WriteEndObject();
-        }
-        return new CalendarQueryFixedBudget(callToolResult.WrittenCount, human.WrittenCount);
+        return CalendarQueryPageBudget.Measure(structured.WrittenMemory, diagnosticsUtf8);
     }
 
     private static void WriteEmptyStructuredContent(

--- a/src/DotnetAgents.CalDav.Core/Internal/CalendarOccurrenceQueryPageCodec.cs
+++ b/src/DotnetAgents.CalDav.Core/Internal/CalendarOccurrenceQueryPageCodec.cs
@@ -12,7 +12,6 @@ internal sealed class CalendarOccurrenceQueryPageCodec : ICalendarQueryPageCodec
     internal const int MaximumPageSize = 200;
     private const int MaximumCallToolResultBytes = 4 * 1024 * 1024;
     private const int MaximumHumanReadableBytes = 64 * 1024;
-    private const string SuccessText = "Occurrence query completed.";
     private static readonly CalendarQueryPageConstraints PageConstraints = new(
         DefaultPageSize,
         MaximumPageSize,
@@ -72,7 +71,7 @@ internal sealed class CalendarOccurrenceQueryPageCodec : ICalendarQueryPageCodec
             diagnostics,
             plan.NextCursor,
             structuredContent,
-            SuccessText,
+            structuredContent.GetRawText(),
             plan.MeasuredCallToolResultBytes,
             TemporalEvaluationContext: CalendarTemporalEvaluationContextCodec.Decode(
                 snapshot.TemporalEvaluationContextUtf8));
@@ -82,37 +81,10 @@ internal sealed class CalendarOccurrenceQueryPageCodec : ICalendarQueryPageCodec
         ReadOnlyMemory<byte> diagnosticsUtf8,
         ReadOnlyMemory<byte> temporalEvaluationContextUtf8)
     {
-        var callToolResult = new ArrayBufferWriter<byte>();
-        using (var writer = new Utf8JsonWriter(callToolResult))
-        {
-            writer.WriteStartObject();
-            writer.WritePropertyName("content");
-            writer.WriteStartArray();
-            writer.WriteStartObject();
-            writer.WriteString("type", "text");
-            writer.WriteString("text", SuccessText);
-            writer.WriteEndObject();
-            writer.WriteEndArray();
-            writer.WritePropertyName("structuredContent");
+        var structured = new ArrayBufferWriter<byte>();
+        using (var writer = new Utf8JsonWriter(structured))
             WriteEmptyStructuredContent(writer, diagnosticsUtf8, temporalEvaluationContextUtf8);
-            writer.WriteBoolean("isError", false);
-            writer.WriteNull("_meta");
-            writer.WriteNull("resultType");
-            writer.WriteEndObject();
-        }
-        var human = new ArrayBufferWriter<byte>();
-        using (var writer = new Utf8JsonWriter(human))
-        {
-            writer.WriteStartObject();
-            writer.WritePropertyName("Text");
-            writer.WriteStartArray();
-            writer.WriteStringValue(SuccessText);
-            writer.WriteEndArray();
-            writer.WritePropertyName("Diagnostics");
-            writer.WriteRawValue(diagnosticsUtf8.Span, skipInputValidation: true);
-            writer.WriteEndObject();
-        }
-        return new CalendarQueryFixedBudget(callToolResult.WrittenCount, human.WrittenCount);
+        return CalendarQueryPageBudget.Measure(structured.WrittenMemory, diagnosticsUtf8);
     }
 
     private static void WriteEmptyStructuredContent(

--- a/src/DotnetAgents.CalDav.Core/Internal/CalendarQueryPageBudget.cs
+++ b/src/DotnetAgents.CalDav.Core/Internal/CalendarQueryPageBudget.cs
@@ -1,0 +1,52 @@
+using System.Buffers;
+using System.Text.Json;
+
+namespace DotnetAgents.CalDav.Core.Internal;
+
+internal static class CalendarQueryPageBudget
+{
+    internal static CalendarQueryFixedBudget Measure(
+        ReadOnlyMemory<byte> structured, ReadOnlyMemory<byte> diagnostics)
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        using (var writer = new Utf8JsonWriter(buffer))
+        {
+            writer.WriteStartObject();
+            writer.WritePropertyName("content");
+            writer.WriteStartArray();
+            writer.WriteStartObject();
+            writer.WriteString("type", "text");
+            writer.WriteString("text", structured.Span);
+            writer.WriteEndObject();
+            writer.WriteEndArray();
+            writer.WritePropertyName("structuredContent");
+            writer.WriteRawValue(structured.Span, skipInputValidation: true);
+            writer.WriteBoolean("isError", false);
+            writer.WriteNull("_meta");
+            writer.WriteNull("resultType");
+            writer.WriteEndObject();
+        }
+        return new CalendarQueryFixedBudget(buffer.WrittenCount, diagnostics.Length);
+    }
+
+    internal static int ItemHumanBytes(ReadOnlyMemory<byte> utf8)
+    {
+        using var document = JsonDocument.Parse(utf8);
+        var item = document.RootElement;
+        if (item.ValueKind != JsonValueKind.Object)
+            return 0;
+        var bytes = DiagnosticBytes(item);
+        if (item.TryGetProperty("snapshot", out var snapshot) && snapshot.ValueKind == JsonValueKind.Object)
+            bytes += DiagnosticBytes(snapshot);
+        return bytes;
+    }
+
+    private static int DiagnosticBytes(JsonElement value) =>
+        value.TryGetProperty("diagnostics", out var diagnostics)
+            ? JsonSerializer.SerializeToUtf8Bytes(diagnostics).Length
+            : 0;
+
+    // Prepared once with each item. No escaped copy is retained in the snapshot.
+    internal static int EscapedBytes(ReadOnlySpan<byte> utf8) =>
+        JsonEncodedText.Encode(utf8).EncodedUtf8Bytes.Length;
+}

--- a/src/DotnetAgents.CalDav.Core/Internal/CalendarQuerySnapshotLifecycle.cs
+++ b/src/DotnetAgents.CalDav.Core/Internal/CalendarQuerySnapshotLifecycle.cs
@@ -28,15 +28,16 @@ internal sealed class CalendarQueryPageAdmission(CalendarQueryCursorIssuer curso
         }
 
         var fixedBudget = pageCodec.MeasureFixedBudget(snapshot);
-        if (fixedBudget.HumanReadableBytes > constraints.MaximumHumanReadableBytes)
+        if (!Fits(fixedBudget.CallToolResultBytes, fixedBudget.HumanReadableBytes, constraints))
         {
             return CalendarQueryPagePlanAdmission.Failure(CalendarQueryFailures.PayloadTooLarge(
-                constraints.HumanReadablePayloadTooLargeMessage));
+                "The query result envelope exceeds the safe payload limit."));
         }
 
         var admitted = new List<StoredCalendarEntityQueryItem>(
             Math.Min(pageSize, snapshot.Items.Length - position));
         var admittedBytes = 0L;
+        var humanBytes = fixedBudget.HumanReadableBytes;
         string? nextCursor = null;
         while (admitted.Count < pageSize && position + admitted.Count < snapshot.Items.Length)
         {
@@ -52,15 +53,16 @@ internal sealed class CalendarQueryPageAdmission(CalendarQueryCursorIssuer curso
                     snapshot.ExpiresAt,
                     snapshot.TemporalEvaluationContextUtf8)
                 : null;
-            var candidateBytes = admittedBytes + stored.JsonByteCount;
+            var candidateBytes = admittedBytes + stored.JsonByteCount + stored.EscapedJsonByteCount;
             var measured = fixedBudget.CallToolResultBytes
                 + candidateBytes
-                + Math.Max(0, candidateCount - 1)
+                + 2 * Math.Max(0, candidateCount - 1)
                 + CursorDelta(candidateCursor);
-            if (measured > constraints.MaximumCallToolResultBytes)
+            if (!Fits(measured, humanBytes + stored.HumanByteCount, constraints))
                 break;
             admitted.Add(stored);
             admittedBytes = candidateBytes;
+            humanBytes += stored.HumanByteCount;
             nextCursor = candidateCursor;
         }
 
@@ -72,7 +74,7 @@ internal sealed class CalendarQueryPageAdmission(CalendarQueryCursorIssuer curso
 
         var measuredBytes = checked((int)(fixedBudget.CallToolResultBytes
             + admittedBytes
-            + Math.Max(0, admitted.Count - 1)
+            + 2 * Math.Max(0, admitted.Count - 1)
             + CursorDelta(nextCursor)));
         return CalendarQueryPagePlanAdmission.Page(new CalendarQueryPagePlan(
             admitted,
@@ -80,7 +82,11 @@ internal sealed class CalendarQueryPageAdmission(CalendarQueryCursorIssuer curso
             measuredBytes));
     }
 
-    private static int CursorDelta(string? cursor) => cursor is null ? 0 : cursor.Length - 2;
+    private static bool Fits(long resultBytes, int humanBytes, CalendarQueryPageConstraints constraints) =>
+        resultBytes <= constraints.MaximumCallToolResultBytes && humanBytes <= constraints.MaximumHumanReadableBytes;
+
+    // Cursors use base64url ASCII. Two quoted copies replace null; the text copy escapes both quotes.
+    private static int CursorDelta(string? cursor) => cursor is null ? 0 : 2 * cursor.Length + 6;
 }
 
 internal sealed class CalendarQuerySnapshotPublication(

--- a/src/DotnetAgents.CalDav.Core/Internal/CalendarQuerySnapshotStore.cs
+++ b/src/DotnetAgents.CalDav.Core/Internal/CalendarQuerySnapshotStore.cs
@@ -203,6 +203,10 @@ internal sealed record CalendarQuerySnapshot(
 internal sealed record StoredCalendarEntityQueryItem(ReadOnlyMemory<byte> JsonUtf8)
 {
     internal int JsonByteCount => JsonUtf8.Length;
+
+    internal int HumanByteCount { get; } = CalendarQueryPageBudget.ItemHumanBytes(JsonUtf8);
+
+    internal int EscapedJsonByteCount { get; } = CalendarQueryPageBudget.EscapedBytes(JsonUtf8.Span);
 }
 
 internal sealed record CalendarQueryStoreAdmission(

--- a/src/DotnetAgents.CalDav.Core/Internal/CalendarTodoQueryPageCodec.cs
+++ b/src/DotnetAgents.CalDav.Core/Internal/CalendarTodoQueryPageCodec.cs
@@ -12,7 +12,6 @@ internal sealed class CalendarTodoQueryPageCodec : ICalendarQueryPageCodec<Calen
     internal const int MaximumPageSize = 200;
     internal const int MaximumCallToolResultBytes = 4 * 1024 * 1024;
     internal const int MaximumHumanReadableBytes = 64 * 1024;
-    internal const string SuccessText = "Compact To-do query completed.";
     private static readonly CalendarQueryPageConstraints PageConstraints = new(
         DefaultPageSize,
         MaximumPageSize,
@@ -50,7 +49,7 @@ internal sealed class CalendarTodoQueryPageCodec : ICalendarQueryPageCodec<Calen
             diagnostics,
             plan.NextCursor,
             structuredContent,
-            SuccessText,
+            structuredContent.GetRawText(),
             plan.MeasuredCallToolResultBytes,
             TemporalEvaluationContext: CalendarTemporalEvaluationContextCodec.Decode(
                 snapshot.TemporalEvaluationContextUtf8));
@@ -58,37 +57,10 @@ internal sealed class CalendarTodoQueryPageCodec : ICalendarQueryPageCodec<Calen
 
     private static CalendarQueryFixedBudget MeasureFixedBudget(CalendarQuerySnapshot snapshot)
     {
-        var callToolResult = new ArrayBufferWriter<byte>();
-        using (var writer = new Utf8JsonWriter(callToolResult))
-        {
-            writer.WriteStartObject();
-            writer.WritePropertyName("content");
-            writer.WriteStartArray();
-            writer.WriteStartObject();
-            writer.WriteString("type", "text");
-            writer.WriteString("text", SuccessText);
-            writer.WriteEndObject();
-            writer.WriteEndArray();
-            writer.WritePropertyName("structuredContent");
+        var structured = new ArrayBufferWriter<byte>();
+        using (var writer = new Utf8JsonWriter(structured))
             WriteStructuredContent(writer, snapshot, [], null);
-            writer.WriteBoolean("isError", false);
-            writer.WriteNull("_meta");
-            writer.WriteNull("resultType");
-            writer.WriteEndObject();
-        }
-        var human = new ArrayBufferWriter<byte>();
-        using (var writer = new Utf8JsonWriter(human))
-        {
-            writer.WriteStartObject();
-            writer.WritePropertyName("Text");
-            writer.WriteStartArray();
-            writer.WriteStringValue(SuccessText);
-            writer.WriteEndArray();
-            writer.WritePropertyName("Diagnostics");
-            writer.WriteRawValue(snapshot.DiagnosticsUtf8.Span, skipInputValidation: true);
-            writer.WriteEndObject();
-        }
-        return new CalendarQueryFixedBudget(callToolResult.WrittenCount, human.WrittenCount);
+        return CalendarQueryPageBudget.Measure(structured.WrittenMemory, snapshot.DiagnosticsUtf8);
     }
 
     private static void WriteStructuredContent(

--- a/src/DotnetAgents.CalDav.Core/InternalsVisibleTo.cs
+++ b/src/DotnetAgents.CalDav.Core/InternalsVisibleTo.cs
@@ -2,3 +2,5 @@ using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("DotnetAgents.CalDav.Core.Tests.Unit")]
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]
+
+[assembly: InternalsVisibleTo("DotnetAgents.CalDav.Mcp.Tests.Unit")]

--- a/src/DotnetAgents.CalDav.Core/Models/CalendarQueryReply.cs
+++ b/src/DotnetAgents.CalDav.Core/Models/CalendarQueryReply.cs
@@ -76,6 +76,7 @@ public abstract record QueryReply<T>
 }
 
 /// <summary>One deterministic page from a completed query result.</summary>
+/// <param name="HumanText">Compact JSON compatibility representation of StructuredContent.</param>
 public sealed record QueryPage<T>(
     IReadOnlyList<T> Items,
     IReadOnlyList<QueryDiagnostic> Diagnostics,

--- a/src/DotnetAgents.CalDav.Core/Services/CalendarQueryAcquisitionExecutor.cs
+++ b/src/DotnetAgents.CalDav.Core/Services/CalendarQueryAcquisitionExecutor.cs
@@ -449,12 +449,12 @@ internal sealed class CalendarTemporalContextResolver(IOptions<CalDavOptions> op
                 ? CalendarTemporalContextResolution.Success(new TemporalEvaluationContext(
                     caller, TemporalEvaluationContextSource.Caller))
                 : CalendarTemporalContextResolution.Failure(CalendarQueryFailures.InvalidInput(
-                    $"The {request.QueryName} query evaluationTimeZone is invalid."));
+                    $"The {request.QueryName} query evaluationTimeZone is invalid; provide a valid IANA time zone identifier in evaluationTimeZone."));
         }
         return options.Value.EvaluationTimeZone is { } configured && IanaTimeZoneIds.IsValid(configured)
             ? CalendarTemporalContextResolution.Success(new TemporalEvaluationContext(
                 configured, TemporalEvaluationContextSource.Configuration))
             : CalendarTemporalContextResolution.Failure(CalendarQueryFailures.InvalidInput(
-                $"A bounded {request.QueryName} query requires a Temporal Evaluation Context."));
+                $"The {request.QueryName} query requires a Temporal Evaluation Context; provide an IANA time zone identifier in evaluationTimeZone or configure CALDAV_EVALUATION_TIME_ZONE."));
     }
 }

--- a/src/DotnetAgents.CalDav.Mcp/.mcp/server.json
+++ b/src/DotnetAgents.CalDav.Mcp/.mcp/server.json
@@ -47,8 +47,8 @@
         },
         {
           "name": "CALDAV_EVALUATION_TIME_ZONE",
-          "description": "Explicit IANA time zone used as the configured Temporal Evaluation Context for bounded Calendar Entity Starts and every Occurrence or To-do Start (optional)",
-          "isRequired": false
+          "description": "Explicit IANA time zone used as the configured Temporal Evaluation Context for bounded Calendar Entity Starts and every Occurrence or To-do Start, including To-do queries without a window",
+          "isRequired": true
         },
         {
           "name": "CALDAV_INTEROPERABILITY_PROFILE",

--- a/src/DotnetAgents.CalDav.Mcp/Contracts/mcp-tool-catalog.json
+++ b/src/DotnetAgents.CalDav.Mcp/Contracts/mcp-tool-catalog.json
@@ -2864,8 +2864,8 @@
     },
     {
       "name": "CALDAV_EVALUATION_TIME_ZONE",
-      "required": false,
-      "description": "Explicit IANA zone for bounded Calendar Entity Starts and every Occurrence or To-do Start under the configured Temporal Evaluation Context"
+      "required": true,
+      "description": "Explicit IANA zone for bounded Calendar Entity Starts and every Occurrence or To-do Start, including To-do queries without a window under the configured Temporal Evaluation Context"
     },
     {
       "name": "CALDAV_INTEROPERABILITY_PROFILE",
@@ -2993,7 +2993,7 @@
         "idempotentHint": true,
         "openWorldHint": true
       },
-      "description": "Start one Calendar Entity query or continue its immutable Query Result Snapshot. A bounded Start requires an explicit IANA Temporal Evaluation Context from evaluationTimeZone or validated configuration; Continue repeats the frozen context without CalDAV or semantic work."
+      "description": "Start one Calendar Entity query or continue its immutable Query Result Snapshot. A bounded Start requires an explicit IANA Temporal Evaluation Context from evaluationTimeZone or validated CALDAV_EVALUATION_TIME_ZONE configuration; Continue repeats the frozen context without CalDAV or semantic work."
     },
     {
       "name": "calendar_occurrences.query",
@@ -3013,7 +3013,7 @@
         "idempotentHint": true,
         "openWorldHint": true
       },
-      "description": "Start one bounded Occurrence query or continue its immutable Query Result Snapshot. Start evaluates recurrence once under an explicit IANA Temporal Evaluation Context from evaluationTimeZone or validated configuration; Continue accepts only cursor and optional pageSize and performs no CalDAV or semantic work."
+      "description": "Start one bounded Occurrence query or continue its immutable Query Result Snapshot. Start evaluates recurrence once under an explicit IANA Temporal Evaluation Context from evaluationTimeZone or validated CALDAV_EVALUATION_TIME_ZONE configuration; Continue accepts only cursor and optional pageSize and performs no CalDAV or semantic work."
     },
     {
       "name": "todos.query",
@@ -3033,7 +3033,7 @@
         "idempotentHint": true,
         "openWorldHint": true
       },
-      "description": "Start one compact To-do query or continue its immutable Query Result Snapshot. A Start resolves an explicit IANA Temporal Evaluation Context before CalDAV work and uses one VTODO-only authoritative corpus; Continue repeats the frozen page context without CalDAV or semantic work."
+      "description": "Start one compact To-do query or continue its immutable Query Result Snapshot. Every Start, including queries without a window, requires an explicit IANA Temporal Evaluation Context from evaluationTimeZone or validated CALDAV_EVALUATION_TIME_ZONE configuration before CalDAV work and uses one VTODO-only authoritative corpus; Continue repeats the frozen page context without CalDAV or semantic work."
     },
     {
       "name": "calendar_resources.get",

--- a/src/DotnetAgents.CalDav.Mcp/Hosting/CalDavEnvironmentMapper.cs
+++ b/src/DotnetAgents.CalDav.Mcp/Hosting/CalDavEnvironmentMapper.cs
@@ -27,6 +27,7 @@ public static class CalDavEnvironmentMapper
             options.CalendarHrefs = getEnv("CALDAV_CALENDAR_HREFS");
             options.DefaultTodoCalendarName = getEnv("CALDAV_DEFAULT_TODO_CALENDAR_NAME");
             options.DefaultEventCalendarName = getEnv("CALDAV_DEFAULT_EVENT_CALENDAR_NAME");
+            // Installation requires this value; manual callers may supply evaluationTimeZone per call.
             options.EvaluationTimeZone = getEnv("CALDAV_EVALUATION_TIME_ZONE");
             options.InteroperabilityProfile = getEnv("CALDAV_INTEROPERABILITY_PROFILE");
         };

--- a/src/DotnetAgents.CalDav.Mcp/Hosting/CalendarExecutionPolicy.cs
+++ b/src/DotnetAgents.CalDav.Mcp/Hosting/CalendarExecutionPolicy.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using DotnetAgents.CalDav.Core.Models;
 using DotnetAgents.CalDav.Core.Services;
+using DotnetAgents.CalDav.Mcp.Tools;
 using Microsoft.Extensions.DependencyInjection;
 using ModelContextProtocol;
 using ModelContextProtocol.Protocol;
@@ -278,13 +279,11 @@ internal static class CalendarExecutionPolicy
 
     internal static CallToolResult CreateBusyResult(bool mutation)
     {
-        CalendarTelemetry.ObserveStructuredError(new CalendarStructuredErrorFacts(
+        var facts = new CalendarStructuredErrorFacts(
             CalendarTelemetryErrorCode.Busy,
             CalendarTelemetryErrorCategory.LimitsAndAdmission,
             CalendarTelemetryErrorPhase.AdmissionAndPayload,
-            true));
-        if (mutation)
-            CalendarTelemetry.ObserveMutationState(CalendarMutationState.NotAttempted);
+            true);
         var structured = new Dictionary<string, object?>
         {
             ["code"] = "busy",
@@ -296,21 +295,21 @@ internal static class CalendarExecutionPolicy
         };
         if (mutation)
             structured["mutationState"] = "not_attempted";
-        return new CallToolResult
+        return new CalendarToolResult(new CallToolResult
         {
             IsError = true,
             StructuredContent = JsonSerializer.SerializeToElement(structured),
-            Content = [new TextContentBlock { Text = "Calendar operation admission failed." }]
-        };
+            Content = []
+        }, new CalendarTerminalFacts(facts, mutation ? CalendarMutationState.NotAttempted : null)).FinalizeResult();
     }
 
     internal static CallToolResult CreateDeadlineResult(bool mutation)
     {
-        CalendarTelemetry.ObserveStructuredError(new CalendarStructuredErrorFacts(
+        var facts = new CalendarStructuredErrorFacts(
             CalendarTelemetryErrorCode.LimitExhausted,
             CalendarTelemetryErrorCategory.LimitsAndAdmission,
             CalendarTelemetryErrorPhase.Execution,
-            false));
+            false);
         var structured = new Dictionary<string, object?>
         {
             ["code"] = "limit_exhausted",
@@ -324,12 +323,12 @@ internal static class CalendarExecutionPolicy
         // Lower layers return a more specific state when they can; the only safe fallback here is unknown.
         if (mutation)
             structured["mutationState"] = "unknown";
-        return new CallToolResult
+        return new CalendarToolResult(new CallToolResult
         {
             IsError = true,
             StructuredContent = JsonSerializer.SerializeToElement(structured),
-            Content = [new TextContentBlock { Text = "Calendar operation exceeded its execution budget." }]
-        };
+            Content = []
+        }, new CalendarTerminalFacts(facts, mutation ? CalendarMutationState.Unknown : null)).FinalizeResult();
     }
 }
 

--- a/src/DotnetAgents.CalDav.Mcp/Hosting/StrictToolInputGuard.cs
+++ b/src/DotnetAgents.CalDav.Mcp/Hosting/StrictToolInputGuard.cs
@@ -132,7 +132,7 @@ internal static class StrictToolInputGuard
         var violations = evidence.Violations.Count > 0
             ? evidence.Violations
             : DefaultViolations(evidence);
-        return CalendarErrorViolations.Attach(createError(false), violations);
+        return CalendarToolResult.WithViolations(() => createError(false), violations);
     }
 
     private static IReadOnlyList<CalendarInputViolation> DefaultViolations(StrictToolInputEvidence evidence)

--- a/src/DotnetAgents.CalDav.Mcp/Tools/CalendarEntityTools.cs
+++ b/src/DotnetAgents.CalDav.Mcp/Tools/CalendarEntityTools.cs
@@ -33,7 +33,7 @@ public sealed class CalendarEntityTools
         OpenWorld = true,
         UseStructuredContent = true,
         OutputSchemaType = typeof(CalendarEntityQuerySuccessResult)),
-     Description("Start one Calendar Entity query or continue its immutable Query Result Snapshot. A bounded Start requires an explicit IANA Temporal Evaluation Context from evaluationTimeZone or validated configuration; Continue repeats the frozen context without CalDAV or semantic work.")]
+     Description("Start one Calendar Entity query or continue its immutable Query Result Snapshot. A bounded Start requires an explicit IANA Temporal Evaluation Context from evaluationTimeZone or validated CALDAV_EVALUATION_TIME_ZONE configuration; Continue repeats the frozen context without CalDAV or semantic work.")]
     public Task<CallToolResult> QueryAsync(
         RequestContext<CallToolRequestParams> requestContext,
         CancellationToken cancellationToken) => QueryRawAsync(requestContext.Params?.Arguments, cancellationToken);
@@ -65,7 +65,7 @@ public sealed class CalendarEntityTools
         payloadTooLarge ? QueryFailureCategory.LimitsAndAdmission : QueryFailureCategory.Input,
         payloadTooLarge
             ? "The query arguments exceed the safe payload limit."
-            : "The Calendar Entity query input is invalid.",
+            : "The Calendar Entity query input is invalid. If evaluationTimeZone is supplied, provide a valid IANA time zone identifier.",
         false,
         payloadTooLarge ? QueryFailurePhase.AdmissionAndPayload : QueryFailurePhase.SchemaLexicalDiscriminator));
 

--- a/src/DotnetAgents.CalDav.Mcp/Tools/CalendarOccurrenceTools.cs
+++ b/src/DotnetAgents.CalDav.Mcp/Tools/CalendarOccurrenceTools.cs
@@ -31,7 +31,7 @@ public sealed class CalendarOccurrenceTools
         OpenWorld = true,
         UseStructuredContent = true,
         OutputSchemaType = typeof(CalendarOccurrenceQuerySuccessResult)),
-     Description("Start one bounded Occurrence query or continue its immutable Query Result Snapshot. Start evaluates recurrence once under an explicit IANA Temporal Evaluation Context from evaluationTimeZone or validated configuration; Continue accepts only cursor and optional pageSize and performs no CalDAV or semantic work.")]
+     Description("Start one bounded Occurrence query or continue its immutable Query Result Snapshot. Start evaluates recurrence once under an explicit IANA Temporal Evaluation Context from evaluationTimeZone or validated CALDAV_EVALUATION_TIME_ZONE configuration; Continue accepts only cursor and optional pageSize and performs no CalDAV or semantic work.")]
     public Task<CallToolResult> QueryAsync(
         RequestContext<CallToolRequestParams> requestContext,
         CancellationToken cancellationToken) => QueryRawAsync(requestContext.Params?.Arguments, cancellationToken);
@@ -58,7 +58,7 @@ public sealed class CalendarOccurrenceTools
         payloadTooLarge ? QueryFailureCategory.LimitsAndAdmission : QueryFailureCategory.Input,
         payloadTooLarge
             ? "The Occurrence query arguments exceed the safe payload limit."
-            : "The Occurrence query input is invalid.",
+            : "The Occurrence query input is invalid. If evaluationTimeZone is supplied, provide a valid IANA time zone identifier.",
         false,
         payloadTooLarge ? QueryFailurePhase.AdmissionAndPayload : QueryFailurePhase.SchemaLexicalDiscriminator));
 

--- a/src/DotnetAgents.CalDav.Mcp/Tools/CalendarQueryToolSupport.cs
+++ b/src/DotnetAgents.CalDav.Mcp/Tools/CalendarQueryToolSupport.cs
@@ -97,13 +97,40 @@ internal static class CalendarQueryToolSupport
         CallToolResult result,
         Func<int, bool, CallToolResult> createPayloadError)
     {
+        ApplyCompatibilityText(result);
         var humanReadableBytes = MeasureHumanReadableResult(result);
-        if (humanReadableBytes > MaximumHumanReadableBytes)
-            return createPayloadError(humanReadableBytes, true);
         var observedBytes = MeasureResult(result);
-        return observedBytes <= MaximumStructuredResultBytes
-            ? result
-            : createPayloadError(observedBytes, false);
+        if (humanReadableBytes <= MaximumHumanReadableBytes && observedBytes <= MaximumStructuredResultBytes)
+            return result;
+        var humanReadable = humanReadableBytes > MaximumHumanReadableBytes;
+        var replacement = createPayloadError(humanReadable ? humanReadableBytes : observedBytes, humanReadable);
+        ApplyCompatibilityText(replacement);
+        if (MeasureHumanReadableResult(replacement) > MaximumHumanReadableBytes
+            || MeasureResult(replacement) > MaximumStructuredResultBytes)
+            throw new InvalidOperationException("The payload-limit error exceeds the result budget.");
+        return replacement;
+    }
+
+    internal static void ApplyCompatibilityText(CallToolResult result)
+    {
+        if (result.StructuredContent is not { } structured)
+            return;
+        result.Content = [new TextContentBlock { Text = structured.GetRawText() },
+            .. AdditionalContent(result)];
+    }
+
+    private static IEnumerable<ContentBlock> AdditionalContent(CallToolResult result)
+    {
+        var replacedText = false;
+        foreach (var block in result.Content)
+        {
+            if (block is TextContentBlock && !replacedText)
+            {
+                replacedText = true;
+                continue;
+            }
+            yield return block;
+        }
     }
 
     private static bool TryCreateNameScope(
@@ -179,16 +206,34 @@ internal static class CalendarQueryToolSupport
 
     internal static int MeasureHumanReadableResult(CallToolResult result)
     {
-        var diagnostics = result.StructuredContent is { ValueKind: JsonValueKind.Object } structured
-            && structured.TryGetProperty("diagnostics", out var value)
-            ? value
-            : JsonSerializer.SerializeToElement(Array.Empty<object>());
-        return JsonSerializer.SerializeToUtf8Bytes(new CalendarHumanReadableBudget(
-            result.Content.OfType<TextContentBlock>().Select(block => block.Text).ToArray(),
-            diagnostics)).Length;
+        if (result.StructuredContent is not { ValueKind: JsonValueKind.Object } structured)
+            return JsonSerializer.SerializeToUtf8Bytes(result.Content.OfType<TextContentBlock>()
+                .Select(block => block.Text)).Length;
+        var bytes = MeasureHumanFields(structured) + MeasureSnapshotDiagnostics(structured);
+        if (structured.TryGetProperty("items", out var items) && items.ValueKind == JsonValueKind.Array)
+            bytes += items.EnumerateArray().Sum(MeasureItemDiagnostics);
+        return bytes + result.Content.OfType<TextContentBlock>().Skip(1)
+            .Sum(block => JsonSerializer.SerializeToUtf8Bytes(block.Text).Length);
     }
 
-    private sealed record CalendarHumanReadableBudget(
-        IReadOnlyList<string> Text,
-        JsonElement Diagnostics);
+    private static int MeasureItemDiagnostics(JsonElement item) => item.ValueKind == JsonValueKind.Object
+        ? MeasureField(item, "diagnostics") + MeasureSnapshotDiagnostics(item)
+        : 0;
+
+    private static int MeasureSnapshotDiagnostics(JsonElement structured)
+    {
+        if (structured.TryGetProperty("snapshot", out var snapshot)
+            && snapshot.ValueKind == JsonValueKind.Object)
+            return MeasureField(snapshot, "diagnostics");
+        return 0;
+    }
+
+    private static int MeasureHumanFields(JsonElement structured) =>
+        MeasureField(structured, "message") + MeasureField(structured, "violations")
+        + MeasureField(structured, "diagnostics");
+
+    private static int MeasureField(JsonElement structured, string name) =>
+        structured.TryGetProperty(name, out var value)
+            ? JsonSerializer.SerializeToUtf8Bytes(value).Length
+            : 0;
 }

--- a/src/DotnetAgents.CalDav.Mcp/Tools/CalendarTodoTools.cs
+++ b/src/DotnetAgents.CalDav.Mcp/Tools/CalendarTodoTools.cs
@@ -37,7 +37,7 @@ public sealed class CalendarTodoTools
         OpenWorld = true,
         UseStructuredContent = true,
         OutputSchemaType = typeof(CalendarTodoQuerySuccessResult)),
-     Description("Start one compact To-do query or continue its immutable Query Result Snapshot. A Start resolves an explicit IANA Temporal Evaluation Context before CalDAV work and uses one VTODO-only authoritative corpus; Continue repeats the frozen page context without CalDAV or semantic work.")]
+     Description("Start one compact To-do query or continue its immutable Query Result Snapshot. Every Start, including queries without a window, requires an explicit IANA Temporal Evaluation Context from evaluationTimeZone or validated CALDAV_EVALUATION_TIME_ZONE configuration before CalDAV work and uses one VTODO-only authoritative corpus; Continue repeats the frozen page context without CalDAV or semantic work.")]
     public Task<CallToolResult> QueryAsync(
         RequestContext<CallToolRequestParams> requestContext,
         CancellationToken cancellationToken) => QueryRawAsync(requestContext.Params?.Arguments, cancellationToken);
@@ -69,7 +69,7 @@ public sealed class CalendarTodoTools
         payloadTooLarge ? QueryFailureCategory.LimitsAndAdmission : QueryFailureCategory.Input,
         payloadTooLarge
             ? "The To-do query arguments exceed the safe payload limit."
-            : "The To-do query input is invalid.",
+            : "The To-do query input is invalid. If evaluationTimeZone is supplied, provide a valid IANA time zone identifier.",
         false,
         payloadTooLarge ? QueryFailurePhase.AdmissionAndPayload : QueryFailurePhase.SchemaLexicalDiscriminator));
 

--- a/src/DotnetAgents.CalDav.Mcp/Tools/CalendarToolResult.cs
+++ b/src/DotnetAgents.CalDav.Mcp/Tools/CalendarToolResult.cs
@@ -1,3 +1,5 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
 using DotnetAgents.CalDav.Core.Models;
 using DotnetAgents.CalDav.Mcp.Hosting;
 using ModelContextProtocol.Protocol;
@@ -37,15 +39,30 @@ internal readonly record struct CalendarToolResult(
         CalendarMutationState mutationState) =>
         new(value, new CalendarTerminalFacts(error, mutationState));
 
-    internal CallToolResult FinalizeResult()
+    private static readonly AsyncLocal<IReadOnlyList<CalendarInputViolation>?> PendingViolations = new();
+
+    internal static CallToolResult WithViolations(
+        Func<CallToolResult> createResult, IReadOnlyList<CalendarInputViolation> violations)
     {
-        Facts.Observe();
-        return Value;
+        var previous = PendingViolations.Value;
+        PendingViolations.Value = violations;
+        try
+        {
+            return createResult();
+        }
+        finally
+        {
+            PendingViolations.Value = previous;
+        }
     }
+
+    internal CallToolResult FinalizeResult() => FinalizeBounded(CreatePayloadError);
 
     internal CallToolResult FinalizeBounded(
         Func<int, bool, CalendarToolResult> createPayloadError)
     {
+        if (PendingViolations.Value is { } violations)
+            CalendarErrorViolations.Attach(Value, violations);
         var terminal = this;
         var bounded = CalendarQueryToolSupport.EnsureBoundedResult(
             Value,
@@ -56,5 +73,34 @@ internal readonly record struct CalendarToolResult(
             });
         terminal.Facts.Observe();
         return bounded;
+    }
+
+    private CalendarToolResult CreatePayloadError(int byteCount, bool humanReadable)
+    {
+        var facts = new CalendarStructuredErrorFacts(
+            CalendarTelemetryErrorCode.PayloadTooLarge,
+            CalendarTelemetryErrorCategory.LimitsAndAdmission,
+            CalendarTelemetryErrorPhase.AdmissionAndPayload,
+            false);
+        var body = new JsonObject
+        {
+            ["code"] = facts.CodeName,
+            ["category"] = facts.CategoryName,
+            ["phase"] = facts.PhaseName,
+            ["retryable"] = false,
+            ["message"] = humanReadable
+                ? "The human-readable result exceeds the safe payload limit."
+                : "The serialized result exceeds the safe payload limit.",
+            ["limits"] = new JsonObject { ["byteCount"] = byteCount }
+        };
+        if (Value.StructuredContent is { } structured
+            && structured.TryGetProperty("mutationState", out var mutation))
+            body["mutationState"] = mutation.GetString();
+        return new CalendarToolResult(new CallToolResult
+        {
+            IsError = true,
+            StructuredContent = JsonSerializer.SerializeToElement(body),
+            Content = []
+        }, new CalendarTerminalFacts(facts, Facts.MutationState));
     }
 }

--- a/tests/DotnetAgents.CalDav.Core.Tests.Unit/Internal/CalendarEntityQueryPageCodecTests.cs
+++ b/tests/DotnetAgents.CalDav.Core.Tests.Unit/Internal/CalendarEntityQueryPageCodecTests.cs
@@ -15,7 +15,7 @@ public sealed class CalendarEntityQueryPageCodecTests
     private static readonly DateTimeOffset Now = new(2026, 8, 23, 12, 0, 0, TimeSpan.Zero);
 
     [Fact]
-    public void ActualAccountantAdmitsExactlyFourMiBAndRejectsOneByteMore()
+    public void ActualAccountantAdmitsNearFourMiBAndRejectsNextCharacter()
     {
         var codec = Codec();
         var temporalContext = CalendarTemporalEvaluationContextCodec.Encode(new TemporalEvaluationContext(
@@ -26,12 +26,13 @@ public sealed class CalendarEntityQueryPageCodecTests
         var initialPlan = admission.Plan(initial, 0, 1, codec, CancellationToken.None).Value!;
         var padding = CalendarEntityQueryPageCodec.MaximumCallToolResultBytes
             - initialPlan.MeasuredCallToolResultBytes;
+        padding /= 2;
         var exact = Snapshot(Json(new string('x', padding + 1)), temporalContext);
 
         var admitted = admission.Plan(exact, 0, 1, codec, CancellationToken.None);
         admitted.Error.ShouldBeNull();
         admitted.Value!.MeasuredCallToolResultBytes.ShouldBe(
-            CalendarEntityQueryPageCodec.MaximumCallToolResultBytes);
+            initialPlan.MeasuredCallToolResultBytes + 2 * padding);
         var page = codec.Materialize(exact, admitted.Value);
         page.TemporalEvaluationContext.ShouldBe(new TemporalEvaluationContext(
             "America/Sao_Paulo",

--- a/tests/DotnetAgents.CalDav.Core.Tests.Unit/Internal/CalendarTemporalContextResolverTests.cs
+++ b/tests/DotnetAgents.CalDav.Core.Tests.Unit/Internal/CalendarTemporalContextResolverTests.cs
@@ -1,0 +1,38 @@
+using DotnetAgents.CalDav.Core.Configuration;
+using DotnetAgents.CalDav.Core.Models;
+using DotnetAgents.CalDav.Core.Services;
+using Microsoft.Extensions.Options;
+using Shouldly;
+using Xunit;
+
+namespace DotnetAgents.CalDav.Core.Tests.Unit.Internal;
+
+public sealed class CalendarTemporalContextResolverTests
+{
+    [Theory]
+    [InlineData(null, null, null)]
+    [InlineData("invalid-zone", "Europe/London", null)]
+    [InlineData("America/Sao_Paulo", null, "America/Sao_Paulo")]
+    [InlineData("America/Sao_Paulo", "Europe/London", "America/Sao_Paulo")]
+    [InlineData(null, "Europe/London", "Europe/London")]
+    public void RequiredContextUsesCallerThenConfiguration(string? caller, string? configured, string? expected)
+    {
+        var resolver = new CalendarTemporalContextResolver(Options.Create(new CalDavOptions
+        {
+            EvaluationTimeZone = configured
+        }));
+        var result = resolver.Resolve(new CalendarTemporalContextRequest(true, caller, "To-do"));
+        if (expected is not null)
+        {
+            result.Context!.TimeZone.ShouldBe(expected);
+            result.Error.ShouldBeNull();
+            return;
+        }
+        result.Error!.Code.ShouldBe(QueryFailureCode.InvalidInput);
+        result.Error.Message.ShouldContain("IANA");
+        result.Error.Message.ShouldContain("evaluationTimeZone");
+        result.Error.Message.ShouldNotContain("bounded");
+        if (caller is null)
+            result.Error.Message.ShouldContain("CALDAV_EVALUATION_TIME_ZONE");
+    }
+}

--- a/tests/DotnetAgents.CalDav.Core.Tests.Unit/Internal/CalendarTodoQueryPageCodecTests.cs
+++ b/tests/DotnetAgents.CalDav.Core.Tests.Unit/Internal/CalendarTodoQueryPageCodecTests.cs
@@ -14,7 +14,7 @@ public sealed class CalendarTodoQueryPageCodecTests
     private static readonly DateTimeOffset Now = new(2026, 8, 23, 12, 0, 0, TimeSpan.Zero);
 
     [Fact]
-    public void ActualAccountantAdmitsExactlyFourMiBAndRejectsOneByteMore()
+    public void ActualAccountantAdmitsNearFourMiBAndRejectsNextCharacter()
     {
         var codec = Codec();
         var initial = Snapshot(Json("x"));
@@ -22,13 +22,14 @@ public sealed class CalendarTodoQueryPageCodecTests
         var initialPlan = admission.Plan(initial, 0, 1, codec, CancellationToken.None).Value!;
         var padding = CalendarTodoQueryPageCodec.MaximumCallToolResultBytes
             - initialPlan.MeasuredCallToolResultBytes;
+        padding /= 2;
         var exact = Snapshot(Json(new string('x', padding + 1)));
 
         var admitted = admission.Plan(exact, 0, 1, codec, CancellationToken.None);
 
         admitted.Error.ShouldBeNull();
         admitted.Value!.MeasuredCallToolResultBytes.ShouldBe(
-            CalendarTodoQueryPageCodec.MaximumCallToolResultBytes);
+            initialPlan.MeasuredCallToolResultBytes + 2 * padding);
         var page = CalendarTodoQueryPageCodec.Materialize(exact, admitted.Value);
         page.StructuredContent.GetProperty("excludedIndeterminateCount").GetInt32().ShouldBe(7);
         page.TemporalEvaluationContext.ShouldBe(new TemporalEvaluationContext(

--- a/tests/DotnetAgents.CalDav.Core.Tests.Unit/Services/CalendarTodoQueryModuleTests.cs
+++ b/tests/DotnetAgents.CalDav.Core.Tests.Unit/Services/CalendarTodoQueryModuleTests.cs
@@ -41,6 +41,9 @@ public sealed class CalendarTodoQueryModuleTests
             CancellationToken.None)).ShouldBeOfType<QueryReply<CalendarTodoQueryPageItem>.Failure>();
 
         failure.Error.Code.ShouldBe(QueryFailureCode.InvalidInput);
+        failure.Error.Message.ShouldContain("evaluationTimeZone");
+        failure.Error.Message.ShouldContain("CALDAV_EVALUATION_TIME_ZONE");
+        failure.Error.Message.ShouldNotContain("bounded");
         constructionCount.ShouldBe(0);
         transport.DiscoveryCount.ShouldBe(0);
         provider.GetRequiredService<CalendarQuerySnapshotStore>().ActiveSnapshotCount.ShouldBe(0);

--- a/tests/DotnetAgents.CalDav.IntegrationTests/CalendarMcpRawStdioTests.cs
+++ b/tests/DotnetAgents.CalDav.IntegrationTests/CalendarMcpRawStdioTests.cs
@@ -1013,6 +1013,8 @@ public sealed class CalendarMcpRawStdioTests
     {
         result.GetProperty("isError").GetBoolean().ShouldBeTrue();
         var structured = result.GetProperty("structuredContent");
+        using var text = JsonDocument.Parse(result.GetProperty("content")[0].GetProperty("text").GetString()!);
+        JsonElement.DeepEquals(text.RootElement, structured).ShouldBeTrue();
         structured.GetProperty("code").GetString().ShouldBe(code);
         structured.GetProperty("phase").GetString().ShouldBe(phase);
         structured.TryGetProperty("items", out _).ShouldBeFalse();

--- a/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/CalDavEnvironmentMapperTests.cs
+++ b/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/CalDavEnvironmentMapperTests.cs
@@ -138,16 +138,19 @@ public class CalDavEnvironmentMapperTests
         ]);
     }
 
-    [Fact]
-    public void MapFromEnvironment_MapsConfiguredTemporalEvaluationContextExactly()
+    [Theory]
+    [InlineData(null)]
+    [InlineData("America/Sao_Paulo")]
+    [InlineData("invalid-zone")]
+    public void MapFromEnvironment_MapsConfiguredTemporalEvaluationContextExactly(string? zone)
     {
         var configure = CalDavEnvironmentMapper.MapFromEnvironment(name =>
-            name == "CALDAV_EVALUATION_TIME_ZONE" ? "America/Sao_Paulo" : null);
+            name == "CALDAV_EVALUATION_TIME_ZONE" ? zone : null);
         var options = new CalDavOptions();
 
         configure(options);
 
-        options.EvaluationTimeZone.ShouldBe("America/Sao_Paulo");
+        options.EvaluationTimeZone.ShouldBe(zone);
     }
 
 }

--- a/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/CalendarEntityToolsTests.cs
+++ b/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/CalendarEntityToolsTests.cs
@@ -387,7 +387,7 @@ public sealed class CalendarEntityToolsTests
         var human = new CallToolResult
         {
             IsError = false,
-            StructuredContent = JsonSerializer.SerializeToElement(new { diagnostics = Array.Empty<object>() }),
+            StructuredContent = JsonSerializer.SerializeToElement(new { message = new string('x', CalendarEntityTools.MaximumHumanReadableBytes) }),
             Content = [new TextContentBlock { Text = new string('x', CalendarEntityTools.MaximumHumanReadableBytes) }]
         };
         CalendarEntityTools.EnsureBoundedResult(human).IsError.ShouldBe(true);
@@ -451,23 +451,32 @@ public sealed class CalendarEntityToolsTests
     [InlineData(1)]
     public void ActualSdkEnvelopeProvesFourMiBBelowAtAndAboveWithSeparatorAndCursor(int delta)
     {
-        static CallToolResult Result(int padding) => new()
+        static CallToolResult Result(int padding)
         {
-            IsError = false,
-            StructuredContent = JsonSerializer.SerializeToElement(new
+            var result = new CallToolResult
             {
-                outcome = "success",
-                items = new object[] { new { marker = 1 }, new { padding = new string('x', padding) } },
-                diagnostics = Array.Empty<object>(),
-                temporalEvaluationContext = new { timeZone = "America/Sao_Paulo", source = "caller" },
-                pagination = new { mode = "query_result_snapshot", nextCursor = "opaque-cursor" }
-            }),
-            Content = [new TextContentBlock { Text = "Calendar Entity query completed." }]
-        };
+                IsError = false,
+                Meta = new System.Text.Json.Nodes.JsonObject { ["padding"] = 0 },
+                StructuredContent = JsonSerializer.SerializeToElement(new
+                {
+                    outcome = "success",
+                    items = new object[] { new { marker = 1 }, new { padding = new string('x', padding) } },
+                    diagnostics = Array.Empty<object>(),
+                    temporalEvaluationContext = new { timeZone = "America/Sao_Paulo", source = "caller" },
+                    pagination = new { mode = "query_result_snapshot", nextCursor = "opaque-cursor" }
+                }),
+                Content = []
+            };
+            CalendarQueryToolSupport.ApplyCompatibilityText(result);
+            return result;
+        }
         var baseline = CalendarEntityTools.MeasureResult(Result(0));
-        var actual = Result(CalendarEntityTools.MaximumStructuredResultBytes - baseline + delta);
+        var target = CalendarEntityTools.MaximumStructuredResultBytes + delta;
+        var actual = Result((target - baseline) / 2);
+        if ((target - baseline) % 2 != 0)
+            actual.Meta!["padding"] = 10;
 
-        CalendarEntityTools.MeasureResult(actual).ShouldBe(CalendarEntityTools.MaximumStructuredResultBytes + delta);
+        CalendarEntityTools.MeasureResult(actual).ShouldBe(target);
         var bounded = CalendarEntityTools.EnsureBoundedResult(actual);
         bounded.IsError.ShouldBe(delta > 0);
     }

--- a/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/CalendarResourceDeleteToolsTests.cs
+++ b/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/CalendarResourceDeleteToolsTests.cs
@@ -189,7 +189,7 @@ public sealed class CalendarResourceDeleteToolsTests
                 CalendarEntityKind.Todo,
                 "\"r1\""),
             Arg.Any<CancellationToken>());
-        result.Content.OfType<TextContentBlock>().Single().Text.ShouldNotContain("todo-1");
+        result.Content.OfType<TextContentBlock>().Single().Text.ShouldContain("todo-1");
     }
 
     [Theory]

--- a/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/CalendarResourceToolsTests.cs
+++ b/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/CalendarResourceToolsTests.cs
@@ -216,7 +216,7 @@ public sealed class CalendarResourceToolsTests
     }
 
     [Fact]
-    public async Task GetAsync_ReturnsFrozenSnapshotShapeWithoutLeakingContentToText()
+    public async Task GetAsync_ReturnsFrozenSnapshotShapeInCompatibilityText()
     {
         const string calendarHref = "https://cal.example/events/";
         const string resourceHref = "https://cal.example/events/a.ics";
@@ -247,7 +247,7 @@ public sealed class CalendarResourceToolsTests
         structured.GetProperty("snapshot").GetProperty("projection").GetProperty("kind").GetString().ShouldBe("event");
         structured.GetProperty("snapshot").GetProperty("entityRevision").GetProperty("entityUid").GetString().ShouldBe("u1");
         result.Content.ShouldHaveSingleItem();
-        result.Content[0].ShouldBeOfType<TextContentBlock>().Text.ShouldNotContain("Secret summary");
+        result.Content[0].ShouldBeOfType<TextContentBlock>().Text.ShouldContain("Secret summary");
         result.Content[0].ShouldBeOfType<TextContentBlock>().Text.ShouldNotContain(Convert.ToBase64String(bytes));
     }
 

--- a/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/CalendarResultPresentationTests.cs
+++ b/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/CalendarResultPresentationTests.cs
@@ -14,6 +14,20 @@ namespace DotnetAgents.CalDav.Mcp.Tests.Unit;
 
 public sealed class CalendarResultPresentationTests
 {
+    [Fact]
+    public void NativeProtocolAdaptersUseCompleteCompatibilityText()
+    {
+        AssertEquivalent(CalendarProtocolToolSupport.Success(new { checkpoint = "opaque", changes = new[] { "href" } }));
+        AssertEquivalent(CalendarProtocolToolSupport.Error(new CalendarProtocolException("invalid_input", "Correct the input.")));
+        var overflow = CalendarProtocolToolSupport.Success(new
+        {
+            mutationState = "committed", calendar = new { description = new string('x', 3 * 1024 * 1024) }
+        }, CalendarMutationState.Committed);
+        AssertEquivalent(overflow);
+        overflow.StructuredContent!.Value.GetProperty("code").GetString().ShouldBe("payload_too_large");
+        overflow.StructuredContent.Value.GetProperty("mutationState").GetString().ShouldBe("committed");
+    }
+
     [Theory]
     [InlineData("success")]
     [InlineData("no_change")]

--- a/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/CalendarResultPresentationTests.cs
+++ b/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/CalendarResultPresentationTests.cs
@@ -1,0 +1,206 @@
+using System.Collections.Immutable;
+using System.Text.Json;
+using DotnetAgents.CalDav.Core.Configuration;
+using DotnetAgents.CalDav.Core.Internal;
+using DotnetAgents.CalDav.Core.Models;
+using DotnetAgents.CalDav.Mcp.Hosting;
+using DotnetAgents.CalDav.Mcp.Tools;
+using Microsoft.Extensions.Options;
+using ModelContextProtocol.Protocol;
+using Shouldly;
+using Xunit;
+
+namespace DotnetAgents.CalDav.Mcp.Tests.Unit;
+
+public sealed class CalendarResultPresentationTests
+{
+    [Theory]
+    [InlineData("success")]
+    [InlineData("no_change")]
+    [InlineData("confirmation_declined")]
+    public void TextOnlyClientReadsCompleteResultAndResourceLinks(string outcome)
+    {
+        var link = new ResourceLinkBlock { Uri = "caldav-exact://snapshot/test", Name = "snapshot" };
+        var result = CalendarToolResult.Success(new CallToolResult
+        {
+            StructuredContent = JsonSerializer.SerializeToElement(new
+            {
+                outcome,
+                items = new[] { new { summary = "ação \"quoted\" \\ 東京", message = new string('x', 70_000) } },
+                pagination = new { nextCursor = "opaque" },
+                temporalEvaluationContext = new { timeZone = "America/Sao_Paulo", source = "caller" }
+            }),
+            Content = [new TextContentBlock { Text = "summary" }, link]
+        }).FinalizeResult();
+
+        AssertEquivalent(result);
+        result.Content.OfType<ResourceLinkBlock>().Single().ShouldBeSameAs(link);
+        result.IsError.ShouldNotBe(true);
+    }
+
+    [Theory]
+    [InlineData(10, "invalid_input")]
+    [InlineData(70_000, "payload_too_large")]
+    public void ViolationsAreEnrichedBeforeTextAndBudget(int pointerLength, string expectedCode)
+    {
+        var result = CalendarToolResult.WithViolations(
+            () => CalendarResourceTools.CreateInputGuardError(false),
+            [new CalendarInputViolation("/" + new string('x', pointerLength), "unknown_member", "Fix the member.")]);
+
+        AssertEquivalent(result);
+        result.StructuredContent!.Value.GetProperty("code").GetString().ShouldBe(expectedCode);
+        if (pointerLength == 10)
+            result.StructuredContent.Value.GetProperty("violations")[0].GetProperty("pointer").GetString()
+                .ShouldBe("/xxxxxxxxxx");
+        CalendarQueryToolSupport.MeasureResult(result).ShouldBeLessThan(4 * 1024 * 1024);
+    }
+
+    [Fact]
+    public void InvalidTemporalArgumentShapesExplainTheRequiredIdentifier()
+    {
+        foreach (var result in new[]
+        {
+            CalendarEntityTools.CreateInputGuardError(false),
+            CalendarOccurrenceTools.CreateInputGuardError(false),
+            CalendarTodoTools.CreateInputGuardError(false)
+        })
+        {
+            AssertEquivalent(result);
+            var message = result.StructuredContent!.Value.GetProperty("message").GetString().ShouldNotBeNull();
+            message.ShouldContain("IANA");
+            message.ShouldContain("evaluationTimeZone");
+        }
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void AdmissionAndDeadlineResultsHaveCompleteText(bool mutation)
+    {
+        AssertEquivalent(CalendarExecutionPolicy.CreateBusyResult(mutation));
+        AssertEquivalent(CalendarExecutionPolicy.CreateDeadlineResult(mutation));
+    }
+
+    [Theory]
+    [InlineData("committed")]
+    [InlineData("unknown")]
+    public void UnpagedOverflowPreservesMutationState(string mutationState)
+    {
+        var result = CalendarToolResult.Success(new CallToolResult
+        {
+            StructuredContent = JsonSerializer.SerializeToElement(new
+            {
+                outcome = "success", mutationState, data = new string('x', 3 * 1024 * 1024)
+            }),
+            Content = []
+        }).FinalizeResult();
+
+        AssertEquivalent(result);
+        result.StructuredContent!.Value.GetProperty("code").GetString().ShouldBe("payload_too_large");
+        result.StructuredContent.Value.GetProperty("mutationState").GetString().ShouldBe(mutationState);
+    }
+
+    [Fact]
+    public void AdditionalTextAndSnapshotDiagnosticsConsumeHumanBudget()
+    {
+        var result = new CallToolResult
+        {
+            StructuredContent = JsonSerializer.SerializeToElement(new { snapshot = new { diagnostics = new[] { "detail" } } }),
+            Content = [new TextContentBlock { Text = "summary" }, new TextContentBlock { Text = new string('x', 65_536) }]
+        };
+        CalendarToolResult.Success(result).FinalizeResult().StructuredContent!.Value
+            .GetProperty("code").GetString().ShouldBe("payload_too_large");
+    }
+
+    [Fact]
+    public void OversizedReplacementIsAlsoMeasured()
+    {
+        var result = new CallToolResult
+        {
+            StructuredContent = JsonSerializer.SerializeToElement(new { message = new string('x', 65_536) }),
+            Content = []
+        };
+        Should.Throw<InvalidOperationException>(() => CalendarQueryToolSupport.EnsureBoundedResult(result, (_, _) => result));
+    }
+
+    [Fact]
+    public void EveryCodecMatchesSdkWithEscapesSeparatorsAndCursor()
+    {
+        VerifyCodec(new CalendarEntityQueryPageCodec());
+        VerifyCodec(new CalendarOccurrenceQueryPageCodec());
+        VerifyCodec(new CalendarTodoQueryPageCodec());
+    }
+
+    [Fact]
+    public void EmptyEnvelopeMustFitAndDiagnosticPagesShrinkWithoutLosingItems()
+    {
+        VerifyAdmission(new CalendarEntityQueryPageCodec());
+        VerifyAdmission(new CalendarOccurrenceQueryPageCodec());
+        VerifyAdmission(new CalendarTodoQueryPageCodec());
+    }
+
+    private static void VerifyAdmission<T>(ICalendarQueryPageCodec<T> codec)
+    {
+        var key = new CalendarQueryCursorKey(Options.Create(new CalDavOptions()), new byte[64]);
+        var admission = new CalendarQueryPageAdmission(new CalendarQueryCursorIssuer(key));
+        var snapshot = new CalendarQuerySnapshot(Guid.NewGuid(), DateTimeOffset.UtcNow.AddMinutes(10),
+            [], "[]"u8.ToArray(), 0);
+        var empty = admission.Plan(snapshot, 0, 3, codec, CancellationToken.None).Value!;
+        var emptyPage = codec.Materialize(snapshot, empty);
+        CalendarQueryToolSupport.MeasureResult(new CallToolResult
+        {
+            IsError = false, StructuredContent = emptyPage.StructuredContent,
+            Content = [new TextContentBlock { Text = emptyPage.HumanText }]
+        }).ShouldBe(empty.MeasuredCallToolResultBytes);
+        var largeContext = JsonSerializer.SerializeToUtf8Bytes(new { timeZone = new string('x', 3 * 1024 * 1024) });
+        admission.Plan(snapshot with { TemporalEvaluationContextUtf8 = largeContext }, 0, 3, codec, CancellationToken.None)
+            .Error!.Code.ShouldBe(QueryFailureCode.PayloadTooLarge);
+        var items = Enumerable.Range(0, 3).Select(index => new StoredCalendarEntityQueryItem(
+            JsonSerializer.SerializeToUtf8Bytes(new
+            {
+                index, diagnostics = new[] { new QueryDiagnostic("test", new string('x', 40_000), "warning") }
+            }))).ToImmutableArray();
+        snapshot = snapshot with { Items = items };
+        var seen = new List<int>();
+        for (var position = 0; position < 3; position++)
+        {
+            var plan = admission.Plan(snapshot, position, 3, codec, CancellationToken.None).Value!;
+            plan.Items.Count.ShouldBe(1);
+            var page = codec.Materialize(snapshot, plan);
+            var replay = codec.Materialize(snapshot, admission.Plan(snapshot, position, 3, codec, CancellationToken.None).Value!);
+            replay.HumanText.ShouldBe(page.HumanText);
+            seen.Add(page.StructuredContent.GetProperty("items")[0].GetProperty("index").GetInt32());
+        }
+        seen.ShouldBe([0, 1, 2]);
+    }
+
+    private static void VerifyCodec<T>(ICalendarQueryPageCodec<T> codec)
+    {
+        var context = CalendarTemporalEvaluationContextCodec.Encode(
+            new TemporalEvaluationContext("America/Sao_Paulo", TemporalEvaluationContextSource.Caller));
+        var items = Enumerable.Range(0, 3).Select(index => new StoredCalendarEntityQueryItem(
+            JsonSerializer.SerializeToUtf8Bytes(new { index, summary = "ação \" \\ / 東京 😀" }))).ToImmutableArray();
+        var snapshot = new CalendarQuerySnapshot(Guid.NewGuid(), DateTimeOffset.UtcNow.AddMinutes(10),
+            items, "[]"u8.ToArray(), 1000, context);
+        var key = new CalendarQueryCursorKey(Options.Create(new CalDavOptions()), new byte[64]);
+        var admission = new CalendarQueryPageAdmission(new CalendarQueryCursorIssuer(key));
+        foreach (var size in new[] { 1, 2, 3 })
+        {
+            var plan = admission.Plan(snapshot, 0, size, codec, CancellationToken.None).Value!;
+            var page = codec.Materialize(snapshot, plan);
+            var result = new CallToolResult
+            {
+                IsError = false, StructuredContent = page.StructuredContent,
+                Content = [new TextContentBlock { Text = page.HumanText }]
+            };
+            AssertEquivalent(result);
+            CalendarQueryToolSupport.MeasureResult(result).ShouldBe(plan.MeasuredCallToolResultBytes);
+        }
+    }
+
+    private static void AssertEquivalent(CallToolResult result)
+    {
+        using var text = JsonDocument.Parse(result.Content.OfType<TextContentBlock>().First().Text);
+        JsonElement.DeepEquals(text.RootElement, result.StructuredContent!.Value).ShouldBeTrue();
+    }
+}

--- a/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/CalendarTodoToolsTests.cs
+++ b/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/CalendarTodoToolsTests.cs
@@ -68,7 +68,7 @@ public sealed class CalendarTodoToolsTests
         result.IsError.ShouldBe(false);
         result.StructuredContent.ShouldBe(structured);
         result.Content.ShouldHaveSingleItem().ShouldBeOfType<ModelContextProtocol.Protocol.TextContentBlock>()
-            .Text.ShouldBe("module-text");
+            .Text.ShouldBe(JsonSerializer.Serialize(result.StructuredContent));
         await module.Received(1).QueryTodosAsync(
             Arg.Is<CalendarTodoQueryRequest.Start>(start =>
                 start.PageSize == 17

--- a/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/CalendarToolsTests.cs
+++ b/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/CalendarToolsTests.cs
@@ -108,7 +108,7 @@ public sealed class CalendarToolsTests
         var result = await sut.ListAsync(CancellationToken.None);
 
         result.IsError.ShouldBe(true);
-        ((TextContentBlock)result.Content.Single()).Text.ShouldBe("Calendar discovery failed.");
+        ((TextContentBlock)result.Content.Single()).Text.ShouldBe(JsonSerializer.Serialize(result.StructuredContent));
         var error = result.StructuredContent!.Value.Deserialize<CalendarErrorResult>()!;
         error.Code.ShouldBe(expectedCode);
         error.Category.ShouldBe(expectedCategory);

--- a/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/ContractCatalogTests.cs
+++ b/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/ContractCatalogTests.cs
@@ -40,6 +40,7 @@ public sealed class ContractCatalogTests
 
         var evaluationZone = catalog["environment"]!.AsArray()
             .Single(item => item!["name"]!.GetValue<string>() == "CALDAV_EVALUATION_TIME_ZONE")!;
+        evaluationZone["required"]!.GetValue<bool>().ShouldBeTrue();
         var description = evaluationZone["description"]!.GetValue<string>();
         description.ShouldContain("bounded Calendar Entity Starts and every Occurrence or To-do Start");
         description.ShouldNotContain("later", Case.Insensitive);

--- a/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/ExactCalendarResourceTests.cs
+++ b/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/ExactCalendarResourceTests.cs
@@ -2302,11 +2302,16 @@ public sealed class ExactCalendarResourceTests
         {
             IsError = false,
             StructuredContent = JsonSerializer.SerializeToElement(new { padding = string.Empty }),
+            Meta = new System.Text.Json.Nodes.JsonObject { ["padding"] = 0 },
             Content = [new TextContentBlock { Text = "ok" }]
         };
+        CalendarQueryToolSupport.ApplyCompatibilityText(result);
         var overhead = ExactCalendarResourceWriteTools.MeasureResult(result);
         result.StructuredContent = JsonSerializer.SerializeToElement(
-            new { padding = new string('x', targetBytes - overhead) });
+            new { padding = new string('x', (targetBytes - overhead) / 2) });
+        if ((targetBytes - overhead) % 2 != 0)
+            result.Meta!["padding"] = 10;
+        CalendarQueryToolSupport.ApplyCompatibilityText(result);
         return result;
     }
 

--- a/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/Hosting/CalendarTelemetryTests.cs
+++ b/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/Hosting/CalendarTelemetryTests.cs
@@ -32,7 +32,7 @@ public sealed class CalendarTelemetryTests
             var candidate = CalendarToolResult.Error(new CallToolResult
             {
                 IsError = true,
-                StructuredContent = JsonSerializer.SerializeToElement(new { code = "conflict" }),
+                StructuredContent = JsonSerializer.SerializeToElement(new { code = "conflict", message = new string('x', CalendarQueryToolSupport.MaximumHumanReadableBytes + 1) }),
                 Content = [new TextContentBlock { Text = new string('x', CalendarQueryToolSupport.MaximumHumanReadableBytes + 1) }]
             }, conflict, CalendarMutationState.NotCommitted);
             var payload = CalendarTelemetryFacts.FromInputGuard(payloadTooLarge: true);

--- a/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/McpMetadataTests.cs
+++ b/tests/DotnetAgents.CalDav.Mcp.Tests.Unit/McpMetadataTests.cs
@@ -84,6 +84,9 @@ public class McpMetadataTests
         envVars.EnumerateArray()
             .Single(item => item.GetProperty("name").GetString() == "OTEL_EXPORTER_OTLP_HEADERS")
             .GetProperty("isSecret").GetBoolean().ShouldBeTrue();
+        envVars.EnumerateArray()
+            .Single(item => item.GetProperty("name").GetString() == "CALDAV_EVALUATION_TIME_ZONE")
+            .GetProperty("isRequired").GetBoolean().ShouldBeTrue();
         var evaluationZoneDescription = envVars.EnumerateArray()
             .Single(item => item.GetProperty("name").GetString() == "CALDAV_EVALUATION_TIME_ZONE")
             .GetProperty("description").GetString();


### PR DESCRIPTION
Clients that prioritize MCP text content currently receive generic summaries that hide query data and error details. This change returns complete compact JSON in the first text block, equivalent to structuredContent, across all 27 tools while preserving resource links and MRTR.

Result finalization now enriches validation errors before presentation, enforces the 4 MiB serialized SDK envelope and separate 64 KiB human-information budget, and records the final telemetry facts. Snapshot admission counts both JSON representations, escaped item bytes, separators, cursors and metadata, reducing page size when needed. Oversized unpaged results preserve the actual mutation state.

Installation metadata now requires CALDAV_EVALUATION_TIME_ZONE. Manual callers can still supply evaluationTimeZone, which takes precedence over validated configuration. Missing or invalid temporal context explains how to provide an IANA identifier, including To-do queries without a window. Public schemas and historical contracts remain unchanged; ADR 0007 documents the decision.

Validation on the current main base:
- Release build: no warnings or errors.
- Complete local suite: 3,123 Core tests, 1,158 MCP tests, 113 integration tests, and 11 tests in each additional Radicale conformance variant passed with no skipped tests.
- Coverage: 94.6% lines and 86.4% branches.
- Slopwatch: no issues.
